### PR TITLE
add dockerfile and makefile to create docker images

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,19 @@
+ARG TF_VERSION=1.5.0
+
+FROM tensorflow/tensorflow:${TF_VERSION}-gpu-py3
+LABEL maintainer="Interactions, LLC."
+LABEL authors="Dan Pressel, Sagnik Choudhury, Yanjie Zhao, Matt Barta"
+
+RUN apt-get update && \
+    apt-get install -y g++ make git vim && \
+    pip install visdom pymongo click && \
+    pip install http://download.pytorch.org/whl/cu90/torch-0.3.1-cp35-cp35m-linux_x86_64.whl  && \
+    pip install torchvision && \
+    jupyter nbextension enable --py widgetsnbextension
+
+COPY ./python ./baseline
+
+VOLUME ["/data/embeddings", "/data/model-store", "/data/tasks", "/data/model-checkpoints"]
+
+WORKDIR ./baseline
+CMD ["bash"]

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,15 @@
+help:
+	@cat Makefile
+
+MODEL_STORE?=/data/model-store
+EMBEDDINGS_DIR?=/data/embeddings
+CHECKPOINTS_DIR?=/data/model-checkpoints
+TASKS_DIR?=/data/tasks
+HOST_NETWORK?=default
+DOCKER?=nvidia-docker
+
+build:
+	docker build --network $(HOST_NETWORK) -t baseline -f ./Dockerfile ../
+
+bash: build
+	${DOCKER} run --rm -it --network ${HOST_NETWORK} -v ${MODEL_STORE}:/data/model-store -v ${EMBEDDINGS}:/data/embeddings -v ${CHECKPOINTS_DIR}:/data/model-checkpoints -v ${TASK_DIR}:/data/tasks baseline


### PR DESCRIPTION
This PR adds a dockerfile that has both TF and Pytorch. The make file provides an easy way to build and create containers.

Note that instead of copying in the data directory for baseline, I added `/data/tasks` as a volume.