### PR TITLE
update Dockerfile and Makefile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,9 +9,10 @@ RUN apt-get update && \
     pip install torchvision && \
     jupyter nbextension enable --py widgetsnbextension
 
-VOLUME ["/baseline", "/data/embeddings", "/data/model-store", "/data/datasets", "/data/model-checkpoints"]
+COPY ./python /baseline
+
+VOLUME ["/data/embeddings", "/data/model-store", "/data/datasets", "/data/model-checkpoints"]
 
 ENV PYTHONPATH='$PYTHONPATH:/baseline'
 
-WORKDIR /baseline
 CMD ["bash"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
 
 COPY ./python ./baseline
 
-VOLUME ["/data/embeddings", "/data/model-store", "/data/tasks", "/data/model-checkpoints"]
+VOLUME ["/data/embeddings", "/data/model-store", "/data/datasets", "/data/model-checkpoints"]
 
 WORKDIR ./baseline
 CMD ["bash"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,5 +15,5 @@ VOLUME ["/data/embeddings", "/data/model-store", "/data/datasets", "/data/model-
 
 ENV PYTHONPATH='$PYTHONPATH:/baseline/python'
 
-WORKDIR /baseline
+WORKDIR /baseline/python
 CMD ["bash"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,4 +15,5 @@ VOLUME ["/data/embeddings", "/data/model-store", "/data/datasets", "/data/model-
 
 ENV PYTHONPATH='$PYTHONPATH:/baseline'
 
+WORKDIR /baseline
 CMD ["bash"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,11 +9,11 @@ RUN apt-get update && \
     pip install torchvision && \
     jupyter nbextension enable --py widgetsnbextension
 
-COPY ./python /baseline
+COPY ./python /baseline/python
 
 VOLUME ["/data/embeddings", "/data/model-store", "/data/datasets", "/data/model-checkpoints"]
 
-ENV PYTHONPATH='$PYTHONPATH:/baseline'
+ENV PYTHONPATH='$PYTHONPATH:/baseline/python'
 
 WORKDIR /baseline
 CMD ["bash"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,9 +9,9 @@ RUN apt-get update && \
     pip install torchvision && \
     jupyter nbextension enable --py widgetsnbextension
 
-COPY ./python ./baseline
+VOLUME ["/baseline", "/data/embeddings", "/data/model-store", "/data/datasets", "/data/model-checkpoints"]
 
-VOLUME ["/data/embeddings", "/data/model-store", "/data/datasets", "/data/model-checkpoints"]
+ENV PYTHONPATH='$PYTHONPATH:/baseline'
 
-WORKDIR ./baseline
+WORKDIR /baseline
 CMD ["bash"]

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -5,6 +5,7 @@ MODEL_STORE?=/data/model-store
 EMBEDDINGS_DIR?=/data/embeddings
 CHECKPOINTS_DIR?=/data/model-checkpoints
 DATASETS_DIR?=/data/datasets
+BASELINE=../python
 HOST_NETWORK?=default
 GPU?=0
 DOCKER=NV_GPU=$(GPU) nvidia-docker
@@ -13,4 +14,4 @@ build:
 	docker build --network $(HOST_NETWORK) -t baseline -f ./Dockerfile ../
 
 bash: build
-	$(DOCKER) run --rm -it --network ${HOST_NETWORK} -v ${MODEL_STORE}:/data/model-store -v ${EMBEDDINGS}:/data/embeddings:ro -v ${CHECKPOINTS_DIR}:/data/model-checkpoints -v ${DATASETS_DIR}:/data/datasets:ro baseline
+	$(DOCKER) run --rm -it --network ${HOST_NETWORK} -v ${BASELINE}:/baseline -v ${MODEL_STORE}:/data/model-store -v ${EMBEDDINGS}:/data/embeddings:ro -v ${CHECKPOINTS_DIR}:/data/model-checkpoints -v ${DATASETS_DIR}:/data/datasets:ro baseline

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -5,7 +5,7 @@ MODEL_STORE?=/data/model-store
 EMBEDDINGS_DIR?=/data/embeddings
 CHECKPOINTS_DIR?=/data/model-checkpoints
 DATASETS_DIR?=/data/datasets
-BASELINE=../python
+BASELINE="$(dirname "$(pwd)")"/python
 HOST_NETWORK?=default
 GPU?=0
 DOCKER=NV_GPU=$(GPU) nvidia-docker

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -4,13 +4,13 @@ help:
 MODEL_STORE?=/data/model-store
 EMBEDDINGS_DIR?=/data/embeddings
 CHECKPOINTS_DIR?=/data/model-checkpoints
-TASKS_DIR?=/data/tasks
+DATASETS_DIR?=/data/datasets
 HOST_NETWORK?=default
 GPU?=0
-DOCKER=GPU=$(GPU) nvidia-docker
+DOCKER=NV_GPU=$(GPU) nvidia-docker
 
 build:
 	docker build --network $(HOST_NETWORK) -t baseline -f ./Dockerfile ../
 
 bash: build
-	${DOCKER} run --rm -it --network ${HOST_NETWORK} -v ${MODEL_STORE}:/data/model-store -v ${EMBEDDINGS}:/data/embeddings -v ${CHECKPOINTS_DIR}:/data/model-checkpoints -v ${TASK_DIR}:/data/tasks baseline
+	$(DOCKER) run --rm -it --network ${HOST_NETWORK} -v ${MODEL_STORE}:/data/model-store -v ${EMBEDDINGS}:/data/embeddings -v ${CHECKPOINTS_DIR}:/data/model-checkpoints -v ${DATASETS_DIR}:/data/datasets baseline

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -13,4 +13,4 @@ build:
 	docker build --network $(HOST_NETWORK) -t baseline -f ./Dockerfile ../
 
 bash: build
-	$(DOCKER) run --rm -it --network ${HOST_NETWORK} -v ${MODEL_STORE}:/data/model-store -v ${EMBEDDINGS}:/data/embeddings -v ${CHECKPOINTS_DIR}:/data/model-checkpoints -v ${DATASETS_DIR}:/data/datasets baseline
+	$(DOCKER) run --rm -it --network ${HOST_NETWORK} -v ${MODEL_STORE}:/data/model-store -v ${EMBEDDINGS}:/data/embeddings:ro -v ${CHECKPOINTS_DIR}:/data/model-checkpoints -v ${DATASETS_DIR}:/data/datasets:ro baseline

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -13,4 +13,4 @@ build:
 	docker build --network $(HOST_NETWORK) -t baseline -f ./Dockerfile ../
 
 bash: build
-	$(DOCKER) run --rm -it --network ${HOST_NETWORK} -v ${MODEL_STORE}:/data/model-store -v ${EMBEDDINGS}:/data/embeddings:ro -v ${CHECKPOINTS_DIR}:/data/model-checkpoints -v ${DATASETS_DIR}:/data/datasets:ro baseline
+	$(DOCKER) run --rm -it --network ${HOST_NETWORK} -v ${MODEL_STORE}:/data/model-store -v ${EMBEDDINGS_DIR}:/data/embeddings:ro -v ${CHECKPOINTS_DIR}:/data/model-checkpoints -v ${DATASETS_DIR}:/data/datasets:ro baseline

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -5,7 +5,6 @@ MODEL_STORE?=/data/model-store
 EMBEDDINGS_DIR?=/data/embeddings
 CHECKPOINTS_DIR?=/data/model-checkpoints
 DATASETS_DIR?=/data/datasets
-BASELINE="$(dirname "$(pwd)")"/python
 HOST_NETWORK?=default
 GPU?=0
 DOCKER=NV_GPU=$(GPU) nvidia-docker
@@ -14,4 +13,4 @@ build:
 	docker build --network $(HOST_NETWORK) -t baseline -f ./Dockerfile ../
 
 bash: build
-	$(DOCKER) run --rm -it --network ${HOST_NETWORK} -v ${BASELINE}:/baseline -v ${MODEL_STORE}:/data/model-store -v ${EMBEDDINGS}:/data/embeddings:ro -v ${CHECKPOINTS_DIR}:/data/model-checkpoints -v ${DATASETS_DIR}:/data/datasets:ro baseline
+	$(DOCKER) run --rm -it --network ${HOST_NETWORK} -v ${MODEL_STORE}:/data/model-store -v ${EMBEDDINGS}:/data/embeddings:ro -v ${CHECKPOINTS_DIR}:/data/model-checkpoints -v ${DATASETS_DIR}:/data/datasets:ro baseline


### PR DESCRIPTION
Datasets are referenced at `/data/datasets`, which should now be reflected in the Dockerfile.

The makefile updates how the GPU is set and makes embeddings and datasets read only.

I also copied baseline into the container at `/baseline/python` so that errors would be more obvious in relation to the package structure.