### PR TITLE
Updated create and load

### DIFF
--- a/python/addons/tagger_gazetteer.py
+++ b/python/addons/tagger_gazetteer.py
@@ -271,9 +271,8 @@ class RNNTaggerGazetteerModel(Tagger):
 
 
 def create_model(labels, embeddings, **kwargs):
-    model = RNNTaggerGazetteerModel.create(labels, embeddings, **kwargs)
-    return model
+    return RNNTaggerGazetteerModel.create(labels, embeddings, **kwargs)
 
 
 def load_model(modelname, **kwargs):
-    return load_tagger_model(RNNTaggerGazetteerModel.load, modelname, **kwargs)
+    return RNNTaggerGazetteerModel.load(modelname, **kwargs)

--- a/python/baseline/model.py
+++ b/python/baseline/model.py
@@ -1,3 +1,4 @@
+from functools import partial
 import numpy as np
 from baseline.utils import revlut, load_user_classifier_model, create_user_classifier_model, load_user_tagger_model, create_user_tagger_model
 from baseline.utils import load_user_seq2seq_model, create_user_seq2seq_model, create_user_lang_model, lowercase
@@ -83,40 +84,51 @@ class Classifier(object):
         return sorted(outcomes, key=lambda tup: tup[1], reverse=True)
 
 
-def create_classifier_model(known_creators, w2v, labels, **kwargs):
+def create_model(known_creators, input_, output_, **kwargs):
     """If `model_type` is given, use it to load an addon model and construct that OW use default
-    
+
+    For classification and tagging tasks input_ is embeddings and output_ is labels
+    For seq2seq tasks input_ is the source embeddings and output_ is the target embeddings
+
     :param known_creators: Map of baseline creators, keyed by `model_type`, typically a static factory method
-    :param w2v: Word embeddings
-    :param labels: A list or map of labels
+    :param input_: parameter for the input, general word vectors
+    :param output_: parameter for the output, generally labels or output vectors
     :param kwargs: Anything required to feed the model its parameters
     :return: A newly created model
     """
     model_type = kwargs.get('model_type', 'default')
+    creator_fn = known_creators[model_type] if model_type in known_creators else kwargs['task_fn']
+    print('Calling model ', creator_fn)
+    return creator_fn(input_, output_, **kwargs)
+
+create_classifier_model = partial(create_model, task_fn=create_user_classifier_model)
+create_tagger_model = partial(create_model, task_fn=create_user_tagger_model)
+create_seq2seq_model = partial(create_model, task_fn=create_user_seq2seq_model)
+
+def create_lang_model(known_creators, embeddings, **kwargs):
+    model_type = kwargs.get('model_type', 'default')
     if model_type in known_creators:
         creator_fn = known_creators[model_type]
-        print('Calling baseline model ', creator_fn)
-        return creator_fn(w2v, labels, **kwargs)
-
-    model = create_user_classifier_model(w2v, labels, **kwargs)
-    return model
+        print('Calling baseline model loader ', creator_fn)
+        return creator_fn(embeddings, **kwargs)
+    return create_user_lang_model(embeddings, **kwargs)
 
 
-def load_classifier_model(known_loaders, outname, **kwargs):
+def load_model(known_loaders, outname, **kwargs):
     """If `model_type` is given, use it to load an addon model and construct that OW use default
-    
+
     :param known_loaders: Map of baseline functions to load the model, typically a static factory method
     :param outname The model name to load
     :param kwargs: Anything required to feed the model its parameters
     :return: A restored model
     """
-
     model_type = kwargs.get('model_type', 'default')
-    if model_type in known_loaders:
-        loader_fn = known_loaders[model_type]
-        print('Calling baseline model loader ', loader_fn)
-        return loader_fn(outname, **kwargs)
-    return load_user_classifier_model(outname, **kwargs)
+    loader_fn = known_loaders[model_type] if model_type in known_loaders else kwargs['task_fn']
+    return loader_fn(outname, **kwargs)
+
+load_classifier_model = partial(load_model, task_fn=load_user_classifier_model)
+load_tagger_model = partial(load_model, task_fn=load_user_tagger_model)
+load_seq2seq_model = partial(load_model, task_fn=load_user_seq2seq_model)
 
 
 class Tagger(object):
@@ -188,24 +200,6 @@ class Tagger(object):
         pass
 
 
-def create_tagger_model(default_create_model_fn, labels, embeddings, **kwargs):
-    model_type = kwargs.get('model_type', 'default')
-    if model_type == 'default':
-        return default_create_model_fn(labels, embeddings, **kwargs)
-
-    model = create_user_tagger_model(labels, embeddings, **kwargs)
-    return model
-
-
-def load_tagger_model(default_load_fn, outname, **kwargs):
-
-    model_type = kwargs.get('model_type', 'default')
-    if model_type == 'default':
-        print('Calling default load fn', default_load_fn)
-        return default_load_fn(outname, **kwargs)
-    return load_user_tagger_model(outname, **kwargs)
-
-
 class LanguageModel(object):
 
     def __init__(self):
@@ -242,31 +236,3 @@ class EncoderDecoder(object):
 
     def run(self, source_dict):
         pass
-
-
-def create_seq2seq_model(known_creators, input_embedding, output_embedding, **kwargs):
-    model_type = kwargs.get('model_type', 'default')
-    if model_type in known_creators:
-        creator_fn = known_creators[model_type]
-        return creator_fn(input_embedding, output_embedding, **kwargs)
-
-    model = create_user_seq2seq_model(input_embedding, output_embedding, **kwargs)
-    return model
-
-
-def load_seq2seq_model(known_loaders, outname, **kwargs):
-    model_type = kwargs.get('model_type', 'default')
-    if model_type in known_loaders:
-        loader_fn = known_loaders[model_type]
-        return loader_fn(outname, **kwargs)
-    return load_user_seq2seq_model(outname, **kwargs)
-
-
-def create_lang_model(known_creators, embeddings, **kwargs):
-    model_type = kwargs.get('model_type', 'default')
-    if model_type in known_creators:
-        creator_fn = known_creators[model_type]
-        print('Calling baseline model loader ', creator_fn)
-        return creator_fn(embeddings, **kwargs)
-    return create_user_lang_model(embeddings, **kwargs)
-

--- a/python/baseline/pytorch/tagger/model.py
+++ b/python/baseline/pytorch/tagger/model.py
@@ -396,12 +396,17 @@ class RNNTaggerModel(nn.Module, Tagger):
         lengths = batch_dict['lengths']
         return predict_seq_bt(self, x, xch, lengths)
 
+BASELINE_TAGGER_MODELS = {
+    'default': RNNTaggerModel.create
+}
+
+BASELINE_TAGGER_LOADERS = {
+    'default': RNNTaggerModel.load
+}
 
 def create_model(labels, embeddings, **kwargs):
-
-    model = create_tagger_model(RNNTaggerModel.create, labels, embeddings, **kwargs)
-    return model
+    return create_tagger_model(BASELINE_TAGGER_MODELS, labels, embeddings, **kwargs)
 
 
 def load_model(modelname, **kwargs):
-    return load_tagger_model(RNNTaggerModel.load, modelname, **kwargs)
+    return load_tagger_model(BASELINE_TAGGER_LOADERS, modelname, **kwargs)

--- a/python/baseline/tf/tagger/model.py
+++ b/python/baseline/tf/tagger/model.py
@@ -287,11 +287,17 @@ class RNNTaggerModel(Tagger):
 
         return word_char
 
+BASELINE_TAGGER_MODELS = {
+    'default': RNNTaggerModel.create,
+}
+
+BASELINE_TAGGER_LOADERS = {
+    'default': RNNTaggerModel.load
+}
 
 def create_model(labels, embeddings, **kwargs):
-    model = create_tagger_model(RNNTaggerModel.create, labels, embeddings, **kwargs)
-    return model
+    return create_tagger_model(BASELINE_TAGGER_MODELS, labels, embeddings, **kwargs)
 
 
 def load_model(modelname, **kwargs):
-    return load_tagger_model(RNNTaggerModel.load, modelname, **kwargs)
+    return load_tagger_model(BASELINE_TAGGER_LOADERS, modelname, **kwargs)

--- a/python/baseline/utils.py
+++ b/python/baseline/utils.py
@@ -2,6 +2,7 @@ import numpy as np
 import time
 import os
 import importlib
+from functools import partial
 
 
 def listify(x):
@@ -55,39 +56,33 @@ def import_user_module(module_type, model_type):
     mod = importlib.import_module(module_name)
     return mod
 
+def create_user_model(input_, output_, **kwargs):
+    """Create a user-defined model
 
-def create_user_classifier_model(w2v, labels, **kwargs):
-    """Create a user-defined classifier model
-
-    This creates an unstructured prediction classification model defined by the user.
+    This creates a model defined by the user.
     It first imports a module that must exist in the `PYTHONPATH`, with a named defined as
-    `classifier_{model_type}.py`.  Once created, this user-defined model can be trained within
+    `{task_type}_{model_type}.py`.  Once created, this user-defined model can be trained within
     the existing training programs
 
-    :param w2v: Some type of word vectors
-    :param labels: The categorical label types
+    :param input_: Some type of word vectors for the input
+    :param output_: Things passed dealing with the output
     :param kwargs:
     :return: A user-defined model
     """
     model_type = kwargs['model_type']
-    mod = import_user_module("classifier", model_type)
-    return mod.create_model(w2v, labels, **kwargs)
+    mod = import_user_module(kwargs['task_type'], model_type)
+    return mod.create_model(input_, output_, **kwargs)
 
 
-def load_user_classifier_model(outname, **kwargs):
-    """Loads a user-defined classifier model
+create_user_classifier_model = partial(create_user_model, task_type='classify')
+create_user_tagger_model = partial(create_user_model, task_type='tagger')
+create_user_seq2seq_model = partial(create_user_model, task_type='seq2seq')
 
-    This loads a previously serialized unstructured prediction classification model defined by the user.
-    It first imports a module that must exist in the `PYTHONPATH`, with a named defined as
-    `classifier_{model_type}.py`.  Once loaded, this user-defined model can be used within the driver programs
 
-    :param outname: The name of the file where the model is serialized
-    :param kwargs:
-    :return: A user-defined model
-    """
+def create_user_lang_model(embeddings, **kwargs):
     model_type = kwargs['model_type']
-    mod = import_user_module("classifier", model_type)
-    return mod.load_model(outname, **kwargs)
+    mod = import_user_module('lang', model_type)
+    return mod.create_model(embeddings, **kwargs)
 
 
 def create_user_trainer(model, **kwargs):
@@ -106,78 +101,26 @@ def create_user_trainer(model, **kwargs):
     return mod.create_trainer(model, **kwargs)
 
 
-def create_user_tagger_model(labels, vocabs, **kwargs):
-    """Create a user-defined tagger model
+def load_user_model(outname, **kwargs):
+    """Loads a user-defined model
 
-    This creates an structured prediction classification model defined by the user.
+    This loads a previously serialized model defined by the user.
     It first imports a module that must exist in the `PYTHONPATH`, with a named defined as
-    `tagger_{model_type}.py`.  Once created, this user-defined model can be trained within
-    the existing training programs
-
-    :param w2v: Some type of word vectors
-    :param labels: The categorical label types
-    :param kwargs:
-    :return: A user-defined model
-    """
-    model_type = kwargs['model_type']
-    mod = import_user_module("tagger", model_type)
-    return mod.create_model(labels, vocabs, **kwargs)
-
-
-def load_user_tagger_model(outname, **kwargs):
-    """Loads a user-defined tagger model
-
-    This loads a previously serialized structured prediction classification model defined by the user.
-    It first imports a module that must exist in the `PYTHONPATH`, with a named defined as
-    `tagger_{model_type}.py`.  Once loaded, this user-defined model can be used within the driver programs
+    `{task_type}_{model_type}.py`.  Once loaded, this user-defined model can be used within the driver programs
 
     :param outname: The name of the file where the model is serialized
     :param kwargs:
     :return: A user-defined model
     """
     model_type = kwargs['model_type']
-    mod = import_user_module("tagger", model_type)
+    mod = import_user_module(kwargs['task_type'], model_type)
     return mod.load_model(outname, **kwargs)
 
 
-def create_user_lang_model(embeddings, **kwargs):
-    model_type = kwargs['model_type']
-    mod = import_user_module('lang', model_type)
-    return mod.create_model(embeddings, **kwargs)
-
-
-def create_user_seq2seq_model(input_embedding, output_embedding, **kwargs):
-    """Create a user-defined encoder-decoder model
-
-    This creates an encoder-decoder model defined by the user.
-    It first imports a module that must exist in the `PYTHONPATH`, with a named defined as
-    `tagger_{model_type}.py`.  Once created, this user-defined model can be trained within
-    the existing training programs
-
-    :param w2v: Some type of word vectors
-    :param labels: The categorical label types
-    :param kwargs:
-    :return: A user-defined model
-    """
-    model_type = kwargs['model_type']
-    mod = import_user_module("seq2seq", model_type)
-    return mod.create_model(input_embedding, output_embedding, **kwargs)
-
-
-def load_user_seq2seq_model(outname, **kwargs):
-    """Loads a user-defined encoder-decoder model
-
-    This loads a previously serialized encoder-decoder model defined by the user.
-    It first imports a module that must exist in the `PYTHONPATH`, with a named defined as
-    `seq2seq_{model_type}.py`.  Once loaded, this user-defined model can be used within the driver programs
-
-    :param outname: The name of the file where the model is serialized
-    :param kwargs:
-    :return: A user-defined model
-    """
-    model_type = kwargs['model_type']
-    mod = import_user_module("seq2seq", model_type)
-    return mod.load_model(outname, **kwargs)
+load_user_classifier_model = partial(load_user_model, task_type='classify')
+load_user_tagger_model = partial(load_user_model, task_type='tagger')
+load_user_seq2seq_model = partial(load_user_model, task_type='seq2seq')
+load_user_lm_model = partial(load_user_model, task_type='lm')
 
 
 def get_model_file(dictionary, task, platform):

--- a/python/mead/trainer.py
+++ b/python/mead/trainer.py
@@ -6,7 +6,7 @@ parser.add_argument('--config', help='JSON Configuration for an experiment', req
 parser.add_argument('--datasets', help='json library of dataset labels', default='./config/datasets.json')
 parser.add_argument('--embeddings', help='json library of embeddings', default='./config/embeddings.json')
 parser.add_argument('--logging', help='json file for logging', default='./config/logging.json')
-parser.add_argument('--task', help='task to run', default='classify')
+parser.add_argument('--task', help='task to run', default='classify', choices=['classify', 'tagger', 'seq2seq', 'lm'])
 args = parser.parse_args()
 
 task = mead.Task.get_task_specific(args.task, args.logging)


### PR DESCRIPTION
This PR:

 * Updates create, load, and the version with user addons so that code that is the same isn't in so many places. This new version work for classify, tagger, and seq2seq creates but lm create still needed its own function. 
  * Changes the order of labels and embeddings for tagger models to match with classify 

I tested this PR by running classification, tagging, and seq2seq models from baseline with mead. I also tested classification. tagging, and seq2seq models that were addons. They all were able to be created and to train.