### PR TITLE
Changed Conv

### DIFF
--- a/python/addons/tagger_gazetteer.py
+++ b/python/addons/tagger_gazetteer.py
@@ -228,10 +228,7 @@ class RNNTaggerGazetteerModel(Tagger):
         with tf.variable_scope("Chars2Word"):
             with tf.control_dependencies([ce0]):
                 rnnchar_bt_x_w = tf.reshape(model.xch, [-1, maxw])
-                mxfiltsz = np.max(filtsz)
-                halffiltsz = mxfiltsz // 2
-                zeropad = tf.pad(rnnchar_bt_x_w, [[0, 0], [halffiltsz, halffiltsz]], "CONSTANT")
-                cembed = tf.nn.embedding_lookup(Wch, zeropad, name="charembeddings")
+                cembed = tf.nn.embedding_lookup(Wch, rnnchar_bt_x_w, name="charembeddings")
                 cmot = char_word_conv_embeddings(cembed, filtsz, char_dsz, wsz)
                 word_char = tf.reshape(cmot, [-1, mxlen, len(filtsz) * wsz])
 

--- a/python/baseline/model.py
+++ b/python/baseline/model.py
@@ -54,7 +54,7 @@ class Classifier(object):
         """
         pass
 
-    def classify_text(self, tokens, mxlen, zeropad=0, zero_alloc=np.zeros, word_trans_fn=lowercase):
+    def classify_text(self, tokens, mxlen, zero_alloc=np.zeros, word_trans_fn=lowercase):
         """Utility method to convert a list of words comprising a text to indices, and create a single element
         batch which is then classified.  The returned decision is sorted in descending order of probability.
 
@@ -63,15 +63,13 @@ class Classifier(object):
         
         :param tokens: A list of words
         :param mxlen: The maximum length of the words.  List items beyond this edge are removed
-        :param zeropad: How much zero-padding (total) to allocate the signal
         :param zero_alloc: A function defining an allocator.  Defaults to numpy zeros
         :param word_trans_fn: A transform on the input word
         :return: A sorted list of outcomes for a single element batch
         """
         vocab = self.get_vocab()
         x = zero_alloc((1, mxlen), dtype=int)
-        halffiltsz = zeropad // 2
-        length = min(len(tokens), mxlen - zeropad + 1)
+        length = min(len(tokens), mxlen)
         for j in range(length):
             word = word_trans_fn(tokens[j])
             if word not in vocab:
@@ -80,7 +78,7 @@ class Classifier(object):
                     idx = 0
             else:
                 idx = vocab[word]
-            x[0, j + halffiltsz] = idx
+            x[0, j] = idx
         outcomes = self.classify({'x': x})[0]
         return sorted(outcomes, key=lambda tup: tup[1], reverse=True)
 

--- a/python/baseline/repl.py
+++ b/python/baseline/repl.py
@@ -7,7 +7,6 @@ import numpy as np
 def tagger_repl(tagger, **kwargs):
     mxlen = int(kwargs.get('mxlen', 100))
     maxw = int(kwargs.get('maxw', 100))
-    #zeropad = int(kwargs.get('zeropad', 0))
     prompt_name = kwargs.get('prompt', 'class> ')
     history_file = kwargs.get('history_file', '.history')
     history = FileHistory(history_file)
@@ -30,7 +29,6 @@ def classifier_repl(classifier, **kwargs):
     mxlen = int(kwargs.get('mxlen', 100))
     k = int(kwargs.get('k', 1))
     thresh = float(kwargs.get('thresh', 0.0))
-    zeropad = int(kwargs.get('zeropad', 0))
     prompt_name = kwargs.get('prompt', 'class> ')
     history_file = kwargs.get('history_file', '.history')
     history = FileHistory(history_file)
@@ -42,7 +40,7 @@ def classifier_repl(classifier, **kwargs):
             break
         try:
             tokens = text.split(' ')
-            outcomes = classifier.classify_text(tokens, mxlen=mxlen, zeropad=zeropad)
+            outcomes = classifier.classify_text(tokens, mxlen=mxlen)
             k = min(k, len(outcomes))
             probs = outcomes[:k]
             for prob_i in probs:


### PR DESCRIPTION
This PR changes the way convolutions are done, changing the input from `[batch, seq, dsz, 1]` to `[batch, 1, seq, dsz]` and changes the kernel from `[fsz, dsz, 1, cmotsz]` to `[1, fsz, dsz, cmotsz]`.

This convolution is equivalent to the old way but now doing a 'SAME' convolution results in a `[batch. 1, seq, cmotsz]`. This means that we don't have to zeropad input manually anymore.

This also moves the convolution into the `parallel_conv` function so that it can be used by itself and reduce duplicated code.

I also added some tests for the parallel conv function
