### PR TITLE
Fixed Vocab location

### DIFF
--- a/python/mead/config/datasets.json
+++ b/python/mead/config/datasets.json
@@ -48,7 +48,7 @@
 	"label": "atis"
     },
     {
-	"vocab_file": "/data/datasets/iwslt15-en-vi/vocab.en_vi",
+	"vocab_file": "/data/datasets/iwslt15-en-vi/vocab",
 	"train_file": "/data/datasets/iwslt15-en-vi/train",
 	"valid_file": "/data/datasets/iwslt15-en-vi/tst2012",
 	"test_file": "/data/datasets/iwslt15-en-vi/tst2013",


### PR DESCRIPTION
This PR fixes the vocab location. Without this fix the vocab files were not being read so the vocab for each embeddings layer had size 22,270. Now the vocab files are used and embeddings layers are the correct sizes.