### PR TITLE
Fix for pytorch03

### DIFF
--- a/python/baseline/pytorch/seq2seq/model.py
+++ b/python/baseline/pytorch/seq2seq/model.py
@@ -164,7 +164,7 @@ class Seq2SeqBase(nn.Module, EncoderDecoder):
 
         for i in range(T):
             lst = [path[-1] for path in paths]
-            dst = torch.LongTensor(lst).type(src.type())
+            dst = torch.LongTensor(lst).type(src.data.type())
             mask_eos = dst == EOS
             mask_pad = dst == 0
             dst = dst.view(1, K)


### PR DESCRIPTION
This is a small fix for the beam search in seq2seq for pytorch 0.3. In pytorch 0.3 `.type()` only works on tensors not variables.

I tested this on pytorch 0.3 but running the iwslt translation task through mead. It was able to train and was able to show examples.

I was unable to test it with pytorch 0.4 because there are are some errors like we discussed for 0.4 but in 0.4 you can do both .data.type() and .type() on variables so it should be fine.