### PR TITLE
Updated Baseline to work with/use pytorch0.4

### DIFF
--- a/python/baseline/pytorch/classify/model.py
+++ b/python/baseline/pytorch/classify/model.py
@@ -86,7 +86,7 @@ class WordClassifierBase(nn.Module, Classifier):
         self.output = nn.Sequential()
         append2seq(self.output, (
             nn.Linear(input_dim, nc),
-            nn.LogSoftmax()
+            nn.LogSoftmax(dim=1)
         ))
 
     def _init_pool(self, dsz, **kwargs):
@@ -146,8 +146,7 @@ class LSTMModel(WordClassifierBase):
 
     def _pool(self, embeddings):
         output, hidden = self.lstm(embeddings)
-        # This squeeze can cause problems when B=1
-        last_frame = output[:, -1, :].squeeze()
+        last_frame = output[:, -1, :].squeeze(1)
         return last_frame
 
 

--- a/python/baseline/pytorch/classify/train.py
+++ b/python/baseline/pytorch/classify/train.py
@@ -10,7 +10,7 @@ import torch.autograd
 def _add_to_cm(cm, y, pred):
     _, best = pred.max(1)
     yt = y.cpu().int()
-    yp = best.cpu().int().squeeze()
+    yp = best.cpu().int()
     cm.add_batch(yt.data.numpy(), yp.data.numpy())
 
 
@@ -53,7 +53,7 @@ class ClassifyTrainerPyTorch(EpochReportingTrainer):
             x, y = self.model.make_input(batch_dict)
             pred = self.model(x)
             loss = self.crit(pred, y)
-            total_loss += loss.data[0]
+            total_loss += loss.item()
             _add_to_cm(cm, y, pred)
             pg.update()
         pg.done()
@@ -75,9 +75,9 @@ class ClassifyTrainerPyTorch(EpochReportingTrainer):
             pred = self.model(x)
             loss = self.crit(pred, y)
 
-            total_loss += loss.data[0]
+            total_loss += loss.item()
             loss.backward()
-            torch.nn.utils.clip_grad_norm(self.model.parameters(), self.clip)
+            torch.nn.utils.clip_grad_norm_(self.model.parameters(), self.clip)
             _add_to_cm(cm, y, pred)
             self.optimizer.step()
             pg.update()

--- a/python/baseline/pytorch/lm/train.py
+++ b/python/baseline/pytorch/lm/train.py
@@ -36,8 +36,8 @@ class LanguageModelTrainerPyTorch(Trainer):
 
     def repackage_hidden(self, h):
         """Wraps hidden states in new Variables, to detach them from their history."""
-        if type(h) == torch.autograd.Variable:
-            return torch.autograd.Variable(h.data)
+        if isinstance(h, torch.Tensor):
+            return h.detach()
         else:
             return tuple(self.repackage_hidden(v) for v in h)
 
@@ -100,7 +100,7 @@ class LanguageModelTrainerPyTorch(Trainer):
                 for reporting in reporting_fns:
                     reporting(metrics, self.train_steps, 'Train')
 
-            torch.nn.utils.clip_grad_norm(self.model.parameters(), self.clip)
+            torch.nn.utils.clip_grad_norm_(self.model.parameters(), self.clip)
             self.optimizer.step()
 
         avg_loss = float(total_loss) / iters / batchsz

--- a/python/baseline/pytorch/seq2seq/model.py
+++ b/python/baseline/pytorch/seq2seq/model.py
@@ -138,6 +138,7 @@ class Seq2SeqBase(nn.Module, EncoderDecoder):
             src_len = src_len.cuda()
         batch = []
         for src_i, src_len_i in zip(src, src_len):
+            src_len_i = src_len_i.unsqueeze(0)
             batch += [self.beam_decode(src_i.view(1, -1), src_len_i, kwargs.get('beam', 1))[0]]
 
         return batch
@@ -225,7 +226,7 @@ class Seq2SeqModel(Seq2SeqBase):
         self.encoder_rnn = pytorch_rnn(dsz, enc_hsz, rnntype, nlayers, pdrop)
         self.preds = nn.Linear(self.hsz, self.nc)
         self.decoder_rnn = pytorch_rnn_cell(dsz, self.hsz, rnntype, nlayers, pdrop)
-        self.probs = nn.LogSoftmax()
+        self.probs = nn.LogSoftmax(dim=1)
 
     def input_i(self, embed_i, output_i):
         return embed_i.squeeze(0)
@@ -254,9 +255,9 @@ class Seq2SeqAttnModel(Seq2SeqBase):
         self.dropout = nn.Dropout(pdrop)
         self.decoder_rnn = pytorch_rnn_cell(self.hsz + dsz, self.hsz, rnntype, nlayers, pdrop)
         self.preds = nn.Linear(self.hsz, self.nc)
-        self.probs = nn.LogSoftmax()
+        self.probs = nn.LogSoftmax(dim=1)
         self.output_to_attn = nn.Linear(self.hsz, self.hsz, bias=False)
-        self.attn_softmax = nn.Softmax()
+        self.attn_softmax = nn.Softmax(dim=1)
         self.attn_out = nn.Linear(2 * self.hsz, self.hsz, bias=False)
         self.attn_tanh = pytorch_activation("tanh")
         self.nlayers = nlayers

--- a/python/baseline/pytorch/seq2seq/train.py
+++ b/python/baseline/pytorch/seq2seq/train.py
@@ -28,7 +28,7 @@ class Seq2SeqTrainerPyTorch(Trainer):
 
     def _total(self, tgt):
         tgtt = tgt.data.long()
-        return torch.sum(tgtt.ne(0))
+        return torch.sum(tgtt.ne(0)).item()
 
     def test(self, vs, reporting_fns, phase):
         self.model.eval()
@@ -47,7 +47,7 @@ class Seq2SeqTrainerPyTorch(Trainer):
             fx = fx[:-1]
             pred = self.model(fx)
             loss = self.crit(pred, tgt)
-            total_loss += loss.data[0]
+            total_loss += loss.item()
             total += self._total(tgt)
             pg.update()
         pg.done()
@@ -79,9 +79,9 @@ class Seq2SeqTrainerPyTorch(Trainer):
             fx = fx[:-1]
             pred = self.model(fx)
             loss = self.crit(pred, tgt)
-            total_loss += loss.data[0]
+            total_loss += loss.item()
             loss.backward()
-            torch.nn.utils.clip_grad_norm(self.model.parameters(), self.clip)
+            torch.nn.utils.clip_grad_norm_(self.model.parameters(), self.clip)
             total += self._total(tgt)
             self.optimizer.step()
             duration += time.time() - start_time

--- a/python/baseline/pytorch/tagger/train.py
+++ b/python/baseline/pytorch/tagger/train.py
@@ -30,7 +30,7 @@ class TaggerTrainerPyTorch(EpochReportingTrainer):
         # For each sentence
         for b in range(len(guess)):
 
-            sentence = guess[b].cpu().squeeze().numpy()
+            sentence = guess[b].cpu().numpy()
 
             sentence_length = sentence_lengths[b]
             gold = truth_n[b, :sentence_length]
@@ -97,9 +97,9 @@ class TaggerTrainerPyTorch(EpochReportingTrainer):
             inputs = self.model.make_input(batch_dict)
             self.optimizer.zero_grad()
             loss = self.model.compute_loss(inputs)
-            total_loss += loss.data[0]
+            total_loss += loss.item()
             loss.backward()
-            torch.nn.utils.clip_grad_norm(self.model.parameters(), self.clip)
+            torch.nn.utils.clip_grad_norm_(self.model.parameters(), self.clip)
             self.optimizer.step()
             pg.update()
 

--- a/python/mead/config/ptb-med.json
+++ b/python/mead/config/ptb-med.json
@@ -1,0 +1,34 @@
+{
+	"batchsz": 20,
+	"unif": 0.05,
+    "nbptt": 35,
+    "charsz": 16,
+    "preproc": {
+        "mxwlen": 40,
+        "lower": true
+    },
+    "backend": "pytorch",
+    "dataset": "ptb",
+    "loader": {
+        "reader_type": "default"
+    },
+    "model": {
+        "model_type": "default",
+        "hsz": 200
+    },
+    "word_embeddings": {
+        "label": "w2v-gn"
+    },
+    "train": {
+        "epochs": 39,
+        "decay_rate": 1.2,
+        "patience": 40000,
+        "optim": "sgd",
+        "start_decay_epoch": 6,
+        "decay_type": "zaremba",
+        "eta": 1.0,
+        "mom": 0.0,
+        "do_early_stopping": true,
+        "clip": 5.0
+    }
+}

--- a/python/mead/tasks.py
+++ b/python/mead/tasks.py
@@ -335,10 +335,11 @@ class EncoderDecoderTask(Task):
             print('PyTorch backend')
             from baseline.pytorch import long_0_tensor_alloc as vec_alloc
             from baseline.pytorch import tensor_shape as vec_shape
+            from baseline.pytorch import tensor_reverse_2nd as rev2nd
             import baseline.pytorch.seq2seq as seq2seq
             self.config_params['preproc']['vec_alloc'] = vec_alloc
             self.config_params['preproc']['vec_shape'] = vec_shape
-            src_vec_trans = baseline.tensor_reverse_2nd if do_reverse else None
+            src_vec_trans = rev2nd if do_reverse else None
             self.config_params['preproc']['word_trans_fn'] = src_vec_trans
             self.config_params['preproc']['show_ex'] = baseline.pytorch.show_examples_pytorch
             self.config_params['preproc']['trim'] = True


### PR DESCRIPTION
This PR is the first barebones update to make Baseline work with pytorch 0.4

Most of the changes are fixing problems introduced by the 0-dim tensors. There are also some changes (including a dim in softmax, and updating function names) that are made to remove UserWarnings and get ready for deprecation in the next release.

This was tested by running different networks with mead and verifying that the models trained, the loss went down, the validation code ran, and final test code ran at the end of training.

The following models were tested:

 * iwslt15-en-vi
   * attn
   * default
 * conll
 * wnut
 * sst2
   * default
   * lstm
   * nbow
   * nbowmax
 * lm
   * ptb medium