### PR TITLE
Updated mask to follow style

### DIFF
--- a/python/baseline/pytorch/seq2seq/model.py
+++ b/python/baseline/pytorch/seq2seq/model.py
@@ -37,6 +37,7 @@ class Seq2SeqBase(nn.Module, EncoderDecoder):
     def create(cls, input_embeddings, output_embeddings, **kwargs):
 
         model = cls(input_embeddings, output_embeddings, **kwargs)
+        print(model)
         return model
 
     def make_input(self, batch_dict):
@@ -267,8 +268,8 @@ class Seq2SeqAttnModel(Seq2SeqBase):
         # Context = B x T x H
         # a = B x T x 1
         a = torch.bmm(context, self.output_to_attn(output_t).unsqueeze(2))
-        scores = attention_mask(a.squeeze(2), src_mask)
-        a = self.attn_softmax(scores)
+        a = a.squeeze(2).masked_fill(src_mask == 0, -1e9)
+        a = self.attn_softmax(a)
         # a = B x T
         # Want to apply over context, scaled by a
         # (B x 1 x T) (B x T x H) = (B x 1 x H)

--- a/python/baseline/pytorch/torchy.py
+++ b/python/baseline/pytorch/torchy.py
@@ -12,21 +12,15 @@ PYT_MAJOR_VERSION = get_version(torch)
 
 
 def sequence_mask(lengths):
-    len = lengths.cpu()
-    max_len = torch.max(len)
+    lens = lengths.cpu()
+    max_len = torch.max(lens)
     # 1 x T
-    row = Variable(torch.arange(0, max_len.item()), requires_grad=False).view(1, -1)
+    row = torch.arange(0, max_len.item()).type_as(lens).view(1, -1)
     # B x 1
-    col = len.view(-1, 1).float()
+    col = lens.view(-1, 1)
     # Broadcast to B x T, compares increasing number to max
     mask = row < col
-    return mask.float()
-
-
-def attention_mask(scores, mask, value=100000):
-    # Make padded scores really low so they become 0 in softmax
-    scores = scores * mask + (mask - 1) * value
-    return scores
+    return mask
 
 
 def classify_bt(model, batch_time):

--- a/test/test_pytorch_masks.py
+++ b/test/test_pytorch_masks.py
@@ -1,19 +1,18 @@
 import unittest
 import torch
-from torch import IntTensor
 from torch.autograd import Variable
 import torch.nn.functional as F
 import numpy as np
-from baseline.pytorch.torchy import sequence_mask, attention_mask
+from baseline.pytorch.torchy import sequence_mask
 
 class MaskTest(unittest.TestCase):
 
     def setUp(self):
         self.batch_size = np.random.randint(5, 10)
         max_seq = np.random.randint(15, 20)
-        self.lengths = Variable(IntTensor(np.random.randint(1, max_seq, size=[self.batch_size])))
-        self.seq_len = torch.max(self.lengths).data[0]
-        self.scores = Variable(torch.rand(self.batch_size, self.seq_len))
+        self.lengths = torch.LongTensor(np.random.randint(1, max_seq, size=[self.batch_size]))
+        self.seq_len = torch.max(self.lengths).item()
+        self.scores = torch.rand(self.batch_size, self.seq_len)
 
     def test_mask_shape(self):
         mask = sequence_mask(self.lengths)
@@ -29,37 +28,21 @@ class MaskTest(unittest.TestCase):
                     np_mask[i, j] = 1
         np.testing.assert_allclose(mask.data.numpy(), np_mask)
 
-    def test_attention_mask_shape(self):
-        mask = sequence_mask(self.lengths)
-        score_mask = attention_mask(self.scores, mask)
-        self.assertEqual(mask.size(), score_mask.size())
-
-    def test_attention_mask_values(self):
-        value = 100000
-        mask = sequence_mask(self.lengths)
-        score_mask = attention_mask(self.scores, mask, value=value)
-        for row, length in zip(score_mask, self.lengths):
-            if length.data[0] == self.seq_len:
-                continue
-            masked = row[length.data[0]:]
-            np.testing.assert_allclose(masked.data.numpy(), -value)
-
     def test_attention_masked_valid_probs(self):
         mask = sequence_mask(self.lengths)
-        score_mask = attention_mask(self.scores, mask)
+        score_mask = self.scores.masked_fill(mask, -1e9)
         attention_weights = F.softmax(score_mask, dim=1)
         for row in attention_weights:
-            np.testing.assert_allclose(torch.sum(row).data[0], 1)
-
+            np.testing.assert_allclose(torch.sum(row).item(), 1)
 
     def test_attention_masked_ignores_pad(self):
         mask = sequence_mask(self.lengths)
-        score_mask = attention_mask(self.scores, mask)
+        score_mask = self.scores.masked_fill(mask, -1e9)
         attention_weights = F.softmax(score_mask, dim=1)
         for row, length in zip(attention_weights, self.lengths):
-            if length.data[0] == self.seq_len:
+            if length.item() == self.seq_len:
                 continue
-            masked = row[length.data[0]:]
+            masked = row[:length.item()]
             np.testing.assert_allclose(masked.data.numpy(), 0.0)
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR updates the attention mask to use `masked_fill` like the rest of the code base does.

It also updates some code to pytorch 0.4 including removing the use of variables.

Tested by running iwslt attention model for one epoch so train, validation, and test code runs and loss decreases.