### PR TITLE
Removes user error when using a 1 layer lstm

### DIFF
--- a/python/baseline/pytorch/torchy.py
+++ b/python/baseline/pytorch/torchy.py
@@ -221,6 +221,8 @@ class BiRNNWrapper(nn.Module):
 
 
 def pytorch_rnn(insz, hsz, rnntype, nlayers, dropout):
+    if nlayers == 1:
+        dropout = 0.0
 
     if rnntype == 'gru':
         rnn = torch.nn.GRU(insz, hsz, nlayers, dropout=dropout)
@@ -275,6 +277,8 @@ class LayerNorm(nn.Module):
 
 
 def pytorch_lstm(insz, hsz, rnntype, nlayers, dropout, unif=0, batch_first=False, initializer=None):
+    if nlayers == 1:
+        dropout = 0.0
     ndir = 2 if rnntype.startswith('b') else 1
     #print('ndir: %d, rnntype: %s, nlayers: %d, dropout: %.2f, unif: %.2f' % (ndir, rnntype, nlayers, dropout, unif))
     rnn = torch.nn.LSTM(insz, hsz, nlayers, dropout=dropout, bidirectional=True if ndir > 1 else False, batch_first=batch_first)#, bias=False)


### PR DESCRIPTION
This PR suppresses the user warning when you try to apply dropout to an rnn with only 1 layer. 

There is a case for leaving the error to point out to users that when applying dropout to an rnn it is not applied to the last layer. However currently there is only a single place for dropout in the config and the value is used everywhere dropout is used so I think there are uses when the rnn is supposed to be 1 layer and the dropout is for other places in the network (for example in `twpos`)

I tested this by running twpos and iwslt in pytorch with layers of size one. I also ran them with layer size >1 and dropout was applied to the rnn