### PR TITLE
Replace python-magic with home rolled magic number checks

### DIFF
--- a/python/mead/downloader.py
+++ b/python/mead/downloader.py
@@ -1,13 +1,13 @@
 import gzip
 import tarfile
 import zipfile
-import magic
 import hashlib
 import shutil
 import requests
 import os
 import re
 import json
+from mead.mime_type import mime_type
 
 
 DATA_CACHE_CONF = "data-cache.json"
@@ -48,10 +48,6 @@ def extract_zip(file_loc):
     with zipfile.ZipFile(file_loc, "r") as zip_ref:
         zip_ref.extractall(temp_file)
     return temp_file
-
-
-def mime_type(loc):
-    return magic.Magic(mime=True).from_file(loc)
 
 
 def extractor(filepath, cache_dir, extractor_func):

--- a/python/mead/mime_type.py
+++ b/python/mead/mime_type.py
@@ -1,0 +1,42 @@
+import re
+from binascii import hexlify
+from functools import partial
+
+class MN(object):
+    GZIP = b'1f8b'
+    TAR = b'7573746172'
+    TAR_START = 257
+    ZIP = b'504b0304'
+
+def check_mn(b, mn=None, start=0):
+    if hexlify(b[start:start+20])[:len(mn)] == mn:
+        return True
+    return False
+
+check_gzip = partial(check_mn, mn=MN.GZIP)
+check_tar = partial(check_mn, mn=MN.TAR, start=MN.TAR_START)
+check_zip = partial(check_mn, mn=MN.ZIP)
+
+class RE(object):
+    HTML = re.compile(b"(<!doctype html>|<html.*?>)")
+    BIN = re.compile(b"\d+? \d+?$", re.MULTILINE)
+
+def check_re(b, regex=None):
+    return True if regex.match(b) else False
+
+check_html = partial(check_re, regex=RE.HTML)
+check_bin = partial(check_re, regex=RE.BIN)
+
+def mime_type(file_name):
+    b = open(file_name, 'rb').read(1024)
+    if check_gzip(b):
+        return "application/gzip"
+    if check_tar(b):
+        return "application/x-tar"
+    if check_zip(b):
+        return "application/zip"
+    if check_html(b):
+        return "text/html"
+    if check_bin(b):
+        return "application/w2v"
+    return "text/plain"

--- a/python/mead/tasks.py
+++ b/python/mead/tasks.py
@@ -5,7 +5,8 @@ import logging
 import logging.config
 import mead.utils
 import os
-from downloader import EmbeddingDownloader, DataDownloader, mime_type, read_json
+from downloader import EmbeddingDownloader, DataDownloader, read_json
+from mead.mime_type import mime_type
 
 class Task(object):
     TASK_REGISTRY = {}


### PR DESCRIPTION
This PR removes the dependency on `python-magic` by checking magic numbers by hand. This should be more robust to user filenames than just checking the file names. It also allows check without the filename which happens in mead.tasks

I tested with PR by running many mead configs that required downloading various datasets and embeddings. It all worked.

In mead tests the following datasets and embeddings were downloaded and used successfully:
 * twpos
 * ptb
 * SST2
 * wnut
 * iwslt15-en-vi
 * conll
 * w2v-gn
 * w2v-twitter-30M
 * numberbatch
 * senna
 * glove-twitter-27B
 * glove-6B-100
 * glove-42B