### PR TITLE
Dynet classification

### DIFF
--- a/python/baseline/data.py
+++ b/python/baseline/data.py
@@ -86,7 +86,7 @@ class SeqLabelExamples(object):
     SEQ_CHAR = 'xch'
     LABEL = 'y'
     SEQ_LENGTH = 'lengths'
-    SCALARS = [SEQ_LENGTH, LABEL]
+    SCALARS = {SEQ_LENGTH, LABEL}
 
     def __init__(self, example_list, do_shuffle=True, do_sort=False):
         """Constructor
@@ -146,7 +146,7 @@ class SeqLabelExamples(object):
             elif k in SeqLabelExamples.SCALARS:
                 pass
             else:
-                batch[k] = batch[k][:0, max_src_len]
+                batch[k] = batch[k][:, :max_src_len]
         return batch
 
     def _batch_objs(self, start, batchsz, trim, vec_alloc, vec_shape):
@@ -229,7 +229,7 @@ class SeqLabelDataFeed(ExampleDataFeed):
         :param i: (``int``) step index
         :return: A batch tensor x, batch tensor y
         """
-        batch = self.examples.batch(i, self.batchsz, trim=False, vec_alloc=self.vec_alloc, vec_shape=self.vec_shape)
+        batch = self.examples.batch(i, self.batchsz, trim=self.trim, vec_alloc=self.vec_alloc, vec_shape=self.vec_shape)
 
         if self.src_vec_trans is not None:
             batch[SeqLabelExamples.SEQ] = self.src_vec_trans(batch[SeqLabelExamples.SEQ])

--- a/python/baseline/dy/classify/__init__.py
+++ b/python/baseline/dy/classify/__init__.py
@@ -1,0 +1,2 @@
+from baseline.dy.classify.train import *
+from baseline.dy.classify.model import *

--- a/python/baseline/dy/classify/model.py
+++ b/python/baseline/dy/classify/model.py
@@ -1,0 +1,166 @@
+from itertools import chain
+import dynet as dy
+from baseline.model import (
+    Classifier,
+    load_classifier_model,
+    create_classifier_model
+)
+from baseline.dy.dynety import *
+
+
+class WordClassifierBase(Classifier):
+
+    def __init__(
+            self,
+            embeddings, labels,
+            finetune=True, dense=False,
+            dropout=0.5,
+            **kwargs
+    ):
+        super(WordClassifierBase, self).__init__()
+        self._pc = dy.ParameterCollection()
+
+        self.pdrop = dropout
+        self.train = True
+
+        vsz = len(embeddings.vocab)
+        dsz = embeddings.dsz
+        self.vocab = embeddings.vocab
+
+        self.embed = Embedding(
+            vsz, dsz, self.pc,
+            embeddings.weights, finetune, dense
+        )
+
+        self.labels = labels
+        n_classes = len(self.labels)
+
+        pool_size, self.pool = self._init_pool(dsz, **kwargs)
+        stack_size, self.stacked = self._init_stacked(pool_size, **kwargs)
+        self.output = self._init_output(stack_size, n_classes)
+
+    @property
+    def pc(self):
+        return self._pc
+
+    def __str__(self):
+        str_ = []
+        for x in chain(self.pc.lookup_parameters_list(), self.pc.parameters_list()):
+            str_.append(f"{x.name()}: {x.shape()}")
+        return '\n'.join(str_)
+
+    def make_input(self, batch_dict):
+        x = batch_dict['x']
+        y = batch_dict['y']
+        return x.T, y.T
+
+    def forward(self, input_):
+        embedded = self.embed(input_)
+        pooled = self.pool(embedded)
+        stacked = self.stacked(pooled)
+        return self.output(stacked)
+
+    def loss(self, input_, y):
+        return dy.pickneglogsoftmax_batch(input_, y)
+
+    def dropout(self, input_):
+        if self.train:
+            return dy.dropout(input_, self.pdrop)
+        return input_
+
+    def _init_stacked(self, input_dim, hsz=None, layers=1, **kwargs):
+        if hsz is None:
+            hsz = kwargs.get("cmotsz", 100)
+        stacked_layers = []
+        isz = input_dim
+        for x in range(layers):
+            stacked_layers.append(Linear(hsz, isz, self.pc))
+            stacked_layers.append(dy.rectify)
+            stacked_layers.append(self.dropout)
+            isz = hsz
+
+        def call_stacked(input_):
+            for layer in stacked_layers:
+                input_ = layer(input_)
+            return input_
+
+        return hsz, call_stacked
+
+    def _init_output(self, input_dim, n_classes):
+        return Linear(n_classes, input_dim, self.pc, name="Output")
+
+    @classmethod
+    def create(cls, embeddings_set, labels, **kwargs):
+        embeddings = embeddings_set['word']
+        model = cls(embeddings, labels, **kwargs)
+        print(model)
+        return model
+
+    def save(self, file_name):
+        self.pc.save(file_name)
+        return self
+
+    def load(self, file_name):
+        self.pc.populate(file_name)
+        return self
+
+class ConvModel(WordClassifierBase):
+    def __init__(self, *args, **kwargs):
+        kwargs['dense'] = True
+        super(ConvModel, self).__init__(*args, **kwargs)
+
+    def _init_pool(self, dsz, filtsz=(2, 3), cmotsz=128, **kwargs):
+        convs = []
+        for fsz in filtsz:
+            convs.append(Convolution1d(fsz, cmotsz, dsz, self.pc))
+
+        def call_pool(input_):
+            input_ = dy.reshape(input_, (1, *input_.dim()[0]))
+            mots = []
+            for conv in convs:
+                mots.append(conv(input_))
+            return dy.concatenate(mots)
+
+        return len(filtsz) * cmotsz, call_pool
+
+class LSTMModel(WordClassifierBase):
+
+    def _init_pool(self, dsz, hsz=100, layers=1, **kwargs):
+        return hsz, LSTM(hsz, dsz, self.pc, layers=layers)
+
+class NBowModel(WordClassifierBase):
+
+    def _init_pool(self, *args, **kwargs):
+        def pool(input_):
+            return dy.esum(input_) / len(input_)
+
+        return args[0], pool
+
+class NBowMax(WordClassifierBase):
+
+    def _init_pool(self, *args, **kwargs):
+        def pool(input_):
+            return dy.emax(input_)
+
+        return args[0], pool
+
+
+BASELINE_CLASSIFICATION_MODELS = {
+    'default': ConvModel.create,
+    'lstm': LSTMModel.create,
+    'nbow': NBowModel.create,
+    'nbowmax': NBowModel.create,
+}
+
+BASELINE_CLASSIFICATION_LOADER = {
+    'default': ConvModel.load,
+    'lstm': LSTMModel.load,
+    'nbow': NBowModel.load,
+    'nbowmax': NBowMax.load
+}
+
+def create_model(embeddings, labels, **kwargs):
+    return create_classifier_model(BASELINE_CLASSIFICATION_MODELS, embeddings, labels, **kwargs)
+
+def load_model(outname, **kwargs):
+    return load_classifier_model(BASELINE_CLASSIFICATION_LOADERS, outname, **kwargs)

--- a/python/baseline/dy/classify/train.py
+++ b/python/baseline/dy/classify/train.py
@@ -1,0 +1,124 @@
+from baseline.utils import listify, get_model_file
+from baseline.progress import create_progress_bar
+from baseline.confusion import ConfusionMatrix
+from baseline.reporting import basic_reporting
+from baseline.train import EpochReportingTrainer, create_trainer
+import dynet as dy
+import numpy as np
+
+def _add_to_cm(cm, y, preds):
+    best = np.argmax(preds, axis=0)
+    best = np.reshape(best, y.shape)
+    cm.add_batch(y, best)
+
+class ClassifyTrainerDynet(EpochReportingTrainer):
+
+    def __init__(
+            self,
+            model,
+            optim='sgd', clip=5, mom=0.9,
+            **kwargs
+    ):
+        super(ClassifyTrainerDynet, self).__init__()
+        self.model = model
+        eta = kwargs.get('eta', kwargs.get('lr', 0.01))
+        print("Using eta [{:.4f}]".format(eta))
+        print("Using optim [{}]".format(optim))
+        self.labels = model.labels
+        if optim == 'adadelta':
+            self.optimizer = dy.AdadeltaTrainer(model.pc)
+        elif optim == 'adam':
+            self.optimizer = dy.AdamTrainer(model.pc)
+        elif optim == 'rmsprop':
+            self.optimizer = dy.RMSPropTrainer(model.pc, learning_rate=eta)
+        else:
+            print("using mom {:.3f}".format(mom))
+            self.optimizer = dy.MomentumSGDTrainer(model.pc, learning_rate=eta, mom=mom)
+        self.optimizer.set_clip_threshold(clip)
+
+    def _test(self, loader):
+        total_loss = 0
+        steps = len(loader)
+        pg = create_progress_bar(steps)
+        cm = ConfusionMatrix(self.labels)
+
+        for batch_dict in pg(loader):
+            dy.renew_cg()
+            xs, ys = self.model.make_input(batch_dict)
+            preds = self.model.forward(xs)
+            losses = self.model.loss(preds, ys)
+            loss = dy.sum_batches(losses)
+            total_loss += loss.npvalue().item()
+            _add_to_cm(cm, ys, preds.npvalue())
+
+        metrics = cm.get_all_metrics()
+        metrics['avg_loss'] = total_loss / float(steps)
+        return metrics
+
+
+    def _train(self, loader):
+        steps = len(loader)
+        pg = create_progress_bar(steps)
+        cm = ConfusionMatrix(self.labels)
+        total_loss = 0
+        for batch_dict in pg(loader):
+            dy.renew_cg()
+            xs, ys = self.model.make_input(batch_dict)
+            preds = self.model.forward(xs)
+            losses = self.model.loss(preds, ys)
+            loss = dy.sum_batches(losses)
+            total_loss += loss.npvalue().item()
+            _add_to_cm(cm, ys, preds.npvalue())
+            loss.backward()
+            self.optimizer.update()
+
+        metrics = cm.get_all_metrics()
+        metrics['avg_loss'] = total_loss / float(steps)
+        return metrics
+
+def fit(
+        model,
+        ts, vs, es,
+        epochs=20,
+        do_early_stopping=True, early_stopping_metric='acc',
+        reporting=basic_reporting,
+        **kwargs
+):
+    model_file = get_model_file(kwargs, 'classify', 'dynet')
+    if do_early_stopping:
+        patience = kwargs.get('patience', epochs)
+        print('Doing early stopping on [{}] with patience [{}]'.format(early_stopping_metric, patience))
+
+    reporting_fns = listify(reporting)
+    print('reporting', reporting_fns)
+
+    trainer = create_trainer(ClassifyTrainerDynet, model, **kwargs)
+
+    max_metric = 0
+    last_improved = 0
+
+    for epoch in range(epochs):
+        trainer.train(ts, reporting_fns)
+        test_metrics = trainer.test(vs, reporting_fns)
+
+        if do_early_stopping is False:
+            model.save(model_file)
+
+        elif test_metrics[early_stopping_metric] > max_metric:
+            last_improved = epoch
+            max_metric = test_metrics[early_stopping_metric]
+            print('New max {:.3f}'.format(max_metric))
+            model.save(model_file)
+
+        elif (epoch - last_improved) > patience:
+            print('Stopping due to persistent failures to improve')
+            break
+
+    if do_early_stopping is True:
+        print('Best performance on max_metric {:.3f} at epoch {}'.format(max_metric, last_improved))
+
+    if es is not None:
+        print('Reloading best checkpoint')
+        model = model.load(model_file)
+        trainer = create_trainer(ClassifyTrainerDynet, model, **kwargs)
+        trainer.test(es, reporting_fns, phase='Test')

--- a/python/baseline/dy/dynety.py
+++ b/python/baseline/dy/dynety.py
@@ -4,7 +4,7 @@ def Linear(osz, isz, pc, name="Linear"):
     weight = pc.add_parameters((osz, isz), name="{}Weight".format(name))
     bias = pc.add_parameters(osz, name="{}Bias".format(name))
 
-    def linear(input_: dy.Expression):
+    def linear(input_):
         output = weight * input_ + bias
         return output
 

--- a/python/baseline/dy/dynety.py
+++ b/python/baseline/dy/dynety.py
@@ -1,0 +1,51 @@
+import dynet as dy
+
+def Linear(osz, isz, pc, name="Linear"):
+    weight = pc.add_parameters((osz, isz), name="{}Weight".format(name))
+    bias = pc.add_parameters(osz, name="{}Bias".format(name))
+
+    def linear(input_: dy.Expression):
+        output = weight * input_ + bias
+        return output
+
+    return linear
+
+def LSTM(osz, isz, pc, layers=1):
+    lstm = dy.VanillaLSTMBuilder(layers, isz, osz, pc)
+
+    def encode(input_):
+        state = lstm.initial_state()
+        out = state.transduce(input_)
+        return out[-1]
+
+    return encode
+
+def Convolution1d(fsz, cmotsz, dsz, pc, strides=(1, 1, 1, 1)):
+    weight = pc.add_parameters((1, fsz, dsz, cmotsz), name='ConvWeight')
+    bias = pc.add_parameters((cmotsz), name="ConvBias")
+
+    def conv(input_):
+        c = dy.conv2d_bias(input_, weight, bias, strides, is_valid=False)
+        activation = dy.rectify(c)
+        mot = dy.reshape(dy.max_dim(activation, 1), (cmotsz,))
+        return mot
+
+    return conv
+
+def Embedding(
+    vsz, dsz, pc,
+    embedding_weight=None, finetune=False, dense=False, batched=True
+):
+    if embedding_weight is not None:
+        embeddings = pc.lookup_parameters_from_numpy(embedding_weight, name="Embeddings")
+    else:
+        embeddings = pc.add_lookup_parameters((vsz, dsz), name="Embeddings")
+
+    def embed(input_):
+        lookup = dy.lookup_batch if batched else dy.lookup
+        embedded = [lookup(embeddings, x, finetune) for x in input_]
+        if dense:
+            return dy.transpose(dy.concatenate(embedded, d=1))
+        return embedded
+
+    return embed

--- a/python/baseline/dy/dynety.py
+++ b/python/baseline/dy/dynety.py
@@ -1,30 +1,98 @@
+from itertools import chain
+import numpy as np
 import dynet as dy
 
+class DynetModel(object):
+    def __init__(self):
+        super(DynetModel, self).__init__()
+
+    def __str__(self):
+        str_ = []
+        for p in chain(self.pc.lookup_parameters_list(), self.pc.parameters_list()):
+            str_.append("{}: {}".format(p.name(), p.shape()))
+        return '\n'.join(str_)
+
 def Linear(osz, isz, pc, name="Linear"):
-    weight = pc.add_parameters((osz, isz), name="{}Weight".format(name))
-    bias = pc.add_parameters(osz, name="{}Bias".format(name))
+    """
+    :param osz: int
+    :param isz: int
+    :param pc: dy.ParameterCollection
+    :param name: str
+    """
+    linear_pc = pc.add_subcollection(name=name)
+    weight = linear_pc.add_parameters((osz, isz), name="Weight".format(name))
+    bias = linear_pc.add_parameters(osz, name="Bias".format(name))
 
     def linear(input_):
+        """
+        :param input_: dy.Expression ((isz,), B)
+
+        Returns:
+            dy.Expression ((osz,), B)
+        """
         output = weight * input_ + bias
         return output
 
     return linear
 
 def LSTM(osz, isz, pc, layers=1):
+    """
+    :param osz: int
+    :param isz: int
+    :param pc: dy.ParameterCollection
+    :param layers: int
+    """
     lstm = dy.VanillaLSTMBuilder(layers, isz, osz, pc)
 
     def encode(input_):
+        """
+        :param input_: List[dy.Expression] ((isz,), B)
+
+        Returns:
+            dy.Expression ((osz,), B)
+        """
         state = lstm.initial_state()
-        out = state.transduce(input_)
-        return out[-1]
+        return state.transduce(input_)
 
     return encode
 
-def Convolution1d(fsz, cmotsz, dsz, pc, strides=(1, 1, 1, 1)):
-    weight = pc.add_parameters((1, fsz, dsz, cmotsz), name='ConvWeight')
-    bias = pc.add_parameters((cmotsz), name="ConvBias")
+def LSTMEncoder(osz, isz, pc, layers=1):
+    """
+    :param osz: int
+    :param isz: int
+    :param pc: dy.ParameterCollection
+    :param layers: int
+    """
+    lstm = LSTM(osz, isz, pc, layers=layers)
+
+    def encode(input_, lengths):
+        states = dy.concatenate_cols(lstm(input_))
+        final_states = dy.pick_batch(states, lengths, dim=1)
+        return final_states
+
+    return encode
+
+def Convolution1d(fsz, cmotsz, dsz, pc, strides=(1, 1, 1, 1), name="Conv"):
+    """1D Convolution.
+
+    :param fsz: int, Size of conv filter.
+    :param cmotsz: int, Size of conv output.
+    :param dsz: int, Size of the input.
+    :param pc: dy.ParameterCollection
+    :param strides: Tuple[int, int, int, int]
+    """
+    conv_pc = pc.add_subcollection(name=name)
+    weight = conv_pc.add_parameters((1, fsz, dsz, cmotsz), name='Weight')
+    bias = conv_pc.add_parameters((cmotsz), name="Bias")
 
     def conv(input_):
+        """Perform the 1D conv.
+
+        :param input: dy.Expression ((1, T, dsz), B)
+
+        Returns:
+            dy.Expression ((cmotsz,), B)
+        """
         c = dy.conv2d_bias(input_, weight, bias, strides, is_valid=False)
         activation = dy.rectify(c)
         mot = dy.reshape(dy.max_dim(activation, 1), (cmotsz,))
@@ -34,14 +102,34 @@ def Convolution1d(fsz, cmotsz, dsz, pc, strides=(1, 1, 1, 1)):
 
 def Embedding(
     vsz, dsz, pc,
-    embedding_weight=None, finetune=False, dense=False, batched=True
+    embedding_weight=None, finetune=False, dense=False, batched=False
 ):
+    """Create Embedding layer.
+
+    :param vsz: int, The Vocab Size
+    :param dsz: int, The Embeddings Size
+    :param pc: dy.ParameterCollection
+    :param embedding_weight: np.ndarray, Pretrained weights
+    :param finetune: bool Should the vectors be updated
+    :param dense: bool Should the result be a single matrix or a list of vectors
+    :param batched: bool Is the input a batched operation
+    """
     if embedding_weight is not None:
         embeddings = pc.lookup_parameters_from_numpy(embedding_weight, name="Embeddings")
     else:
         embeddings = pc.add_lookup_parameters((vsz, dsz), name="Embeddings")
 
     def embed(input_):
+        """Embed a sequence.
+
+        :param input_: List[List[int]] (batched) or List[int] (normal)
+            When batched the input should be a list over timesteps of lists of
+            words (over a batch) (T, B). Otherwise it is a list of words over time (T)
+
+        Returns:
+            dy.Expression ((T, H), B) if dense (useful for conv encoders)
+            List[dy.Expression] otherwise (used for RNNs)
+        """
         lookup = dy.lookup_batch if batched else dy.lookup
         embedded = [lookup(embeddings, x, finetune) for x in input_]
         if dense:
@@ -49,3 +137,185 @@ def Embedding(
         return embedded
 
     return embed
+
+def Attention(
+    lstmsz, pc, name="Attention"
+):
+    """Vectorized Bahdanau Attention.
+
+    :param lstmsz: int
+    :param pc: dy.ParameterCollection
+    """
+    attn_pc = pc.add_subcollection(name=name)
+    attention_w1 = attn_pc.add_parameters((lstmsz, lstmsz))
+    attention_w2 = attn_pc.add_parameters((lstmsz, lstmsz))
+    attention_v = attn_pc.add_parameters((1, lstmsz))
+
+    def attention(encoder_vectors):
+        """Compute the projected encoder vectors once per decoder.
+
+        :param encoder_vectors: dy.Expression ((H, T), B)
+            often from dy.concatenate_cols([lstm.transduce(embedded)])
+        """
+        projected_vectors = attention_w1 * encoder_vectors
+
+        def attend(state):
+            """Calculate the attention weighted sum of the encoder vectors.
+
+            :param state: dy.Expression ((H,), B)
+            """
+            projected_state = attention_w2 * state
+            non_lin = dy.tanh(dy.colwise_add(projected_vectors, projected_state))
+            attention_scores = attention_v * non_lin
+            attention_weights = dy.softmax(dy.transpose(attention_scores))
+            # Encoder Vectors has data along the columns so a matmul with the
+            # weights (which are also a column) creates a sum of encoder weighted
+            # by attention weights
+            output_vector = encoder_vectors * attention_weights
+            return dy.reshape(output_vector, (lstmsz,))
+
+        return attend
+
+    return attention
+
+class CRF(DynetModel):
+    """Linear Chain CRF in Dynet."""
+
+    def __init__(self, n_tags, pc=None, idxs=None):
+        """Initialize the object.
+
+        :param n_tags: int The number of tags in your output (emission size)
+        :param pc: dy.ParameterCollection
+        :param idxs: Tuple(int. int) The index of the start and stop symbol in emissions.
+
+        Note:
+            if idxs is none then the CRF adds these symbols to the emission vectors and
+            n_tags is assumed to be the number of output tags.
+
+            if idxs is not none then the first element is assumed to be the start index
+            and the second idx is assumed to be the end index. In this case n_tags is
+            assumed to include the start and end symbols.
+        """
+        super(CRF, self).__init__()
+        if pc is None:
+            self.pc = dy.ParameterCollection()
+        else:
+            self.pc = pc.add_subcollection(name="CRF")
+        if idxs is None:
+            self.start_idx = n_tags
+            self.end_idx = n_tags + 1
+            self.n_tags = n_tags + 2
+            self.add_ends = True
+        else:
+            self.start_idx, self.end_idx = idxs
+            self.n_tags = n_tags
+            self.add_ends = False
+
+        self.transitions = self.pc.add_parameters((self.n_tags, self.n_tags), name="transition")
+
+    @staticmethod
+    def _prep_input(emissions):
+        """Append scores for start and end to the emission.
+
+        :param emissions: List[dy.Expression ((H,), B)]
+
+        Returns:
+            List[dy.Expression ((H + 2,), B)]
+        """
+        return [dy.concatenate([e, dy.inputVector([-1e4, -1e4])], d=0) for e in emissions]
+
+    def score_sentence(self, emissions, tags):
+        """Get the score of a given sentence.
+
+        :param emissions: List[dy.Expression ((H,), B)]
+        :param tags: List[int]
+
+        Returns:
+            dy.Expression ((1,), B)
+        """
+        tags = [self.start_idx] + tags
+        score = dy.scalarInput(0)
+        for i, e in enumerate(emissions):
+            # Due to Dynet being column based it is best to use the transmission
+            # matrix so that x -> y is T[y, x].
+            score += dy.pick(dy.pick(self.transitions, tags[i + 1]), tags[i]) + dy.pick(e, tags[i + 1])
+        score += dy.pick(dy.pick(self.transitions, self.end_idx), tags[-1])
+        return score
+
+    def neg_log_loss(self, emissions, tags):
+        """Get the Negative Log Loss.
+
+        :param emissions: List[dy.Expression ((H,), B)]
+        :param tags: List[int]
+
+        Returns:
+            dy.Expression ((1,), B)
+        """
+        if self.add_ends:
+            emissions = CRF._prep_input(emissions)
+        viterbi_score = self._forward(emissions)
+        gold_score = self.score_sentence(emissions, tags)
+        # CRF Loss: P_real / P_1..N -> -log(CRF Loss)
+        # -(log (e^S_real) / (e^S_1..N))
+        # -(log (e^S_real) - log(e^S_1..N))
+        # -(S_real - S_1..N)
+        # S_1..N - S_real
+        return viterbi_score - gold_score
+
+    def _forward(self, emissions):
+        """Viterbi forward to calculate all path scores.
+
+        :param emissions: List[dy.Expression]
+
+        Returns:
+            dy.Expression ((1,), B)
+        """
+        init_alphas = [-1e4] * (self.n_tags)
+        init_alphas[self.start_idx] = 0
+        alphas = dy.inputVector(init_alphas)
+        for emission in emissions:
+            add_emission = dy.colwise_add(self.transitions, emission)
+            scores = dy.colwise_add(dy.transpose(add_emission), alphas)
+            # dy.logsumexp takes a list of dy.Expression and computes logsumexp
+            # elementwise across the lists so for example the logsumexp is calculated
+            # for [0] in each list. This means we want the scores for a given
+            # transition scores for a tag to be in the columns
+            alphas = dy.logsumexp([x for x in scores])
+        last_alpha = alphas + dy.pick(self.transitions, self.end_idx)
+        alpha = dy.logsumexp([x for x in last_alpha])
+        return alpha
+
+    def decode(self, emissions):
+        """Viterbi decode to find the best sequence.
+
+        :param emissions: List[dy.Expression]
+
+        Returns:
+            List[int], dy.Expression ((1,), B)
+        """
+        if self.add_ends:
+            emissions = CRF._prep_input(emissions)
+        backpointers = []
+
+        inits = [-1e4] * (self.n_tags)
+        inits[self.start_idx] = 0
+        alphas = dy.inputVector(inits)
+
+        for emission in emissions:
+            next_vars = dy.colwise_add(dy.transpose(self.transitions), alphas)
+            best_tags = np.argmax(next_vars.npvalue(), 0)
+            v_t = [dy.pick(dy.pick(next_vars, b), i) for i, b in enumerate(best_tags)]
+            alphas = dy.concatenate(v_t) + emission
+            backpointers.append(best_tags)
+
+        terminal_expr = alphas + dy.pick(self.transitions, self.end_idx)
+        best_tag = np.argmax(terminal_expr.npvalue())
+        path_score = dy.pick(terminal_expr, best_tag)
+
+        best_path = [best_tag]
+        for bp_t in reversed(backpointers):
+            best_tag = bp_t[best_tag]
+            best_path.append(best_tag)
+        _ = best_path.pop()
+        best_path.reverse()
+        return best_path, path_score

--- a/python/baseline/progress.py
+++ b/python/baseline/progress.py
@@ -107,6 +107,15 @@ class ProgressBarTerminal(Progress):
         self.update(step=0)
         print('')
 
+    def __call__(self, real_iter):
+        return self.__iter__(real_iter)
+
+    def __iter__(self, real_iter):
+        for x in real_iter:
+            yield x
+            self.update()
+        self.done()
+
 
 # This is retrofitted in, maybe there is a better way though
 g_Progress = ProgressBarTerminal

--- a/python/baseline/reader.py
+++ b/python/baseline/reader.py
@@ -445,6 +445,10 @@ class TSVSeqLabelReader(SeqLabelReader):
         self.do_chars = do_chars
 
     @staticmethod
+    def splits(text):
+        return list(filter(lambda s: len(s) != 0, re.split('\s+', text)))
+
+    @staticmethod
     def do_clean(l):
         l = l.lower()
         l = re.sub(r"[^A-Za-z0-9(),!?\'\`]", " ", l)
@@ -591,7 +595,6 @@ class TSVSeqLabelReader(SeqLabelReader):
         return baseline.data.SeqLabelDataFeed(baseline.data.SeqLabelExamples(examples, do_shuffle=shuffle, do_sort=do_sort),
                                               batchsz=batchsz, shuffle=shuffle,
                                               vec_alloc=self.vec_alloc, src_vec_trans=self.src_vec_trans)
-
 
 @exporter
 def create_pred_reader(mxlen, zeropadding, clean_fn, vec_alloc, src_vec_trans, **kwargs):

--- a/python/baseline/reader.py
+++ b/python/baseline/reader.py
@@ -428,7 +428,12 @@ class TSVSeqLabelReader(SeqLabelReader):
                 "!": " ! ",
                 }
 
-    def __init__(self, max_sentence_length=-1, max_word_length=-1, mxfiltsz=0, clean_fn=None, vec_alloc=np.zeros, src_vec_trans=None, do_chars=False, data_format='objs'):
+    def __init__(
+            self,
+            max_sentence_length=-1, max_word_length=-1, mxfiltsz=0,
+            clean_fn=None, vec_alloc=np.zeros, src_vec_trans=None,
+            do_chars=False, data_format='objs', trim=False
+    ):
         super(TSVSeqLabelReader, self).__init__()
 
         self.vocab = None
@@ -443,6 +448,7 @@ class TSVSeqLabelReader(SeqLabelReader):
             self.clean_fn = lambda x: x
         self.src_vec_trans = src_vec_trans
         self.do_chars = do_chars
+        self.trim = trim
 
     @staticmethod
     def splits(text):
@@ -593,7 +599,7 @@ class TSVSeqLabelReader(SeqLabelReader):
             if self.do_chars:
                 examples['xch'] = xch
         return baseline.data.SeqLabelDataFeed(baseline.data.SeqLabelExamples(examples, do_shuffle=shuffle, do_sort=do_sort),
-                                              batchsz=batchsz, shuffle=shuffle,
+                                              batchsz=batchsz, shuffle=shuffle, trim=self.trim,
                                               vec_alloc=self.vec_alloc, src_vec_trans=self.src_vec_trans)
 
 @exporter
@@ -603,8 +609,9 @@ def create_pred_reader(mxlen, zeropadding, clean_fn, vec_alloc, src_vec_trans, *
     if reader_type == 'default':
         do_chars = kwargs.get('do_chars', False)
         data_format = kwargs.get('data_format', 'objs')
+        trim = kwargs.get('trim', False)
         reader = TSVSeqLabelReader(mxlen, kwargs.get('mxwlen', -1), zeropadding, clean_fn, vec_alloc, src_vec_trans,
-                                   do_chars=do_chars, data_format=data_format)
+                                   do_chars=do_chars, data_format=data_format, trim=trim)
     else:
         mod = import_user_module("reader", reader_type)
         reader = mod.create_pred_reader(mxlen, zeropadding, clean_fn, vec_alloc, src_vec_trans, **kwargs)

--- a/python/mead/config/sst2-dy-autobatch.yml
+++ b/python/mead/config/sst2-dy-autobatch.yml
@@ -1,4 +1,4 @@
-batchsz: 50
+batchsz: 1
 preproc:
   mxlen: 100
   rev: false
@@ -7,19 +7,19 @@ backend: dynet
 dataset: SST2
 loader:
   reader_type: default
+  trim: true
 unif: 0.25
 model:
-  model_type: default
-  filtsz: [3,4,5]
-  cmotsz: 100
+  model_type: nbowmax
+  hsz: 256
   dropout: 0.5
   finetune: true
-  batched: true
 word_embeddings:
   label: w2v-gn
 train:
-  epochs: 2
-  optim: adadelta
-  eta: 1.0
+  epochs: 1
+  optim: adam
+  eta: 0.0003
   model_base: ./models/sst2
   early_stopping_metric: acc
+  autobatchsz: 50

--- a/python/mead/config/sst2-dy-autobatch.yml
+++ b/python/mead/config/sst2-dy-autobatch.yml
@@ -1,16 +1,16 @@
 batchsz: 1
 preproc:
-  mxlen: 100
+  mxlen: -1
   rev: false
   clean: true
+  trim: true
 backend: dynet
 dataset: SST2
 loader:
   reader_type: default
-  trim: true
 unif: 0.25
 model:
-  model_type: nbowmax
+  model_type: lstm
   hsz: 256
   dropout: 0.5
   finetune: true

--- a/python/mead/config/sst2-dy.yml
+++ b/python/mead/config/sst2-dy.yml
@@ -1,0 +1,26 @@
+batchsz: 50
+preproc:
+  mxlen: 100
+  rev: false
+  clean: true
+backend: dynet
+dataset: SST2
+loader:
+  reader_type: default
+unif: 0.25
+model:
+  model_type: default
+  filtsz: [3,4,5]
+  cmotsz: 128
+  hsz: 110
+  dropout: 0.5
+  finetune: true
+  layers: 1
+word_embeddings:
+  label: w2v-gn
+train:
+  epochs: 2
+  optim: adam
+  eta: 0.0003
+  model_base: ./models/sst2
+  early_stopping_metric: acc

--- a/python/mead/config/sst2-dy.yml
+++ b/python/mead/config/sst2-dy.yml
@@ -1,6 +1,6 @@
 batchsz: 50
 preproc:
-  mxlen: 100
+  mxlen: -1
   rev: false
   clean: true
 backend: dynet

--- a/python/mead/tasks.py
+++ b/python/mead/tasks.py
@@ -220,6 +220,9 @@ class ClassifierTask(Task):
             if backend == 'keras':
                 print('Keras backend')
                 import baseline.keras.classify as classify
+            if backend == 'dynet':
+                print('Dynet backend')
+                import baseline.dy.classify as classify
             else:
                 print('TensorFlow backend')
                 import baseline.tf.classify as classify

--- a/python/mead/tasks.py
+++ b/python/mead/tasks.py
@@ -222,7 +222,10 @@ class ClassifierTask(Task):
                 import baseline.keras.classify as classify
             if backend == 'dynet':
                 print('Dynet backend')
+                if 'autobatchsz' in self.config_params['train']:
+                    self.config_params['model']['batched'] = False
                 import baseline.dy.classify as classify
+                from baseline.data import reverse_2nd as rev2nd
             else:
                 print('TensorFlow backend')
                 import baseline.tf.classify as classify

--- a/python/mead/tasks.py
+++ b/python/mead/tasks.py
@@ -203,6 +203,7 @@ class ClassifierTask(Task):
                                            vec_alloc=self.config_params['preproc']['vec_alloc'],
                                            src_vec_trans=self.config_params['preproc']['src_vec_trans'],
                                            mxwlen=self.config_params['preproc'].get('mxwlen', -1),
+                                           trim=self.config_params['preproc'].get('trim', False),
                                            **self.config_params['loader'])
 
     def _setup_task(self):
@@ -222,8 +223,14 @@ class ClassifierTask(Task):
                 import baseline.keras.classify as classify
             if backend == 'dynet':
                 print('Dynet backend')
+                import _dynet
+                dy_params = _dynet.DynetParams()
+                dy_params.from_args()
+                dy_params.set_requested_gpus(1)
                 if 'autobatchsz' in self.config_params['train']:
                     self.config_params['model']['batched'] = False
+                    dy_params.set_autobatch(True)
+                dy_params.init()
                 import baseline.dy.classify as classify
                 from baseline.data import reverse_2nd as rev2nd
             else:
@@ -312,7 +319,7 @@ class TaggerTask(Task):
             self.config_params['preproc']['word_trans_fn'] = baseline.lowercase
             print('Lower')
         else:
-            self.config_params['preproc']['word_trans_fn'] = None 
+            self.config_params['preproc']['word_trans_fn'] = None
 
     def initialize(self, embeddings):
         self.dataset = DataDownloader(self.dataset, self.data_download_cache).download()

--- a/python/mead/trainer.py
+++ b/python/mead/trainer.py
@@ -11,7 +11,7 @@ def main():
     parser.add_argument('--embeddings', help='json library of embeddings', default='config/embeddings.json', type=convert_path)
     parser.add_argument('--logging', help='json file for logging', default='config/logging.json', type=convert_path)
     parser.add_argument('--task', help='task to run', default='classify', choices=['classify', 'tagger', 'seq2seq', 'lm'])
-    args = parser.parse_args()
+    args = parser.parse_known_args()[0]
 
     task = mead.Task.get_task_specific(args.task, args.logging, args.settings)
     task.read_config(args.config, args.datasets)

--- a/python/tests/test_dynety.py
+++ b/python/tests/test_dynety.py
@@ -1,0 +1,222 @@
+import random
+import numpy as np
+import dynet as dy
+from baseline.dy.dynety import *
+
+SIZES = [128, 256, 300, 512]
+FILTER_SIZES = [3, 4, 5]
+
+
+def test_linear_params_present():
+    dy.renew_cg()
+    pc = dy.ParameterCollection()
+    linear = Linear(12, 6, pc)
+    names = {p.name() for p in pc.parameters_list()}
+    assert "/Linear/Weight" in names
+    assert "/Linear/Bias" in names
+
+def test_linear_params_rename():
+    dy.renew_cg()
+    pc = dy.ParameterCollection()
+    gold = "TESTING"
+    linear = Linear(12, 6, pc, name=gold)
+    names = {p.name() for p in pc.parameters_list()}
+    assert "/{}/Weight".format(gold) in names
+    assert "/{}/Bias".format(gold) in names
+
+def test_linear_param_shapes():
+    dy.renew_cg()
+    pc = dy.ParameterCollection()
+    out = random.choice(SIZES)
+    in_ = random.choice(SIZES)
+    linear = Linear(out, in_, pc)
+    params = {p.name(): p for p in pc.parameters_list()}
+    assert params['/Linear/Weight'].shape() == (out, in_)
+    assert params['/Linear/Bias'].shape() == (out,)
+
+def test_linear_forward_shape():
+    dy.renew_cg()
+    pc = dy.ParameterCollection()
+    out = random.choice(SIZES)
+    in_ = random.choice(SIZES)
+    linear = Linear(out, in_, pc)
+    input_ = dy.inputVector(np.random.randn(in_))
+    out_ = linear(input_)
+    assert out_.dim() == ((out,), 1)
+
+def test_linear_forward_shape_batched():
+    dy.renew_cg()
+    pc = dy.ParameterCollection()
+    out = random.choice(SIZES)
+    in_ = random.choice(SIZES)
+    batch_size = random.randint(5, 11)
+    linear = Linear(out, in_, pc)
+    input_ = [dy.inputVector(np.random.randn(in_)) for _ in range(batch_size)]
+    input_ = dy.concatenate_to_batch(input_)
+    out_ = linear(input_)
+    assert out_.dim() == ((out,), batch_size)
+
+def test_LSTM_shape():
+    dy.renew_cg()
+    pc = dy.ParameterCollection()
+    out = random.choice(SIZES)
+    in_ = random.choice(SIZES)
+    seq_len = random.randint(5, 11)
+    input_ = [dy.inputVector(np.random.randn(in_)) for _ in range(seq_len)]
+    lstm = LSTM(out, in_, pc)
+    output_ = lstm(input_)
+    assert len(output_) == seq_len
+    for out_ in output_:
+        assert out_.dim() == ((out,), 1)
+
+def test_LSTM_shape_batch():
+    dy.renew_cg()
+    pc = dy.ParameterCollection()
+    out = random.choice(SIZES)
+    in_ = random.choice(SIZES)
+    seq_len = random.randint(5, 11)
+    batch_size = random.randint(5, 11)
+    input_ = [dy.concatenate_to_batch([dy.inputVector(np.random.randn(in_)) for _ in range(batch_size)]) for _ in range(seq_len)]
+    lstm = LSTM(out, in_, pc)
+    output_ = lstm(input_)
+    assert len(output_) == seq_len
+    for out_ in output_:
+        assert out_.dim() == ((out,), batch_size)
+
+def test_LSTM_Encoder_shape():
+    dy.renew_cg()
+    pc = dy.ParameterCollection()
+    out = random.choice(SIZES)
+    in_ = random.choice(SIZES)
+    seq_len = random.randint(5, 11)
+    lens = [seq_len - 1]
+    input_ = [dy.inputVector(np.random.randn(in_)) for _ in range(seq_len)]
+    lstm = LSTMEncoder(out, in_, pc)
+    output_ = lstm(input_, lens)
+    assert output_.dim() == ((out,), 1)
+
+def test_LSTM_Encoder_shape_batch():
+    dy.renew_cg()
+    pc = dy.ParameterCollection()
+    out = random.choice(SIZES)
+    in_ = random.choice(SIZES)
+    seq_len = random.randint(5, 11)
+    batch_size = random.randint(5, 11)
+    lens = [random.randint(1, seq_len) for _ in range(batch_size)]
+    input_ = [dy.concatenate_to_batch([dy.inputVector(np.random.randn(in_)) for _ in range(batch_size)]) for _ in range(seq_len)]
+    lstm = LSTMEncoder(out, in_, pc)
+    output_ = lstm(input_, lens)
+    assert output_.dim() == ((out,), batch_size)
+
+def test_conv_params_shape():
+    dy.renew_cg()
+    pc = dy.ParameterCollection()
+    fsz = random.choice(FILTER_SIZES)
+    dsz = random.choice(SIZES)
+    cmotsz = random.choice(SIZES)
+    conv = Convolution1d(fsz, cmotsz, dsz, pc)
+    params = {p.name(): p for p in pc.parameters_list()}
+    assert params['/Conv/Weight'].shape() == (1, fsz, dsz, cmotsz)
+    assert params['/Conv/Bias'].shape() == (cmotsz,)
+
+def test_conv_output_shape():
+    dy.renew_cg()
+    pc = dy.ParameterCollection()
+    fsz = random.choice(FILTER_SIZES)
+    dsz = random.choice(SIZES)
+    cmotsz = random.choice(SIZES)
+    seq_len = random.randint(fsz + 1, fsz + 5)
+    input_ = dy.inputTensor(np.random.randn(1, seq_len, dsz))
+    conv = Convolution1d(fsz, cmotsz, dsz, pc)
+    output_ = conv(input_)
+    assert output_.dim() == ((cmotsz,), 1)
+
+def test_conv_output_shape_batched():
+    dy.renew_cg()
+    pc = dy.ParameterCollection()
+    fsz = random.choice(FILTER_SIZES)
+    dsz = random.choice(SIZES)
+    cmotsz = random.choice(SIZES)
+    seq_len = random.randint(fsz + 1, fsz + 5)
+    batch_size = random.randint(5, 11)
+    input_ = dy.concatenate_to_batch([dy.inputTensor(np.random.randn(1, seq_len, dsz)) for _ in range(batch_size)])
+    conv = Convolution1d(fsz, cmotsz, dsz, pc)
+    output_ = conv(input_)
+    assert output_.dim() == ((cmotsz,), batch_size)
+
+def test_embedded_dense_shape():
+    dy.renew_cg()
+    pc = dy.ParameterCollection()
+    vsz = random.choice(SIZES)
+    dsz = random.choice(SIZES)
+    seq_len = random.randint(5, 11)
+    input_ = [random.randint(0, vsz) for _ in range(seq_len)]
+    embed = Embedding(vsz, dsz, pc, dense=True)
+    output_ = embed(input_)
+    assert output_.dim() == ((seq_len, dsz), 1)
+
+def test_embedded_shape():
+    dy.renew_cg()
+    pc = dy.ParameterCollection()
+    vsz = random.choice(SIZES)
+    dsz = random.choice(SIZES)
+    seq_len = random.randint(5, 11)
+    input_ = [random.randint(0, vsz) for _ in range(seq_len)]
+    embed = Embedding(vsz, dsz, pc)
+    output_ = embed(input_)
+    assert len(output_) == seq_len
+    for out_ in output_:
+        assert out_.dim() == ((dsz,), 1)
+
+def test_embedded_shape_batched():
+    dy.renew_cg()
+    pc = dy.ParameterCollection()
+    vsz = random.choice(SIZES)
+    dsz = random.choice(SIZES)
+    seq_len = random.randint(5, 11)
+    batch_size = random.randint(5, 11)
+    input_ = [[random.randint(0, vsz) for _ in range(batch_size)] for _ in range(seq_len)]
+    embed = Embedding(vsz, dsz, pc, batched=True)
+    output_ = embed(input_)
+    assert len(output_) == seq_len
+    for out_ in output_:
+        assert out_.dim() == ((dsz, ), batch_size)
+
+def test_embedded_dense_batched():
+    dy.renew_cg()
+    pc = dy.ParameterCollection()
+    vsz = random.choice(SIZES)
+    dsz = random.choice(SIZES)
+    seq_len = random.randint(5, 11)
+    batch_size = random.randint(5, 11)
+    input_ = [[random.randint(0, vsz) for _ in range(batch_size)] for _ in range(seq_len)]
+    embed = Embedding(vsz, dsz, pc, dense=True, batched=True)
+    output_ = embed(input_)
+    output_.dim() == ((dsz, vsz), batch_size)
+
+def test_embedding_from_numpy():
+    dy.renew_cg()
+    pc = dy.ParameterCollection()
+    gold = np.random.randn(200, 100)
+    embed = Embedding(12, 12, pc, embedding_weight=gold)
+    embedding_weights = pc.lookup_parameters_list()[0]
+    np.testing.assert_allclose(gold.T, embedding_weights.npvalue())
+
+def test_embedding_lookup():
+    dy.renew_cg()
+    pc = dy.ParameterCollection()
+    gold = np.random.randn(200, 100)
+    embed = Embedding(12, 12, pc, embedding_weight=gold)
+    idx = random.randint(0, len(gold))
+    vector = embed([idx])
+    gold_v = gold[idx, :]
+    np.testing.assert_allclose(gold_v, vector[0].npvalue())
+
+def test_embedding_shape():
+    dy.renew_cg()
+    pc = dy.ParameterCollection()
+    vsz = random.choice(SIZES)
+    dsz = random.choice(SIZES)
+    embed = Embedding(vsz, dsz, pc)
+    weights = pc.lookup_parameters_list()[0]
+    assert weights.shape() == (vsz, dsz)


### PR DESCRIPTION
This PR adds Dynet classification models to baseline.

In order to pass dynet commandline flags through mead to dynet I had to change the trainer to use `parse_known_args()` rather then just `parse_args()`. This lets the dynet flags pass through.

These models are batched and work on GPU. There is also an example of how to build and train a model using the dynet autobatch feature. To show how autobatching could be useful I had to add the ability to create trimmed batches for the classification reader.

I also made a modification to the terminal progress bar so that it can wrap an iterable. Them means you don't need to manually call `.update()` or `.done()`