### PR TITLE
Updated Dockerfile and made using the cache in docker easier

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,21 +1,25 @@
 ARG TF_VERSION=1.5.0
 
+FROM python:3.5
 FROM tensorflow/tensorflow:${TF_VERSION}-gpu-py3
 
 RUN apt-get update && \
     apt-get install -y g++ make git vim && \
-    pip install visdom pymongo click && \
-    pip install http://download.pytorch.org/whl/cu90/torch-0.3.1-cp35-cp35m-linux_x86_64.whl  && \
+    pip install visdom pymongo pyyaml && \
+    pip install http://download.pytorch.org/whl/cu90/torch-0.4.0-cp35-cp35m-linux_x86_64.whl && \
     pip install torchvision && \
     jupyter nbextension enable --py widgetsnbextension
 
 COPY python /baseline/python
 COPY docs /baseline/docs
-RUN  cd /baseline/python/ && ./install_dev.sh xpctl && ./install_dev.sh baseline
+COPY test /baseline/test
+
+RUN  cd /baseline/python/ && bash ./install_dev.sh xpctl no_test && bash ./install_dev.sh baseline no_test
 
 VOLUME ["/data/embeddings", "/data/model-store", "/data/datasets", "/data/model-checkpoints"]
 
-ENV PYTHONPATH='$PYTHONPATH:/baseline/python'
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
 
 WORKDIR /baseline/python
 CMD ["bash"]

--- a/docker/build_docker.sh
+++ b/docker/build_docker.sh
@@ -1,0 +1,11 @@
+MEAD_CONFIG_LOC='../python/mead/config/mead-settings.json'
+if [ ! -e $MEAD_CONFIG_LOC ]; then
+    echo -e "{\"datacache\": \"$HOME/.bl-data\"}" > $MEAD_CONFIG_LOC
+fi
+
+CON_BUILD=baseline
+docker build --network=host -t ${CON_BUILD} -f Dockerfile ../
+if [ $? -ne 0 ]; then
+    echo "could not build container, exiting"
+    exit 1
+fi

--- a/docker/run_docker.sh
+++ b/docker/run_docker.sh
@@ -26,12 +26,12 @@ fi
 echo "using GPU: "${GPU_NUM}", container name: "${CON_NAME}
 
 CON_BUILD=baseline
-docker build --network=host -t ${CON_BUILD} -f Dockerfile ../
-if [ $? -ne 0 ]; then
-    echo "could not build container, exiting"
-    exit 1
+
+if [ -e $HOME/.bl-data ]; then
+    CACHE_MOUNT="-v $HOME/.bl-data:$HOME/.bl-data"
+else
+    CACHE_MOUNT=""
 fi
 
-
-NV_GPU=${GPU_NUM} nvidia-docker run -e LANG=C.UTF-8 --rm --name=${CON_NAME} --net=host -v /data/embeddings:/data/embeddings:ro -v /data/datasets:/data/datasets:ro -v /data/model-store:/data/model-store -v /data/model-checkpoints:/data/model-checkpoints -it ${CON_BUILD} bash
+NV_GPU=${GPU_NUM} nvidia-docker run -e LANG=C.UTF-8 --rm --name=${CON_NAME} --net=host -v /data/embeddings:/data/embeddings:ro -v /data/datasets:/data/datasets:ro -v /data/model-store:/data/model-store -v /data/model-checkpoints:/data/model-checkpoints ${CACHE_MOUNT} -it ${CON_BUILD} bash
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -10,14 +10,14 @@ nvidia-docker run --net=host -v /data:/data:ro -it baseline bash
 
 We assume all necessary files (datasests, embeddings etc.) are stored in `/data/` in your machine.
 
-For convenience, we also provide a [script](../docker/docker.sh), which can be run as `./docker.sh -g 0 -n <container_name>`, eg. `./docker.sh -g 0 -n test`. The script assumes that following directories exist in your machine:
+For convenience, we also provide a [build script](../docker/build_docker.sh), and a [run script](../docker/run_docker.sh) which can be run as `./run_docker.sh -g 0 -n <container_name>`, eg. `./run_docker.sh -g 0 -n test`. The script assumes that following directories exist in your machine:
 
 
-- `/data/embeddings`: location for embedding files (W2v, Glove), see [embeddings.json](../python/mead/config/embeddings.json) in `mead`.  
+- `/data/embeddings`: location for embedding files (W2v, Glove), see [embeddings.json](../python/mead/config/embeddings.json) in `mead`.
 
 - `/data/datasets`: dataset locations (PTB, CoNLL), see [datasets.json](../python/mead/config/datasets.json) in `mead`.
 
-- `/data/model-checkpoints`: directory to store _saved_ models (model graph + data)   
+- `/data/model-checkpoints`: directory to store _saved_ models (model graph + data)
 
-- `/data/model-store`: directory to store _exported_ models.    
+- `/data/model-store`: directory to store _exported_ models.
 

--- a/python/install_dev.sh
+++ b/python/install_dev.sh
@@ -1,7 +1,8 @@
+#!/bin/bash
+
 package=${1:-"baseline"}
 test=${2:-"test"}
 
-rm -rf *.egg*
 cp setup_$package.py setup.py
 pip install -e .[test]
 rm setup.py

--- a/python/mead/config/mead-settings.json
+++ b/python/mead/config/mead-settings.json
@@ -1,3 +1,0 @@
-{
-  "datacache":"/data/bl-data/"
-}

--- a/python/mead/tasks.py
+++ b/python/mead/tasks.py
@@ -5,9 +5,9 @@ import logging
 import logging.config
 import mead.utils
 import os
-from mead.downloader import EmbeddingDownloader, DataDownloader, read_json
+from mead.downloader import EmbeddingDownloader, DataDownloader
 from mead.mime_type import mime_type
-from baseline.utils import export, read_config_file
+from baseline.utils import export, read_config_file, read_json, write_json
 
 __all__ = []
 exporter = export(__all__)
@@ -21,10 +21,16 @@ class Task(object):
         self.config_params = None
         self.ExporterType = None
         self.mead_config = mead_config
-        if mead_config is not None:
-            self.data_download_cache = os.path.expanduser(read_json(mead_config).get("datacache", "~/.bl-data/"))
+        if os.path.exists(mead_config):
+            mead_settings = read_json(mead_config)
         else:
-            self.data_download_cache = os.path.expanduser("~/.bl-data/")
+            mead_settings = {}
+        if 'datacache' not in mead_settings:
+            self.data_download_cache = os.path.expanduser("~/.bl-data")
+            mead_settings['datacache'] = self.data_download_cache
+            write_json(mead_settings, mead_config)
+        else:
+            self.data_download_cache = os.path.expanduser(mead_settings['datacache'])
         print("using {} as data/embeddings cache".format(self.data_download_cache))
         self._configure_logger(logger_file)
 

--- a/python/mead/trainer.py
+++ b/python/mead/trainer.py
@@ -6,7 +6,7 @@ from mead.utils import convert_path
 def main():
     parser = argparse.ArgumentParser(description='Train a text classifier')
     parser.add_argument('--config', help='JSON Configuration for an experiment', required=True, type=convert_path)
-    parser.add_argument('--settings', help='JSON Configuration for mead', required=False)
+    parser.add_argument('--settings', help='JSON Configuration for mead', default='config/mead-settings.json', type=convert_path)
     parser.add_argument('--datasets', help='json library of dataset labels', default='config/datasets.json', type=convert_path)
     parser.add_argument('--embeddings', help='json library of embeddings', default='config/embeddings.json', type=convert_path)
     parser.add_argument('--logging', help='json file for logging', default='config/logging.json', type=convert_path)

--- a/python/setup_xpctl.py
+++ b/python/setup_xpctl.py
@@ -61,6 +61,9 @@ def main():
                 'xpctl = xpctl.cli:cli'
             ],
         },
+        extras_require={
+            'test': []
+        },
         classifiers={
             'Development Status :: 2 - Pre-Alpha',
             'Environment :: Console',


### PR DESCRIPTION
This PR updated docker to be more usable by doing the following:

 * Fixes the bug where installing baseline with the `install_dev.sh` would uninstall xpctl and vis-a-versa.
 * Updated Dockerfile to use updated pytorch and set needed environment variables
 * Separates the build and run scripts for the docker container
 *  Updates the `mead-settings.json` so that is is always loaded. If it doesn't exist it is created. If no cache is found it is set to `~/.bl-data`. Now the data cache location can be found inside docker without user passing in settings. If there are other settings present but datacache is not they will be unaffected by adding datacache.
 * If no settings are found when you build the docker container with `build_docker.sh` then the settings are created with the default cache location. For example this is what happens then you clone then immediately run docker.
 * The docker run script checks for a default cache mount point (`~/.bl-data`) and mounts that if it exists.

This was testing in both my local setup and on research1 and it worked
