### PR TITLE
Moved Pytorch CRF into its own object

### DIFF
--- a/python/baseline/pytorch/tagger/model.py
+++ b/python/baseline/pytorch/tagger/model.py
@@ -3,157 +3,6 @@ from baseline.model import Tagger, create_tagger_model, load_tagger_model
 import torch.autograd
 import math
 
-# Some of this code is borrowed from here:
-# https://github.com/rguthrie3/DeepLearningForNLPInPytorch
-# I have vectorized the implementation for reasonable performance on real data
-# Helper functions to make the code more readable.
-def argmax(vec):
-    # return the argmax as a python int
-    _, idx = torch.max(vec, 1)
-    return idx.data[0]
-
-
-# Compute log sum exp in a numerically stable way for the forward algorithm
-def log_sum_exp(vec):
-    max_score = vec[0, argmax(vec)]
-    max_score_broadcast = max_score.view(1, -1).expand(1, vec.size()[1])
-    return max_score + torch.log(torch.sum(torch.exp(vec - max_score_broadcast)))
-
-
-# This code is not used, its here only for reference!
-def forward_algorithm(unary, transitions, start_idx, end_idx):
-    siglen, num_labels = unary.size()
-
-    # Do the forward algorithm to compute the partition function
-    init_alphas = torch.Tensor(1, num_labels).fill_(-10000.).cuda()
-    # START_TAG has all of the score.
-    init_alphas[0][start_idx] = 0.
-
-    # Wrap in a variable so that we will get automatic backprop
-    alphas = torch.autograd.Variable(init_alphas)
-
-    # Iterate through the sentence
-    for unary_t in unary:
-        # torch.Size([T, num_labels])
-        alphas_t = []  # The forward variables at this timestep
-        for tag in range(num_labels):
-            # broadcast the emission score: it is the same regardless of the previous tag
-            #            [1x1]                           [1 x L] (replicated)
-            emit_score = unary_t[tag].view(1, -1).expand(1, num_labels)
-            # the ith entry of trans_score is the score of transitioning to tag from i
-            #             [1xL]
-            trans_score = transitions[tag].view(1, -1)
-            # The ith entry of next_tag_var is the value for the edge (i -> tag)
-            # before we do log-sum-exp
-            #              [1xL]
-            next_tag_var = alphas + trans_score + emit_score
-            # The forward variable for this tag is log-sum-exp of all the scores.
-            alphas_t.append(log_sum_exp(next_tag_var))
-        alphas = torch.cat(alphas_t).view(1, -1)
-    terminal_var = alphas + transitions[end_idx]
-    alpha = log_sum_exp(terminal_var)
-    return alpha
-
-
-def vec_log_sum_exp(vec, dim):
-    """Vectorized version of log-sum-exp
-    
-    :param vec: Vector
-    :param dim: What dimension to operate on
-    :return: 
-    """
-    max_scores, idx = torch.max(vec, dim, keepdim=True)
-    max_scores_broadcast = max_scores.expand_as(vec)
-    return max_scores + torch.log(torch.sum(torch.exp(vec - max_scores_broadcast), dim, keepdim=True))
-
-
-def forward_algorithm_vec(unary, transitions, start_idx, end_idx):
-    """Vectorized forward algorithm for CRF layer
-    
-    :param unary: The observations
-    :param transitions: The transitions
-    :param start_idx: The index of the start position
-    :param end_idx: The index of the end position
-    :return: Alphas
-    """
-    siglen, num_labels = unary.size()
-
-    # Do the forward algorithm to compute the partition function
-    init_alphas = torch.Tensor(1, num_labels).fill_(-10000.).cuda()
-    # START_TAG has all of the score.
-    init_alphas[0][start_idx] = 0.
-
-    # Wrap in a variable so that we will get automatic backprop
-    alphas = torch.autograd.Variable(init_alphas)
-
-    # Iterate through the sentence
-    for t, unary_t in enumerate(unary):
-        expanded_alpha_t = alphas.expand(num_labels, num_labels)
-        # torch.Size([T, num_labels])
-        emit_scores_transpose = unary_t.view(1, -1).transpose(0, 1).expand(num_labels, num_labels)
-        next_tag_var = expanded_alpha_t + transitions
-        next_tag_var += emit_scores_transpose
-        scores = vec_log_sum_exp(next_tag_var, 1).transpose(0, 1)
-        alphas = scores
-
-    terminal_var = alphas + transitions[end_idx]
-    alpha = log_sum_exp(terminal_var)
-    return alpha
-
-
-def viterbi_decode(unary, transitions, start_idx, end_idx):
-    backpointers = []
-
-    siglen, num_labels = unary.size()
-
-    inits = torch.Tensor(1, num_labels).fill_(-10000.).cuda()
-    inits[0][start_idx] = 0
-
-    # alphas at step i holds the viterbi variables for step i-1
-    alphas = torch.autograd.Variable(inits)
-    for unary_t in unary:
-        backpointers_t = []  # holds the backpointers for this step
-        viterbi_t = []  # holds the viterbi variables for this step
-
-        for tag in range(num_labels):
-            next_tag_var = alphas + transitions[tag]
-            best_tag_id = argmax(next_tag_var)
-            backpointers_t.append(best_tag_id)
-            viterbi_t.append(next_tag_var[0][best_tag_id])
-
-        if PYT_MAJOR_VERSION < 0.4:
-            alphas = (torch.cat(viterbi_t) + unary_t).view(1, -1)
-
-        else:
-            alphas = (torch.stack(viterbi_t, 0) + unary_t).view(1, -1)
-        backpointers.append(backpointers_t)
-
-    # Transition to STOP_TAG
-    terminal_var = alphas + transitions[end_idx]
-    best_tag_id = argmax(terminal_var)
-    path_score = terminal_var[0][best_tag_id]
-
-    # Follow the back pointers to decode the best path.
-    best_path = [best_tag_id]
-    for backpointers_t in reversed(backpointers):
-        best_tag_id = backpointers_t[best_tag_id]
-        best_path.append(best_tag_id)
-    # Pop off the start tag (we dont want to return that to the caller)
-    start = best_path.pop()
-    assert start == start_idx
-    best_path.reverse()
-    return torch.LongTensor(best_path), path_score
-
-
-def score_sentence(unary, tags, transitions, start_idx, end_idx):
-    # Gives the score of a provided tag sequence
-    score = torch.autograd.Variable(torch.Tensor([0]).cuda())
-    tags = torch.cat([torch.LongTensor([start_idx]).cuda(), tags])
-    for i, unary_t in enumerate(unary):
-        score = score + transitions[tags[i + 1], tags[i]] + unary_t[tags[i + 1]]
-    score = score + transitions[end_idx, tags[-1]]
-    return score
-
 
 class RNNTaggerModel(nn.Module, Tagger):
 
@@ -194,7 +43,7 @@ class RNNTaggerModel(nn.Module, Tagger):
         word_dsz = 0
         hsz = int(kwargs['hsz'])
         model.proj = bool(kwargs.get('proj', False))
-        model.crf = bool(kwargs.get('crf', False))
+        model.use_crf = bool(kwargs.get('crf', False))
         model.activation_type = kwargs.get('activation', 'tanh')
         nlayers = int(kwargs.get('layers', 1))
         rnntype = kwargs.get('rnntype', 'blstm')
@@ -230,10 +79,10 @@ class RNNTaggerModel(nn.Module, Tagger):
                 pytorch_linear(out_hsz, len(model.labels)),
             ))
 
-        if model.crf:
-            weights = torch.Tensor(len(labels), len(labels)).zero_()
-            model.transitions = nn.Parameter(weights)
+        if model.use_crf:
+            model.crf = CRF(len(labels), (model.labels.get("<GO>"), model.labels.get("<EOS>")))
         model.crit = SequenceCriterion(LossFn=nn.CrossEntropyLoss)
+        print(model)
         return model
 
     def char2word(self, xch_i):
@@ -313,8 +162,6 @@ class RNNTaggerModel(nn.Module, Tagger):
 
     # Input better be xch, x
     def forward(self, input):
-        START_IDX = self.labels.get("<GO>")
-        END_IDX = self.labels.get("<EOS>")
         x = input[0].transpose(0, 1).contiguous()
         xch = input[1].transpose(0, 1).contiguous()
         lengths = input[2]
@@ -323,11 +170,11 @@ class RNNTaggerModel(nn.Module, Tagger):
 
         probv = self._compute_unary_tb(x, xch, lengths)
         preds = []
-        if self.crf is True:
+        if self.use_crf is True:
 
             for pij, sl in zip(probv, lengths):
                 unary = pij[:sl]
-                viterbi, _ = viterbi_decode(unary, self.transitions, START_IDX, END_IDX)
+                viterbi, _ = self.crf.decode(unary)
                 preds.append(viterbi)
         else:
             # Get batch (B, T)
@@ -339,8 +186,6 @@ class RNNTaggerModel(nn.Module, Tagger):
         return preds
 
     def compute_loss(self, input):
-        START_IDX = self.labels.get("<GO>")
-        END_IDX = self.labels.get("<EOS>")
         x = input[0].transpose(0, 1).contiguous()
         xch = input[1].transpose(0, 1).contiguous()
         lengths = input[2]
@@ -349,15 +194,13 @@ class RNNTaggerModel(nn.Module, Tagger):
         probv = self._compute_unary_tb(x, xch, lengths)
         batch_loss = 0.
         total_tags = 0.
-        if self.crf is True:
+        if self.use_crf is True:
             for pij, gold, sl in zip(probv, tags.data, lengths):
 
                 gold_tags = gold[:sl]
                 unary = pij[:sl]
                 total_tags += len(gold_tags)
-                forward_score = forward_algorithm_vec(unary, self.transitions, START_IDX, END_IDX)
-                gold_score = score_sentence(unary, gold_tags, self.transitions, START_IDX, END_IDX)
-                batch_loss += forward_score - gold_score
+                batch_loss += self.crf.neg_log_loss(unary, gold_tags)
         else:
             # Get batch (B, T)
             for pij, gold, sl in zip(probv, tags, lengths):
@@ -381,11 +224,11 @@ class RNNTaggerModel(nn.Module, Tagger):
         return predict_seq_bt(self, x, xch, lengths)
 
 BASELINE_TAGGER_MODELS = {
-    'default': RNNTaggerModel.create
+    'default': RNNTaggerModel.create,
 }
 
 BASELINE_TAGGER_LOADERS = {
-    'default': RNNTaggerModel.load
+    'default': RNNTaggerModel.load,
 }
 
 def create_model(labels, embeddings, **kwargs):


### PR DESCRIPTION
Moved Pytorch CRF into its own Object.

Tested by running the object version and the functional version and comparing results (they matched) and by using the object in a full tagger. The results were comparable after 10 epochs on conll (object crf performed a little better).