### PR TITLE
Clean up the way tests are skipped

### DIFF
--- a/python/tests/test_dynety.py
+++ b/python/tests/test_dynety.py
@@ -1,6 +1,7 @@
 import random
+import pytest
 import numpy as np
-import dynet as dy
+dy = pytest.importorskip('dynet')
 from baseline.dy.dynety import *
 
 SIZES = [128, 256, 300, 512]

--- a/python/tests/test_parallel_conv.py
+++ b/python/tests/test_parallel_conv.py
@@ -1,110 +1,111 @@
 try:
     import random
+    import unittest
     from mock import patch, MagicMock
     import numpy as np
     import tensorflow as tf
     from baseline.tf.tfy import parallel_conv, char_word_conv_embeddings, char_word_conv_embeddings_var_fm
+except ImportError:
+    raise unittest.SkipTest('Failed to import tensorflow')
 
 
-    class ParallelConvTest(tf.test.TestCase):
+class ParallelConvTest(tf.test.TestCase):
 
-        def setUp(self):
-            tf.reset_default_graph()
-            self.batchsz = random.randint(5, 65)
-            self.seqsz = random.randint(5, 11)
-            self.embedsz = random.randint(100, 301)
-            self.num_filt = random.randint(2, 6)
-            self.filtsz = set()
-            while len(self.filtsz) != self.num_filt:
-                self.filtsz.add(random.randint(2, 7))
-            self.filtsz = list(self.filtsz)
-            self.motsz = random.randint(128, 257)
-            self.nfeat_factor = random.randint(1, 4)
-            self.max_feat = random.randint(100, 301)
-            self.input = np.random.uniform(size=(self.batchsz, self.seqsz, self.embedsz)).astype(np.float32)
-            self.p = tf.placeholder(tf.float32, shape=(None, self.seqsz, self.embedsz))
+    def setUp(self):
+        tf.reset_default_graph()
+        self.batchsz = random.randint(5, 65)
+        self.seqsz = random.randint(5, 11)
+        self.embedsz = random.randint(100, 301)
+        self.num_filt = random.randint(2, 6)
+        self.filtsz = set()
+        while len(self.filtsz) != self.num_filt:
+            self.filtsz.add(random.randint(2, 7))
+        self.filtsz = list(self.filtsz)
+        self.motsz = random.randint(128, 257)
+        self.nfeat_factor = random.randint(1, 4)
+        self.max_feat = random.randint(100, 301)
+        self.input = np.random.uniform(size=(self.batchsz, self.seqsz, self.embedsz)).astype(np.float32)
+        self.p = tf.placeholder(tf.float32, shape=(None, self.seqsz, self.embedsz))
 
-        def test_output_batch_shape_int_arg(self):
+    def test_output_batch_shape_int_arg(self):
+        conv = parallel_conv(self.p, self.filtsz, self.embedsz, self.motsz)
+        with self.test_session() as sess:
+            sess.run(tf.global_variables_initializer())
+            self.assertEqual(conv.eval({self.p: self.input}).shape[0], self.batchsz)
+
+    def test_output_batch_shape_list_arg(self):
+        motsz = [self.motsz] * len(self.filtsz)
+        conv = parallel_conv(self.p, self.filtsz, self.embedsz, motsz)
+        with self.test_session() as sess:
+            sess.run(tf.global_variables_initializer())
+            self.assertEqual(conv.eval({self.p: self.input}).shape[0], self.batchsz)
+
+    def test_output_feature_shape_int_arg(self):
+        conv = parallel_conv(self.p, self.filtsz, self.embedsz, self.motsz)
+        with self.test_session() as sess:
+            sess.run(tf.global_variables_initializer())
+            self.assertEqual(conv.eval({self.p: self.input}).shape[1], self.motsz * self.num_filt)
+
+    def test_output_feature_shape_list_arg(self):
+        motsz = [self.nfeat_factor * fsz for fsz in self.filtsz]
+        conv = parallel_conv(self.p, self.filtsz, self.embedsz, motsz)
+        with self.test_session() as sess:
+            sess.run(tf.global_variables_initializer())
+            self.assertEqual(conv.eval({self.p: self.input}).shape[1], sum(motsz))
+
+    def test_shape_available_int(self):
+        """The previous tests test the shape of the actual output tensor. This
+        tests the output shape information available when building the graph.
+        When tf.squeeze is used on a tensor with a None dimension all shape info
+        is lost because it is unknown if the None dimension is 1 and should be
+        squeezed out. This cased error later because layers needed shape information
+        to set the right size. This test makes sure that needed size information
+        is present. This test would have caught the break in the classify method.
+        """
+        conv = parallel_conv(self.p, self.filtsz, self.embedsz, self.motsz)
+        conv_shape = conv.get_shape().as_list()
+        self.assertEqual(conv_shape, [None, self.motsz * len(self.filtsz)])
+
+    def test_shape_available_list(self):
+        """Same as the `test_shape_available_int` commnet."""
+        motsz = [self.nfeat_factor * fsz for fsz in self.filtsz]
+        conv = parallel_conv(self.p, self.filtsz, self.embedsz, motsz)
+        conv_shape = conv.get_shape().as_list()
+        self.assertEqual(conv_shape, [None, sum(motsz)])
+
+    def test_conv_called(self):
+        with patch('baseline.tf.tfy.tf.nn.conv2d') as conv_mock:
+            conv_mock.return_value = tf.zeros((self.batchsz, 1, self.seqsz, self.motsz))
             conv = parallel_conv(self.p, self.filtsz, self.embedsz, self.motsz)
-            with self.test_session() as sess:
-                sess.run(tf.global_variables_initializer())
-                self.assertEqual(conv.eval({self.p: self.input}).shape[0], self.batchsz)
+            self.assertEqual(conv_mock.call_count, self.num_filt)
 
-        def test_output_batch_shape_list_arg(self):
-            motsz = [self.motsz] * len(self.filtsz)
-            conv = parallel_conv(self.p, self.filtsz, self.embedsz, motsz)
-            with self.test_session() as sess:
-                sess.run(tf.global_variables_initializer())
-                self.assertEqual(conv.eval({self.p: self.input}).shape[0], self.batchsz)
+    def test_list_and_number_args_equal(self):
+        with tf.variable_scope("TEST"):
+            conv1 = parallel_conv(self.p, self.filtsz, self.embedsz, self.motsz)
+        with tf.variable_scope("TEST", reuse=True):
+            conv2 = parallel_conv(self.p, self.filtsz, self.embedsz, [self.motsz] * len(self.filtsz))
+        with self.test_session() as sess:
+            sess.run(tf.global_variables_initializer())
+            np.testing.assert_allclose(conv1.eval({self.p: self.input}), conv2.eval({self.p: self.input}))
 
-        def test_output_feature_shape_int_arg(self):
-            conv = parallel_conv(self.p, self.filtsz, self.embedsz, self.motsz)
-            with self.test_session() as sess:
-                sess.run(tf.global_variables_initializer())
-                self.assertEqual(conv.eval({self.p: self.input}).shape[1], self.motsz * self.num_filt)
+    @patch('baseline.tf.tfy.parallel_conv')
+    @patch('baseline.tf.tfy.skip_conns')
+    def test_char_word_call_correct(self, skip_mock, conv_mock):
+        conv_ret = MagicMock()
+        conv_mock.return_value = conv_ret
+        _ = char_word_conv_embeddings(self.p, self.filtsz, self.embedsz, self.motsz)
+        conv_mock.assert_called_once_with(self.p, self.filtsz, self.embedsz, self.motsz, tf.nn.tanh)
+        skip_mock.assert_called_once_with(conv_ret, self.motsz * len(self.filtsz), 1)
 
-        def test_output_feature_shape_list_arg(self):
-            motsz = [self.nfeat_factor * fsz for fsz in self.filtsz]
-            conv = parallel_conv(self.p, self.filtsz, self.embedsz, motsz)
-            with self.test_session() as sess:
-                sess.run(tf.global_variables_initializer())
-                self.assertEqual(conv.eval({self.p: self.input}).shape[1], sum(motsz))
-
-        def test_shape_available_int(self):
-            """The previous tests test the shape of the actual output tensor. This
-            tests the output shape information available when building the graph.
-            When tf.squeeze is used on a tensor with a None dimension all shape info
-            is lost because it is unknown if the None dimension is 1 and should be
-            squeezed out. This cased error later because layers needed shape information
-            to set the right size. This test makes sure that needed size information
-            is present. This test would have caught the break in the classify method.
-            """
-            conv = parallel_conv(self.p, self.filtsz, self.embedsz, self.motsz)
-            conv_shape = conv.get_shape().as_list()
-            self.assertEqual(conv_shape, [None, self.motsz * len(self.filtsz)])
-
-        def test_shape_available_list(self):
-            """Same as the `test_shape_available_int` commnet."""
-            motsz = [self.nfeat_factor * fsz for fsz in self.filtsz]
-            conv = parallel_conv(self.p, self.filtsz, self.embedsz, motsz)
-            conv_shape = conv.get_shape().as_list()
-            self.assertEqual(conv_shape, [None, sum(motsz)])
-
-        def test_conv_called(self):
-            with patch('baseline.tf.tfy.tf.nn.conv2d') as conv_mock:
-                conv_mock.return_value = tf.zeros((self.batchsz, 1, self.seqsz, self.motsz))
-                conv = parallel_conv(self.p, self.filtsz, self.embedsz, self.motsz)
-                self.assertEqual(conv_mock.call_count, self.num_filt)
-
-        def test_list_and_number_args_equal(self):
-            with tf.variable_scope("TEST"):
-                conv1 = parallel_conv(self.p, self.filtsz, self.embedsz, self.motsz)
-            with tf.variable_scope("TEST", reuse=True):
-                conv2 = parallel_conv(self.p, self.filtsz, self.embedsz, [self.motsz] * len(self.filtsz))
-            with self.test_session() as sess:
-                sess.run(tf.global_variables_initializer())
-                np.testing.assert_allclose(conv1.eval({self.p: self.input}), conv2.eval({self.p: self.input}))
-
-        @patch('baseline.tf.tfy.parallel_conv')
-        @patch('baseline.tf.tfy.skip_conns')
-        def test_char_word_call_correct(self, skip_mock, conv_mock):
-            conv_ret = MagicMock()
-            conv_mock.return_value = conv_ret
-            _ = char_word_conv_embeddings(self.p, self.filtsz, self.embedsz, self.motsz)
-            conv_mock.assert_called_once_with(self.p, self.filtsz, self.embedsz, self.motsz, tf.nn.tanh)
-            skip_mock.assert_called_once_with(conv_ret, self.motsz * len(self.filtsz), 1)
-
-        @patch('baseline.tf.tfy.parallel_conv')
-        @patch('baseline.tf.tfy.highway_conns')
-        def test_char_word_var_fm_call_correct(self, skip_mock, conv_mock):
-            conv_ret = MagicMock()
-            conv_mock.return_value = conv_ret
-            nfeats = [min(self.nfeat_factor * fsz, self.max_feat) for fsz in self.filtsz]
-            _ = char_word_conv_embeddings_var_fm(self.p, self.filtsz, self.embedsz, self.nfeat_factor, max_feat=self.max_feat)
-            conv_mock.assert_called_once_with(self.p, self.filtsz, self.embedsz, nfeats, tf.nn.tanh)
-            skip_mock.assert_called_once_with(conv_ret, sum(nfeats), 2)
-except ImportError as e:
-    pass
+    @patch('baseline.tf.tfy.parallel_conv')
+    @patch('baseline.tf.tfy.highway_conns')
+    def test_char_word_var_fm_call_correct(self, skip_mock, conv_mock):
+        conv_ret = MagicMock()
+        conv_mock.return_value = conv_ret
+        nfeats = [min(self.nfeat_factor * fsz, self.max_feat) for fsz in self.filtsz]
+        _ = char_word_conv_embeddings_var_fm(self.p, self.filtsz, self.embedsz, self.nfeat_factor, max_feat=self.max_feat)
+        conv_mock.assert_called_once_with(self.p, self.filtsz, self.embedsz, nfeats, tf.nn.tanh)
+        skip_mock.assert_called_once_with(conv_ret, sum(nfeats), 2)
 
 if __name__ == "__main__":
     tf.test.main()

--- a/python/tests/test_pytorch_masks.py
+++ b/python/tests/test_pytorch_masks.py
@@ -5,48 +5,48 @@ try:
     import torch.nn.functional as F
     import numpy as np
     from baseline.pytorch.torchy import sequence_mask
-
-    class MaskTest(unittest.TestCase):
-
-        def setUp(self):
-            self.batch_size = np.random.randint(5, 10)
-            max_seq = np.random.randint(15, 20)
-            self.lengths = torch.LongTensor(np.random.randint(1, max_seq, size=[self.batch_size]))
-            self.seq_len = torch.max(self.lengths).item()
-            self.scores = torch.rand(self.batch_size, self.seq_len)
-
-        def test_mask_shape(self):
-            mask = sequence_mask(self.lengths)
-            self.assertEqual(mask.size(0), self.batch_size)
-            self.assertEqual(mask.size(1), self.seq_len)
-
-        def test_mask(self):
-            mask = sequence_mask(self.lengths)
-            np_mask = np.zeros((self.batch_size, self.seq_len))
-            for i in range(self.batch_size):
-                for j in range(self.seq_len):
-                    if j < self.lengths.data[i]:
-                        np_mask[i, j] = 1
-            np.testing.assert_allclose(mask.data.numpy(), np_mask)
-
-        def test_attention_masked_valid_probs(self):
-            mask = sequence_mask(self.lengths)
-            score_mask = self.scores.masked_fill(mask, -1e9)
-            attention_weights = F.softmax(score_mask, dim=1)
-            for row in attention_weights:
-                np.testing.assert_allclose(torch.sum(row).item(), 1)
-
-        def test_attention_masked_ignores_pad(self):
-            mask = sequence_mask(self.lengths)
-            score_mask = self.scores.masked_fill(mask, -1e9)
-            attention_weights = F.softmax(score_mask, dim=1)
-            for row, length in zip(attention_weights, self.lengths):
-                if length.item() == self.seq_len:
-                    continue
-                masked = row[:length.item()]
-                np.testing.assert_allclose(masked.data.numpy(), 0.0)
 except ImportError:
-    pass
+    raise unittest.SkipTest('Failed to import Torch')
+
+class MaskTest(unittest.TestCase):
+
+    def setUp(self):
+        self.batch_size = np.random.randint(5, 10)
+        max_seq = np.random.randint(15, 20)
+        self.lengths = torch.LongTensor(np.random.randint(1, max_seq, size=[self.batch_size]))
+        self.seq_len = torch.max(self.lengths).item()
+        self.scores = torch.rand(self.batch_size, self.seq_len)
+
+    def test_mask_shape(self):
+        mask = sequence_mask(self.lengths)
+        self.assertEqual(mask.size(0), self.batch_size)
+        self.assertEqual(mask.size(1), self.seq_len)
+
+    def test_mask(self):
+        mask = sequence_mask(self.lengths)
+        np_mask = np.zeros((self.batch_size, self.seq_len))
+        for i in range(self.batch_size):
+            for j in range(self.seq_len):
+                if j < self.lengths.data[i]:
+                    np_mask[i, j] = 1
+        np.testing.assert_allclose(mask.data.numpy(), np_mask)
+
+    def test_attention_masked_valid_probs(self):
+        mask = sequence_mask(self.lengths)
+        score_mask = self.scores.masked_fill(mask, -1e9)
+        attention_weights = F.softmax(score_mask, dim=1)
+        for row in attention_weights:
+            np.testing.assert_allclose(torch.sum(row).item(), 1)
+
+    def test_attention_masked_ignores_pad(self):
+        mask = sequence_mask(self.lengths)
+        score_mask = self.scores.masked_fill(mask, -1e9)
+        attention_weights = F.softmax(score_mask, dim=1)
+        for row, length in zip(attention_weights, self.lengths):
+            if length.item() == self.seq_len:
+                continue
+            masked = row[:length.item()]
+            np.testing.assert_allclose(masked.data.numpy(), 0.0)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR cleans up the way import Errors are handled when skipping tests for frameworks that are not installed.