### PR TITLE
Variational Dropout for Pytorch

### DIFF
--- a/python/baseline/pytorch/classify/model.py
+++ b/python/baseline/pytorch/classify/model.py
@@ -40,6 +40,7 @@ class WordClassifierBase(nn.Module, Classifier):
         model.lut = pytorch_embedding(word_embeddings, finetune)
         model.vocab = {}
         model.vocab['word'] = word_embeddings.vocab
+        model.vdrop = bool(kwargs.get('variational_dropout', False))
 
         if model.char_dsz > 0:
             model.char_lut = pytorch_embedding(char_embeddings)

--- a/python/baseline/pytorch/tagger/model.py
+++ b/python/baseline/pytorch/tagger/model.py
@@ -46,6 +46,7 @@ class RNNTaggerModel(nn.Module, Tagger):
         model.use_crf = bool(kwargs.get('crf', False))
         model.crf_mask = bool(kwargs.get('crf_mask', False))
         model.span_type = kwargs.get('span_type')
+        model.vdrop = bool(kwargs.get('variational_dropout', False))
         model.activation_type = kwargs.get('activation', 'tanh')
         nlayers = int(kwargs.get('layers', 1))
         rnntype = kwargs.get('rnntype', 'blstm')
@@ -66,7 +67,10 @@ class RNNTaggerModel(nn.Module, Tagger):
 
         model.char_vocab = char_vec.vocab
         model.cembed = pytorch_embedding(char_vec)
-        model.dropout = nn.Dropout(pdrop)
+        if model.vdrop:
+            model.dropout = VariationalDropout(pdrop)
+        else:
+            model.dropout = nn.Dropout(pdrop)
         model.rnn = LSTMEncoder(model.wchsz + word_dsz, hsz, rnntype, nlayers, pdrop)
         out_hsz = model.rnn.outsz
         model.decoder = nn.Sequential()

--- a/python/baseline/pytorch/torchy.py
+++ b/python/baseline/pytorch/torchy.py
@@ -36,6 +36,30 @@ def classify_bt(model, batch_time):
     return results
 
 
+class VariationalDropout(nn.Module):
+    """Inverted dropout that applies the same mask at each time step."""
+
+    def __init__(self, p=0.5):
+        """Variational Dropout
+
+        :param p: float, the percentage to drop
+        """
+        super(VariationalDropout, self).__init__()
+        self.p = p
+
+    def extra_repr(self):
+        return 'p=%.1f' % self.p
+
+    def forward(self, input):
+        if not self.training:
+            return input
+        # Create a mask that covers a single time step
+        mask = torch.zeros(1, input.size(1), input.size(2)).bernoulli_(1 - self.p).to(input.device)
+        mask = mask / self.p
+        # Broadcast the mask over the sequence
+        return mask * input
+
+
 def predict_seq_bt(model, x, xch, lengths):
     x_t = torch.from_numpy(x) if type(x) == np.ndarray else x
     xch_t = torch.from_numpy(xch) if type(xch) == np.ndarray else xch

--- a/python/baseline/tf/classify/model.py
+++ b/python/baseline/tf/classify/model.py
@@ -503,6 +503,7 @@ class LSTMModel(WordClassifierBase):
         :return: 
         """
         hsz = kwargs.get('rnnsz', kwargs.get('hsz', 100))
+        vdrop = bool(kwargs.get('variational_dropout', False))
         if type(hsz) is list:
             hsz = hsz[0]
 
@@ -510,8 +511,8 @@ class LSTMModel(WordClassifierBase):
         nlayers = int(kwargs.get('layers', 1))
 
         if rnntype == 'blstm':
-            rnnfwd = stacked_lstm(hsz, self.pkeep, nlayers)
-            rnnbwd = stacked_lstm(hsz, self.pkeep, nlayers)
+            rnnfwd = stacked_lstm(hsz, self.pkeep, nlayers, variational=vdrop)
+            rnnbwd = stacked_lstm(hsz, self.pkeep, nlayers, variational=vdrop)
             ((_, _), (fw_final_state, bw_final_state)) = tf.nn.bidirectional_dynamic_rnn(rnnfwd,
                                                                                          rnnbwd,
                                                                                          word_embeddings,
@@ -522,7 +523,7 @@ class LSTMModel(WordClassifierBase):
             out_hsz = hsz
 
         else:
-            rnnfwd = stacked_lstm(hsz, self.pkeep, nlayers)
+            rnnfwd = stacked_lstm(hsz, self.pkeep, nlayers, variational=vdrop)
             (_, (output_state)) = tf.nn.dynamic_rnn(rnnfwd, word_embeddings, sequence_length=self.lengths, dtype=tf.float32)
             output_state = output_state[-1].h
             out_hsz = hsz

--- a/python/baseline/tf/lm/model.py
+++ b/python/baseline/tf/lm/model.py
@@ -19,7 +19,8 @@ class AbstractLanguageModel(object):
 
         #rnnfwd = stacked_lstm(self.hsz, self.pkeep, self.layers)
         def cell():
-            return lstm_cell_w_dropout(self.hsz, self.pkeep)
+            return lstm_cell_w_dropout(self.hsz, self.pkeep, variational=self.vdrop)
+
         rnnfwd = tf.contrib.rnn.MultiRNNCell([cell() for _ in range(self.layers)], state_is_tuple=True)
 
         self.initial_state = rnnfwd.zero_state(self.batchsz, tf.float32)
@@ -80,6 +81,7 @@ class WordLanguageModel(AbstractLanguageModel):
         lm.x = kwargs.get('x', tf.placeholder(tf.int32, [None, lm.mxlen], name="x"))
         lm.y = kwargs.get('y', tf.placeholder(tf.int32, [None, lm.mxlen], name="y"))
         lm.rnntype = kwargs.get('rnntype', 'lstm')
+        lm.vdrop = kwargs.get('variational_dropout', False)
         lm.pkeep = kwargs.get('pkeep', tf.placeholder(tf.float32, name="pkeep"))
         pdrop = kwargs.get('pdrop', 0.5)
         lm.pdrop_value = pdrop
@@ -153,6 +155,7 @@ class CharCompLanguageModel(AbstractLanguageModel):
         lm.x = kwargs.get('x', tf.placeholder(tf.int32, [None, lm.mxlen], name="x"))
         lm.xch = kwargs.get('xch', tf.placeholder(tf.int32, [None, lm.mxlen, lm.maxw], name="xch"))
         lm.y = kwargs.get('y', tf.placeholder(tf.int32, [None, lm.mxlen], name="y"))
+        lm.vdrop = kwargs.get('variational_dropout', False)
         lm.pkeep = kwargs.get('pkeep', tf.placeholder(tf.float32, name="pkeep"))
         lm.rnntype = kwargs.get('rnntype', 'lstm')
         vsz = word_vec.vsz + 1

--- a/python/baseline/utils.py
+++ b/python/baseline/utils.py
@@ -256,7 +256,7 @@ def read_json(filepath, default_value=None, strict=False):
     """
     if not os.path.exists(filepath):
         if strict:
-            raise FileNotFoundError('No file [] found'.format(filepath))
+            raise FileNotFoundError('No file {} found'.format(filepath))
         return default_value if default_value is not None else {}
     with open(filepath) as f:
         return json.load(f)
@@ -274,7 +274,7 @@ def read_yaml(filepath, default_value=None, strict=False):
     """
     if not os.path.exists(filepath):
         if strict:
-            raise FileNotFoundError('No file [] found'.format(filepath))
+            raise FileNotFoundError('No file {} found'.format(filepath))
         return default_value if default_value is not None else {}
     with open(filepath) as f:
         import yaml

--- a/python/mead/config/conll-iobes-tf.json
+++ b/python/mead/config/conll-iobes-tf.json
@@ -24,7 +24,7 @@
         "rnntype": "blstm",
         "layers": 1,
         "crf_mask": true,
-	"crf": 1
+        "crf": 1
     },
 
     "word_embeddings": {

--- a/python/mead/config/conll-iobes.json
+++ b/python/mead/config/conll-iobes.json
@@ -23,7 +23,7 @@
         "rnntype": "blstm",
         "layers": 1,
         "crf_mask": true,
-	"crf": 1
+        "crf": 1
     },
 
     "word_embeddings": {

--- a/python/mead/config/iwslt15-en-vi.json
+++ b/python/mead/config/iwslt15-en-vi.json
@@ -14,7 +14,7 @@
     },
     "model": {
         "model_type": "attn",
-	"rnntype": "blstm",
+        "rnntype": "blstm",
         "hsz": 500,
         "dropout": 0.5,
         "layers": 2

--- a/python/tests/test_pytorch_variational_dropout.py
+++ b/python/tests/test_pytorch_variational_dropout.py
@@ -1,0 +1,59 @@
+import random
+import pytest
+import numpy as np
+torch = pytest.importorskip('torch')
+from baseline.pytorch.torchy import VariationalDropout
+
+
+@pytest.fixture
+def input_():
+    SEQ_LEN = random.randint(20, 101)
+    BATCH_SIZE = random.randint(5, 21)
+    FEAT_SIZE = random.choice([128, 256, 300])
+    return torch.randn((SEQ_LEN, BATCH_SIZE, FEAT_SIZE))
+
+
+@pytest.fixture
+def pdrop():
+    return random.choice(np.arange(0.2, 0.8, 0.1))
+
+
+def test_dropout_same_across_seq(input_, pdrop):
+    """Test the dropout masks are the same across a sequence."""
+    vd = VariationalDropout(pdrop)
+    dropped = vd(input_)
+    first_mask = (dropped[0, :, :] == 0).detach().numpy()
+    for drop in dropped:
+        mask = drop == 0
+        np.testing.assert_allclose(first_mask, mask.detach().numpy())
+
+
+def test_dropout_probs(input_, pdrop):
+    """Test that approximately the right number of units are dropped."""
+    vd = VariationalDropout(pdrop)
+    dropped = vd(input_)
+    initial_non_zero = np.count_nonzero(input_.numpy())
+    dropped_non_zero = np.count_nonzero(dropped.detach().numpy())
+    np.testing.assert_allclose((dropped_non_zero / initial_non_zero), (1 - pdrop), atol=1e-1)
+
+
+def test_dropout_scaling(input_, pdrop):
+    """Test that the dropout layer scales correctly."""
+    vd = VariationalDropout(pdrop)
+    dropped = vd(input_)
+    re_dropped = input_.masked_fill(dropped == 0, 0)
+    dropped_np = dropped.detach().numpy()
+    re_dropped = re_dropped.numpy()
+    np.testing.assert_allclose(re_dropped * (1 / float(pdrop)), dropped_np)
+
+
+def test_gradient_flow(input_, pdrop):
+    """Test that a gradient can flow through the Variational Dropout."""
+    input_.requires_grad_()
+    vd = VariationalDropout(pdrop)
+    dropped = vd(input_)
+    output = torch.mean(dropped)
+    loss = torch.pow(torch.sub(torch.Tensor([1.0]), output), 2)
+    assert input_.grad is None
+    loss.backward()
+    assert input_.grad is not None


### PR DESCRIPTION
Adds a Variational Dropout (same mask at each time-step) to Pytorch.

This only works on the input/output of the RNN, not on recurrent connections yet. 

Assumes that input is `(T, B, H)` which is what RNNs already do to to utilize cudnn.

Tagger using Variational Dropout is currently top of tagger conll results in xpctl