### PR TITLE
This adds optional multi-GPU support for TensorFlow to `seq2seq` and `classify` tasks

### DIFF
--- a/docs/classify.md
+++ b/docs/classify.md
@@ -96,7 +96,7 @@ python classify_sentence.py --optim sgd --eta 0.01 --batchsz 50 --epochs 40 --pa
 | sst2    |       87.9 |
 | dbpedia |     99.054 | 
 | trec-qa |       94.6 |
-
+| AG      |       92.5 |
 
 Note that these are randomly initialized and these numbers will vary
 (IOW, don't assume that one implementation is guaranteed to outperform the others from a single run).

--- a/docs/classify.md
+++ b/docs/classify.md
@@ -133,7 +133,7 @@ Two different pooling methods for NBoW are supported: max (`--model_type nbowmax
 
 ### Status
 
-This model is implemented in TensorFlow and PyTorch.  
+This model is implemented in TensorFlow and PyTorch.  Multi-GPU support can be enabled with `"gpus": <N>`.  `"gpus": -1` is a special case that tells the driver to run with all available GPUs.  The `CUDA_VISIBLE_DEVICES` environment variable should be set to create a mask of GPUs that are visible to the program.
 
 ### Latest Runs
 

--- a/docs/seq2seq.md
+++ b/docs/seq2seq.md
@@ -6,11 +6,13 @@ Encoder-decoder frameworks have been used for Statistical Machine Translation, I
 
 This code implements seq2seq with mini-batching (as in other examples) using adagrad, adadelta, sgd or adam.  It supports two vocabularies, and supports word2vec pre-trained models as input, filling in words that are attested in the dataset but not found in the pre-trained models.  It uses dropout for regularization.
 
-For any reasonable size data, this really needs to run on the GPU for realistic training times.
+For any reasonable size data, this really needs to run on the GPU.
 
 ## Status
 
-This model is implemented in TensorFlow and PyTorch.  The English-Vietnamese dataset is from https://nlp.stanford.edu/projects/nmt/ and the site authors have published previously on the dataset here: https://nlp.stanford.edu/pubs/luong-manning-iwslt15.pdf. Test results are for Single NMT on TED tst2013.  The WMT dataset is available via https://github.com/tensorflow/nmt#wmt-german-english
+This model is implemented in TensorFlow and PyTorch. Multi-GPU support can be enabled with `"gpus": <N>`.  `"gpus": -1` is a special case that tells the driver to run with all available GPUs.  The `CUDA_VISIBLE_DEVICES` environment variable should be set to create a mask of GPUs that are visible to the program.
+
+The English-Vietnamese dataset is from https://nlp.stanford.edu/projects/nmt/ and the site authors have published previously on the dataset here: https://nlp.stanford.edu/pubs/luong-manning-iwslt15.pdf. Test results are for Single NMT on TED tst2013.  The WMT dataset is available via https://github.com/tensorflow/nmt#wmt-german-english
 
 
 *Our results for Single NMT*

--- a/python/baseline/tf/classify/model.py
+++ b/python/baseline/tf/classify/model.py
@@ -121,7 +121,6 @@ class WordClassifierBase(Classifier):
         """
         super(WordClassifierBase, self).__init__()
 
-
     def set_saver(self, saver):
         self.saver = saver
 
@@ -250,7 +249,7 @@ class WordClassifierBase(Classifier):
         
         :return: A restored model
         """
-        sess = kwargs.get('session', tf.Session())
+        sess = kwargs.get('session', kwargs.get('sess', tf.Session()))
         model = cls()
         with open(basename + '.saver') as fsv:
             saver_def = tf.train.SaverDef()

--- a/python/baseline/tf/classify/model.py
+++ b/python/baseline/tf/classify/model.py
@@ -51,7 +51,7 @@ class ClassifyParallelModel(Classifier):
         self.labels = labels
         with tf.Session(config=tf.ConfigProto(allow_soft_placement=True, log_device_placement=False)) as sess:
             for i, g in enumerate(gpus):
-                with tf.device(tf.DeviceSpec(device_type='GPU', device_index=g)):
+                with tf.device(tf.DeviceSpec(device_type='GPU', device_index=i)):
                     replica = create_fn(embed, labels, sess=sess, x=x_splits[i], y=y_splits[i], lengths=lengths_splits[i],
                                         pkeep=self.pkeep, **kwargs)
                     self.replicas.append(replica)

--- a/python/baseline/tf/classify/train.py
+++ b/python/baseline/tf/classify/train.py
@@ -15,7 +15,7 @@ class ClassifyTrainerTf(EpochReportingTrainer):
         self.sess = model.sess
         self.loss = model.create_loss()
         self.model = model
-        self.global_step, self.train_op = optimizer(self.loss, **kwargs)
+        self.global_step, self.train_op = optimizer(self.loss, colocate_gradients_with_ops=True, **kwargs)
 
     def _train(self, loader):
 
@@ -24,7 +24,6 @@ class ClassifyTrainerTf(EpochReportingTrainer):
         steps = len(loader)
         pg = create_progress_bar(steps)
         for batch_dict in loader:
-            y = batch_dict['y']
             feed_dict = self.model.make_input(batch_dict, do_dropout=True)
             _, step, lossv = self.sess.run([self.train_op, self.global_step, self.loss], feed_dict=feed_dict)
             total_loss += lossv
@@ -32,13 +31,11 @@ class ClassifyTrainerTf(EpochReportingTrainer):
 
         pg.done()
         metrics = {}
-        #metrics = cm.get_all_metrics()
         metrics['avg_loss'] = total_loss/float(steps)
         return metrics
 
     def _test(self, loader, **kwargs):
 
-        total_loss = 0
         cm = ConfusionMatrix(self.model.labels)
         steps = len(loader)
         verbose = kwargs.get("verbose", False)
@@ -53,7 +50,6 @@ class ClassifyTrainerTf(EpochReportingTrainer):
 
         pg.done()
         metrics = cm.get_all_metrics()
-        #metrics['avg_loss'] = total_loss/float(steps)
         if verbose:
             print(cm)
 

--- a/python/baseline/tf/seq2seq/model.py
+++ b/python/baseline/tf/seq2seq/model.py
@@ -74,7 +74,7 @@ class Seq2SeqParallelModel(EncoderDecoder):
         losses = []
         with tf.Session(config=tf.ConfigProto(allow_soft_placement=True, log_device_placement=False)) as sess:
             for i, g in enumerate(gpus):
-                with tf.device(tf.DeviceSpec(device_type='GPU', device_index=g)):
+                with tf.device(tf.DeviceSpec(device_type='GPU', device_index=i)):
                     replica = create_fn(src_vocab_embed, dst_vocab_embed, sess=sess,
                                         src=src_splits[i], tgt=tgt_splits[i],
                                         src_len=src_len_splits[i], tgt_len=tgt_len_splits[i],

--- a/python/baseline/tf/seq2seq/model.py
+++ b/python/baseline/tf/seq2seq/model.py
@@ -66,10 +66,10 @@ class Seq2SeqParallelModel(EncoderDecoder):
         self.pkeep = kwargs.get('pkeep', tf.placeholder(tf.float32, name="pkeep"))
         self.pdrop_value = kwargs.get('dropout', 0.5)
 
-        src_splits = tf.split(self.src, ng)
-        tgt_splits = tf.split(self.tgt, ng)
-        src_len_splits = tf.split(self.src_len, ng)
-        tgt_len_splits = tf.split(self.tgt_len, ng)
+        src_splits = tf.split(self.src, gpus)
+        tgt_splits = tf.split(self.tgt, gpus)
+        src_len_splits = tf.split(self.src_len, gpus)
+        tgt_len_splits = tf.split(self.tgt_len, gpus)
         losses = []
         with tf.Session(config=tf.ConfigProto(allow_soft_placement=True, log_device_placement=False)) as sess:
             for i in range(gpus):

--- a/python/baseline/tf/seq2seq/model.py
+++ b/python/baseline/tf/seq2seq/model.py
@@ -70,11 +70,11 @@ class Seq2SeqParallelModel(EncoderDecoder):
         tgt_len_splits = tf.split(self.tgt_len, ng)
 
         with tf.Session(config=tf.ConfigProto(allow_soft_placement=True, log_device_placement=True)) as sess:
-            for g in gpus:
+            for i, g in enumerate(gpus):
                 with tf.device(tf.DeviceSpec(device_type='GPU', device_index=g)):
                     replica = create_fn(src_vocab_embed, dst_vocab_embed, sess=sess,
-                                        src=src_splits[g], tgt=tgt_splits[g],
-                                        src_len=src_len_splits[g], tgt_len=tgt_len_splits[g], **kwargs)
+                                        src=src_splits[i], tgt=tgt_splits[i],
+                                        src_len=src_len_splits[i], tgt_len=tgt_len_splits[i], **kwargs)
                     self.replicas.append(replica)
                     loss_op = replica.create_loss()
                     self.losses.append(loss_op)

--- a/python/baseline/tf/seq2seq/train.py
+++ b/python/baseline/tf/seq2seq/train.py
@@ -18,6 +18,7 @@ class Seq2SeqTrainerTf(Trainer):
         self.global_step = tf.get_variable(
             'global_step', [],
             initializer=tf.constant_initializer(0), trainable=False)
+
         self.global_step, self.train_op = optimizer(self.loss, colocate_gradients_with_ops=True, **kwargs)
         #self.train_op = tf.train.AdamOptimizer(kwargs.get('eta')).minimize(tf.reduce_mean(self.loss),
         #                                                                   global_step=self.global_step,

--- a/python/baseline/tf/tfy.py
+++ b/python/baseline/tf/tfy.py
@@ -73,7 +73,7 @@ def optimizer(loss_fn, **kwargs):
     eta = kwargs.get('eta', kwargs.get('lr', 0.01))
     decay_type = kwargs.get('decay_type', None)
     decay_fn = None
-
+    colocate_gradients_with_ops = bool(kwargs.get('colocate_gradients_with_ops', False))
     if decay_type == 'piecewise':
         boundaries = kwargs.get('bounds', None)
         decay_values = kwargs.get('decay_values', None)
@@ -130,6 +130,7 @@ def optimizer(loss_fn, **kwargs):
     print('clip', clip)
     print('decay', decay_fn)
     return global_step, tf.contrib.layers.optimize_loss(loss_fn, global_step, eta, optz,
+                                                        colocate_gradients_with_ops=colocate_gradients_with_ops,
                                                         clip_gradients=clip, learning_rate_decay_fn=decay_fn)
 
 

--- a/python/baseline/tf/tfy.py
+++ b/python/baseline/tf/tfy.py
@@ -117,6 +117,9 @@ def optimizer(loss_fn, **kwargs):
     elif optim == 'adam':
         print('adam', eta)
         optz = lambda lr: tf.train.AdamOptimizer(lr)
+    elif optim == 'rmsprop':
+        print('rmsprop', eta)
+        optz = lambda lr: tf.train.RMSPropOptimizer(lr, momentum=mom)
     elif mom > 0:
         print('sgd-mom', eta, mom)
         optz = lambda lr: tf.train.MomentumOptimizer(lr, mom)

--- a/python/classify_sentence.py
+++ b/python/classify_sentence.py
@@ -39,6 +39,8 @@ parser.add_argument('--trainer_type', help='Name of trainer to load and train', 
 parser.add_argument('--rev', help='Time reverse input text', default=False, type=str2bool)
 parser.add_argument('--bounds', type=int, default=16000, help='Tell optim decay functionality how many steps before applying decay')
 parser.add_argument('--verbose', type=str2bool, default=False, help='print confusion matrix for the test data')
+parser.add_argument('--gpus', help='GPUs', nargs='+', default=[], type=int)
+
 
 args = parser.parse_args()
 
@@ -73,7 +75,7 @@ unif = 0 if args.static else args.unif
 
 EmbeddingsModelType = GloVeModel if args.embed.endswith(".txt") else Word2VecModel
 embeddings = {}
-embeddings['word'] = EmbeddingsModelType(args.embed, vocab, unif_weight=args.unif, keep_unused=args.keep_unused)
+embeddings['word'] = EmbeddingsModelType(args.embed, vocab['word'], unif_weight=args.unif, keep_unused=args.keep_unused)
 feature2index = {}
 feature2index['word'] = embeddings['word'].vocab
 

--- a/python/classify_sentence.py
+++ b/python/classify_sentence.py
@@ -39,7 +39,7 @@ parser.add_argument('--trainer_type', help='Name of trainer to load and train', 
 parser.add_argument('--rev', help='Time reverse input text', default=False, type=str2bool)
 parser.add_argument('--bounds', type=int, default=16000, help='Tell optim decay functionality how many steps before applying decay')
 parser.add_argument('--verbose', type=str2bool, default=False, help='print confusion matrix for the test data')
-parser.add_argument('--gpus', help='GPUs', nargs='+', default=[], type=int)
+parser.add_argument('--gpus', help='GPUs', type=int)
 
 
 args = parser.parse_args()

--- a/python/classify_sentence.py
+++ b/python/classify_sentence.py
@@ -96,6 +96,7 @@ model = classify.create_model(embeddings, labels,
                               filtsz=args.filtsz,
                               cmotsz=args.cmotsz,
                               dropout=args.dropout,
-                              finetune=not args.static)
+                              finetune=not args.static,
+                              gpus=args.gpus)
 
 classify.fit(model, ts, vs, es, **vars(args))

--- a/python/mead/config/ag-news.json
+++ b/python/mead/config/ag-news.json
@@ -1,0 +1,32 @@
+{
+    "task": "classify",
+    "batchsz": 100,
+    "preproc": {
+	"mxlen": 100,
+	"clean": true
+    },
+    "backend": "tensorflow",
+    "dataset": "AG",
+    "loader": {
+	"reader_type": "default"
+    },
+    "unif": 0.25,
+    "model": {
+	"model_type": "default",
+	"filtsz": [3,4,5],
+	"cmotsz": 200,
+	"dropout": 0.5,
+	"finetune": true
+    },
+    "word_embeddings": {
+	"label": "w2v-gn"
+    },
+    "train": {
+	"epochs": 10,
+	"optim": "adadelta",
+	"eta": 1.0,
+	"model_base": "./models/ag-news",
+	"early_stopping_metric": "acc",
+        "verbose": true
+    }
+}

--- a/python/mead/config/datasets.json
+++ b/python/mead/config/datasets.json
@@ -16,6 +16,20 @@
     "label": "SST2"
   },
   {
+    "train_file": "train-tok-shuf.txt",
+    "valid_file": "dev-tok.txt",
+    "test_file": "test-tok.txt",
+    "download": "https://www.dropbox.com/s/3o9ioqp2nh5wdqh/ag-news-tok.tar.gz?dl=1",
+    "label": "AG"
+  },
+  {
+    "train_file": "train-tok-shuf.txt",
+    "valid_file": "dev-tok.txt",
+    "test_file": "test-tok.txt",
+    "download": "https://www.dropbox.com/s/shnbgg5xmd7w239/dbpedia_tok.tar.gz?dl=1",
+    "label": "dbpedia"
+  },
+  {
     "train_file": "trec.nodev.utf8",
     "valid_file": "trec.dev.utf8",
     "test_file": "trec.test.utf8",

--- a/python/mead/config/dbpedia.json
+++ b/python/mead/config/dbpedia.json
@@ -13,7 +13,7 @@
     "unif": 0.25,
     "model": {
 	"model_type": "default",
-	"filtsz": [2,3,4,5],
+	"filtsz": [1,2,3,4,5,7],
 	"cmotsz": 400,
 	"dropout": 0.5,
         "gpus": 4,
@@ -23,7 +23,7 @@
 	"label": "glove-42B"
     },
     "train": {
-	"epochs": 60,
+	"epochs": 80,
 	"optim": "sgd",
 	"eta": 0.02,
 	"model_base": "./models/dbpedia",

--- a/python/mead/config/dbpedia.json
+++ b/python/mead/config/dbpedia.json
@@ -13,7 +13,7 @@
     "unif": 0.25,
     "model": {
 	"model_type": "default",
-	"filtsz": [2,3,4,5]
+	"filtsz": [2,3,4,5],
 	"cmotsz": 400,
 	"dropout": 0.5,
 	"finetune": true
@@ -22,7 +22,7 @@
 	"label": "glove-42B"
     },
     "train": {
-	"epochs": 25,
+	"epochs": 60,
 	"optim": "sgd",
 	"eta": 0.02,
 	"decay": 0.02,

--- a/python/mead/config/dbpedia.json
+++ b/python/mead/config/dbpedia.json
@@ -1,0 +1,34 @@
+{
+    "task": "classify",
+    "batchsz": 1024,
+    "preproc": {
+	"mxlen": 100,
+	"clean": true
+    },
+    "backend": "tensorflow",
+    "dataset": "dbpedia",
+    "loader": {
+	"reader_type": "default"
+    },
+    "unif": 0.25,
+    "model": {
+	"model_type": "default",
+	"filtsz": [2,3,4,5]
+	"cmotsz": 400,
+	"dropout": 0.5,
+	"finetune": true
+    },
+    "word_embeddings": {
+	"label": "glove-42B"
+    },
+    "train": {
+	"epochs": 25,
+	"optim": "sgd",
+	"eta": 0.02,
+	"decay": 0.02,
+        "gpus": 4,
+	"model_base": "./models/dbpedia",
+	"early_stopping_metric": "acc",
+        "verbose": true
+    }
+}

--- a/python/mead/config/dbpedia.json
+++ b/python/mead/config/dbpedia.json
@@ -26,7 +26,6 @@
 	"epochs": 60,
 	"optim": "sgd",
 	"eta": 0.02,
-	"decay": 0.02,
 	"model_base": "./models/dbpedia",
 	"early_stopping_metric": "acc",
         "verbose": true

--- a/python/mead/config/dbpedia.json
+++ b/python/mead/config/dbpedia.json
@@ -16,7 +16,6 @@
 	"filtsz": [1,2,3,4,5,7],
 	"cmotsz": 400,
 	"dropout": 0.5,
-        "gpus": 4,
 	"finetune": true
     },
     "word_embeddings": {

--- a/python/mead/config/dbpedia.json
+++ b/python/mead/config/dbpedia.json
@@ -16,6 +16,7 @@
 	"filtsz": [2,3,4,5],
 	"cmotsz": 400,
 	"dropout": 0.5,
+        "gpus": 4,
 	"finetune": true
     },
     "word_embeddings": {
@@ -26,7 +27,6 @@
 	"optim": "sgd",
 	"eta": 0.02,
 	"decay": 0.02,
-        "gpus": 4,
 	"model_base": "./models/dbpedia",
 	"early_stopping_metric": "acc",
         "verbose": true

--- a/python/mead/config/embeddings.json
+++ b/python/mead/config/embeddings.json
@@ -43,8 +43,7 @@
   },
   {
     "label": "w2v-gn",
-    "file": "https://s3.amazonaws.com/mordecai-geo/GoogleNews-vectors-negative300.bin.gz",
-    "sha1": "be9bfda5fdc3b3cc7376e652fc489350fe9ff863",
+    "file": "https://www.dropbox.com/s/699kgut7hdb5tg9/GoogleNews-vectors-negative300.bin.gz?dl=1",
     "dsz": 300
   },
   {

--- a/python/mead/trainer.py
+++ b/python/mead/trainer.py
@@ -12,9 +12,12 @@ def main():
     parser.add_argument('--embeddings', help='json library of embeddings', default='config/embeddings.json', type=convert_path)
     parser.add_argument('--logging', help='json file for logging', default='config/logging.json', type=convert_path)
     parser.add_argument('--task', help='task to run', choices=['classify', 'tagger', 'seq2seq', 'lm'])
+    parser.add_argument('--gpus', help='Number of GPUs (defaults to 1)', type=int)
     args = parser.parse_known_args()[0]
 
     config_params = read_config_file(args.config)
+    if args.gpus is not None:
+        config_params['model']['gpus'] = args.gpus
     task_name = config_params.get('task', 'classify') if args.task is None else args.task
     print('Task: [{}]'.format(task_name))
     task = mead.Task.get_task_specific(task_name, args.logging, args.settings)

--- a/python/seq2seq.py
+++ b/python/seq2seq.py
@@ -40,6 +40,7 @@ parser.add_argument('--reader_type', default='default', help='reader type')
 parser.add_argument('--model_type', help='Name of model to load and train', default='default')
 parser.add_argument('--trainer_type', help='Name of trainer to load and train', default='default')
 parser.add_argument('--arc_state', help='Create arc between encoder final state and decoder init state', default=False, type=str2bool)
+parser.add_argument('--gpus', help='GPUs', nargs='+', default=[], type=int)
 args = parser.parse_args()
 gpu = not args.nogpu
 
@@ -87,7 +88,9 @@ es = reader.load(args.test, embed1.vocab, embed2.vocab, args.batchsz)
 print('Finished loading datasets')
 rlut1 = revlut(embed1.vocab)
 rlut2 = revlut(embed2.vocab)
+
 model = seq2seq.create_model(embed1, embed2, **vars(args))
+
 # This code is framework specific
 if args.showex:
     args.after_train_fn = lambda model: show_ex_fn(model, es, rlut1, rlut2, embed2,

--- a/python/seq2seq.py
+++ b/python/seq2seq.py
@@ -40,7 +40,7 @@ parser.add_argument('--reader_type', default='default', help='reader type')
 parser.add_argument('--model_type', help='Name of model to load and train', default='default')
 parser.add_argument('--trainer_type', help='Name of trainer to load and train', default='default')
 parser.add_argument('--arc_state', help='Create arc between encoder final state and decoder init state', default=False, type=str2bool)
-parser.add_argument('--gpus', help='GPUs', nargs='+', default=[], type=int)
+parser.add_argument('--gpus', help='GPUs', type=int)
 args = parser.parse_args()
 gpu = not args.nogpu
 


### PR DESCRIPTION
- These can be run in the individual driver programs `seq2seq.py` and `classify_sentence.py` by passing `--gpus <num_gpus>`, or they can be run inside mead's `trainer.py` (`mead-train`) using `"gpus": <num_gpus>` in the mead config.

- The change allows the creator factory methods to check for presence of `gpus` in `kwargs` and, if found, it will construct a parallel wrapper class for this task.  The parallel wrapper will instantiate the graph one time per GPU, and once for inference (on CPU), and it construct the per-GPU graphs to have a `tf.split` operation on the front of the graph, which will operate on the placeholders in the parallel wrapper.

- Tested on driver programs for both mead and stand-alone task drivers