### PR TITLE
Batched CRF in pytorch

### DIFF
--- a/python/baseline/pytorch/torchy.py
+++ b/python/baseline/pytorch/torchy.py
@@ -564,7 +564,7 @@ class CRF(nn.Module):
             unary = unary.transpose(0, 1)
             tags = tags.transpose(0, 1)
         if self.add_ends:
-            unary = BatchedCRF._prep_input(unary)
+            unary = CRF._prep_input(unary)
         _, batch_size, _ = unary.size()
         min_lengths = torch.min(lengths)
         viterbi_score = self.forward(unary, lengths, batch_size, min_lengths)
@@ -654,7 +654,7 @@ class CRF(nn.Module):
         if self.batch_first:
             unary = unary.transpose(0, 1)
         if self.add_ends:
-            unary = BatchedCRF._prep_input(unary)
+            unary = CRF._prep_input(unary)
         seq_len, batch_size, _ = unary.size()
         min_length = torch.min(lengths)
         batch_range = torch.arange(batch_size, dtype=torch.int64)

--- a/python/baseline/pytorch/torchy.py
+++ b/python/baseline/pytorch/torchy.py
@@ -487,26 +487,22 @@ def crf_mask(vocab, span_type, s_idx, e_idx, pad_idx=None):
     np_mask = crf_m(vocab, span_type, s_idx, e_idx, pad_idx=pad_idx)
     return (torch.from_numpy(np_mask) == 0)
 
+
 class CRF(nn.Module):
-
-    def __init__(self, n_tags, idxs=None, vocab=None, span_type=None, pad_idx=None):
+    def __init__(self, n_tags, idxs=None, batch_first=True, vocab=None, span_type=None, pad_idx=None):
         """Initialize the object.
-
         :param n_tags: int The number of tags in your output (emission size)
         :param idxs: Tuple(int. int) The index of the start and stop symbol
             in emissions.
         :param vocab: The label vocab of the form vocab[string]: int
         :param span_type: The tagging span_type used. `IOB`, `IOB2`, or `IOBES`
         :param pds_idx: The index of the pad symbol in the vocab
-
         Note:
             if idxs is none then the CRF adds these symbols to the emission
             vectors and n_tags is assumed to be the number of output tags.
-
             if idxs is not none then the first element is assumed to be the
             start index and the second idx is assumed to be the end index. In
             this case n_tags is assumed to include the start and end symbols.
-
             if vocab is not None then a transition mask will be created that
             limits illegal transitions.
         """
@@ -530,11 +526,23 @@ class CRF(nn.Module):
                 vocab['<GO>'] = self.start_idx
                 vocab['<EOS>'] = self.end_idx
             self.span_type = span_type
-            self.register_buffer('mask', crf_mask(vocab, span_type, self.start_idx, self.end_idx, pad_idx))
+            self.register_buffer('mask', crf_mask(vocab, span_type, self.start_idx, self.end_idx, pad_idx).unsqueeze(0))
         else:
             self.mask = None
 
-        self.transitions_p = nn.Parameter(torch.Tensor(self.n_tags, self.n_tags).zero_())
+        self.transitions_p = nn.Parameter(torch.Tensor(1, self.n_tags, self.n_tags).zero_())
+        self.batch_first = batch_first
+
+    def extra_repr(self):
+        str_ = "n_tags=%d, batch_first=%s" % (self.n_tags, self.batch_first)
+        if self.mask is not None:
+            str_ += ", masked=True, span_type=%s" % self.span_type
+        return str_
+
+    @staticmethod
+    def _prep_input(input_):
+        ends = torch.Tensor(input_.size()[0], input_.size()[1], 2).fill_(-1e4).to(input_.device)
+        return torch.cat([input_, ends], dim=2)
 
     @property
     def transitions(self):
@@ -542,97 +550,159 @@ class CRF(nn.Module):
             return self.transitions_p.masked_fill(self.mask, -1e4)
         return self.transitions_p
 
-    def extra_repr(self):
-        str_ = "n_tags=%d" % self.n_tags
-        if self.mask is not None:
-            str_ += ", masked=True, span_type=%s" % self.span_type
-        return str_
+    def neg_log_loss(self, unary, tags, lengths):
+        """Neg Log Loss with a Batched CRF.
 
-    @staticmethod
-    def _prep_input(input_):
-        ends = torch.Tensor(input_.size()[0], 2).fill_(-1000.).to(input_.device)
-        return torch.cat([input_, ends], dim=1)
+        :param unary: torch.FloatTensor: [T, B, N] or [B, T, N]
+        :param tags: torch.LongTensor: [T, B] or [B, T]
+        :param lengths: torch.LongTensor: [B]
 
-    def neg_log_loss(self, unary, tags):
+        :return: torch.FloatTensor: [B]
+        """
+        # Convert from [B, T, N] -> [T, B, N]
+        if self.batch_first:
+            unary = unary.transpose(0, 1)
+            tags = tags.transpose(0, 1)
         if self.add_ends:
-            unary = CRF._prep_input(unary)
-        viterbi_score = self.forward(unary)
-        gold_score = self.score_sentence(unary, tags)
+            unary = BatchedCRF._prep_input(unary)
+        _, batch_size, _ = unary.size()
+        min_lengths = torch.min(lengths)
+        viterbi_score = self.forward(unary, lengths, batch_size, min_lengths)
+        gold_score = self.score_sentence(unary, tags, lengths, batch_size, min_lengths)
         return viterbi_score - gold_score
 
-    def score_sentence(self, unary, tags):
-        """"Get the score of a provided tag sequence."""
-        # Don't apply the mask each time use use self.transitions, save compute
-        transitions = self.transitions
-        score = torch.autograd.Variable(torch.Tensor([0]).cuda())
-        tags = torch.cat([torch.LongTensor([self.start_idx]).cuda(), tags])
-        for i, unary_t in enumerate(unary):
-            score = score + transitions[tags[i + 1], tags[i]] + unary_t[tags[i + 1]]
-        score = score + transitions[self.end_idx, tags[-1]]
-        return score
+    def score_sentence(self, unary, tags, lengths, batch_size, min_length):
+        """Score a batch of sentences.
 
-    def forward(self, unary):
-        """Vectorized forward algorithm for CRF layer
+        :param unary: torch.FloatTensor: [T, B, N]
+        :param tags: torch.LongTensor: [T, B]
+        :param lengths: torch.LongTensor: [B]
+        :param batzh_size: int: B
+        :param min_length: torch.LongTensor: []
 
-        :param unary: The observations
-        :param transitions: The transitions
-        :param start_idx: The index of the start position
-        :param end_idx: The index of the end position
-        :return: Alphas
+        :return: torch.FloatTensor: [B]
         """
-        # Do the forward algorithm to compute the partition function
-        init_alphas = torch.Tensor(1, self.n_tags).fill_(-1000.).to(unary.device)
-        # START_TAG has all of the score.
-        init_alphas[0][self.start_idx] = 0.
+        trans = self.transitions.squeeze(0)  # [N, N]
+        batch_range = torch.arange(batch_size, dtype=torch.int64)  # [B]
+        start = torch.full((1, batch_size), self.start_idx, dtype=tags.dtype, device=tags.device)  # [1, B]
+        tags = torch.cat([start, tags], 0)  # [T, B]
+        scores = torch.zeros(batch_size, requires_grad=True).to(unary.device)  # [B]
+        for i, unary_t in enumerate(unary):
+            new_scores = (
+                trans[tags[i + 1], tags[i]] +
+                unary_t[batch_range, tags[i + 1]]
+            )
+            if i >= min_length:
+                # If we are father along `T` than your length don't add to your score
+                mask = (i >= lengths)
+                scores = scores + new_scores.masked_fill(mask, 0)
+            else:
+                scores = scores + new_scores
+        # Add stop tag
+        scores = scores + trans[self.end_idx, tags[lengths, batch_range]]
+        return scores
 
-        # Wrap in a variable so that we will get automatic backprop
-        alphas = torch.autograd.Variable(init_alphas)
+    def forward(self, unary, lengths, batch_size, min_length):
+        """For CRF forward on a batch.
 
-        # Don't apply the mask each time use use self.transitions, save compute
-        transitions = self.transitions
+        :param unary: torch.FloatTensor: [T, B, N]
+        :param lengths: torch.LongTensor: [B]
+        :param batzh_size: int: B
+        :param min_length: torch.LongTensor: []
 
-        # Iterate through the sentence
-        for t, unary_t in enumerate(unary):
-            emit_scores_transpose = unary_t.view(-1, 1)
-            next_tag_var = alphas + emit_scores_transpose + transitions
-            scores = vec_log_sum_exp(next_tag_var, 1).transpose(0, 1)
-            alphas = scores
+        :return: torch.FloatTensor: [B]
+        """
+        # alphas: [B, 1, N]
+        alphas = torch.Tensor(batch_size, 1, self.n_tags).fill_(-1e4).to(unary.device)
+        alphas[:, 0, self.start_idx] = 0.
+        alphas.requires_grad = True
 
-        terminal_var = alphas + transitions[self.end_idx]
-        alpha = log_sum_exp(terminal_var)
-        return alpha
+        trans = self.transitions # [1, N, N]
 
-    def decode(self, unary):
+        for i, unary_t in enumerate(unary):
+            # unary_t: [B, N]
+            unary_t = unary_t.unsqueeze(2) # [B, N, 1]
+            # Broadcast alphas along the rows of trans
+            # Broadcast trans along the batch of alphas
+            # [B, 1, N] + [1, N, N] -> [B, N, N]
+            # Broadcast unary_t along the cols of result
+            # [B, N, N] + [B, N, 1] -> [B, N, N]
+            scores = alphas + trans + unary_t
+            new_alphas = vec_log_sum_exp(scores, 2).transpose(1, 2)
+            # If we haven't reached your length zero out old alpha and take new one.
+            # If we are past your length, zero out new_alpha and keep old one.
+
+            if i >= min_length:
+                mask = (i < lengths).view(-1, 1, 1)
+                alphas = alphas.masked_fill(mask, 0) + new_alphas.masked_fill(mask == 0, 0)
+            else:
+                alphas = new_alphas
+
+        terminal_vars = alphas + trans[:, self.end_idx]
+        alphas = vec_log_sum_exp(terminal_vars, 2)
+        return alphas.squeeze()
+
+    def decode(self, unary, lengths):
+        """Do Viterbi decode on a batch.
+
+        :param unary: torch.FloatTensor: [T, B, N] or [B, T, N]
+        :param lengths: torch.LongTensor: [B]
+
+        :return: List[torch.LongTensor]: [B] the paths
+        :return: torch.FloatTensor: [B] the path score
+        """
+        if self.batch_first:
+            unary = unary.transpose(0, 1)
         if self.add_ends:
-            unary = CRF._prep_input(unary)
+            unary = BatchedCRF._prep_input(unary)
+        seq_len, batch_size, _ = unary.size()
+        min_length = torch.min(lengths)
+        batch_range = torch.arange(batch_size, dtype=torch.int64)
         backpointers = []
-        # Don't apply the mask each time use use self.transitions, save compute
-        transitions = self.transitions
 
-        inits = torch.Tensor(1, self.n_tags).fill_(-10000.).cuda()
-        inits[0][self.start_idx] = 0
+        # alphas: [B, 1, N]
+        alphas = torch.Tensor(batch_size, 1, self.n_tags).fill_(-1e4).to(unary.device)
+        alphas[:, 0, self.start_idx] = 0
+        alphas.requires_grad = True
 
-        # alphas at step i holds the viterbi variables for step i-1
-        alphas = torch.autograd.Variable(inits)
+        trans = self.transitions # [1, N, N]
 
-        for unary_t in unary:
-            next_tag_var = alphas + transitions
-            viterbi, best_tag_ids = torch.max(next_tag_var, 1)
+        for i, unary_t in enumerate(unary):
+            # Broadcast alphas along the rows of trans and trans along the batch of alphas
+            next_tag_var = alphas + trans # [B, 1, N] + [1, N, N] -> [B, N, N]
+            viterbi, best_tag_ids = torch.max(next_tag_var, 2) # [B, N]
             backpointers.append(best_tag_ids.data)
-            alphas = (viterbi + unary_t).view(1, -1)
+            new_alphas = viterbi + unary_t # [B, N] + [B, N]
+            new_alphas.unsqueeze_(1) # Prep for next round
+            # If we haven't reached your length zero out old alpha and take new one.
+            # If we are past your length, zero out new_alpha and keep old one.
+            if i >= min_length:
+                mask = (i < lengths).view(-1, 1, 1)
+                alphas = alphas.masked_fill(mask, 0) + new_alphas.masked_fill(mask == 0, 0)
+            else:
+                alphas = new_alphas
 
-        # Transition to STOP_TAG
-        terminal_var = alphas + transitions[self.end_idx]
-        best_tag_id = argmax(terminal_var)
-        path_score = terminal_var[0][best_tag_id]
+        # Add end tag
+        terminal_var = alphas.squeeze(1) + trans[:, self.end_idx]
+        _, best_tag_id = torch.max(terminal_var, 1)
+        path_score = terminal_var[batch_range, best_tag_id] # Select best_tag from each batch
 
-        # Follow the back pointers to decode the best path.
         best_path = [best_tag_id]
-        for backpointers_t in reversed(backpointers):
-            best_tag_id = backpointers_t[best_tag_id]
+        # Flip lengths
+        rev_len = seq_len - lengths - 1
+        for i, backpointer_t in enumerate(reversed(backpointers)):
+            # Get new best tag candidate
+            new_best_tag_id = backpointer_t[batch_range, best_tag_id]
+            # We are going backwards now, if you passed your flipped length then you aren't in your real results yet
+            mask = (i > rev_len)
+            best_tag_id = best_tag_id.masked_fill(mask, 0) + new_best_tag_id.masked_fill(mask == 0, 0)
             best_path.append(best_tag_id)
-        # Pop off the start tag (we dont want to return that to the caller)
         start = best_path.pop()
-        assert start == self.start_idx
         best_path.reverse()
-        return torch.LongTensor(best_path), path_score
+        best_path = torch.stack(best_path)
+        # Return list of paths
+        paths = []
+        best_path = best_path.transpose(0, 1)
+        for path, length in zip(best_path, lengths):
+            paths.append(path[:length])
+        return paths, path_score.squeeze(0)

--- a/python/mead/config/conll-bio.json
+++ b/python/mead/config/conll-bio.json
@@ -23,7 +23,7 @@
         "rnntype": "blstm",
         "layers": 1,
         "crf_mask": true,
-	"crf": 1
+        "crf": 1
     },
 
     "word_embeddings": {

--- a/python/tests/test_crf_pytorch.py
+++ b/python/tests/test_crf_pytorch.py
@@ -27,7 +27,7 @@ def label_vocab():
 def crf(label_vocab):
     return CRF(
         len(label_vocab),
-        (label_vocab[S], label_vocab[E]),
+        (label_vocab[S], label_vocab[E]), True,
         label_vocab, SPAN_TYPE, label_vocab[P]
     )
 
@@ -49,7 +49,7 @@ def model(label_vocab, embeds):
 
 def test_mask_is_applied(label_vocab, crf):
     t = crf.transitions.detach().numpy()
-    assert t[label_vocab['<GO>'], label_vocab['O']] == -1e4
+    assert t[0, label_vocab['<GO>'], label_vocab['O']] == -1e4
 
 def test_mask_skipped(label_vocab):
     crf = CRF(
@@ -57,13 +57,13 @@ def test_mask_skipped(label_vocab):
         (label_vocab[S], label_vocab[E]),
     )
     t = crf.transitions.detach().numpy()
-    assert t[label_vocab['<GO>'], label_vocab['O']] != -1e4
+    assert t[0, label_vocab['<GO>'], label_vocab['O']] != -1e4
 
 def test_error_without_type(label_vocab):
     with pytest.raises(AssertionError):
         _ = CRF(
             len(label_vocab),
-            (label_vocab[S], label_vocab[E]),
+            (label_vocab[S], label_vocab[E]), True,
             label_vocab
         )
 
@@ -93,7 +93,7 @@ def test_error_without_type(label_vocab):
 
 def test_mask_used_in_model(label_vocab, model):
     t = model.crf.transitions.detach().numpy()
-    assert t[label_vocab['<GO>'], label_vocab['O']] == -1e4
+    assert t[0, label_vocab['<GO>'], label_vocab['O']] == -1e4
 
 def test_mask_not_used_in_model(label_vocab, embeds):
     model = create_model(
@@ -103,7 +103,7 @@ def test_mask_not_used_in_model(label_vocab, embeds):
         layers=2, rnntype="blstm"
     )
     t = model.crf.transitions.detach().numpy()
-    assert t[label_vocab['<GO>'], label_vocab['O']] != -1e4
+    assert t[0, label_vocab['<GO>'], label_vocab['O']] != -1e4
 
 def test_error_when_mask_and_no_span(label_vocab, embeds):
     with pytest.raises(AssertionError):


### PR DESCRIPTION
This is a batched version of a CRF in pytorch. When I was testing the CRF masks in pytorch each epoch was way too slow so I batched it.

```
Old Speed:
Train: 112.7518 ± 1.064
Dev:     4.4706 ± 0.023651

Batched Speed:
Train:   37.0712 ± 0.143
Dev:      2.1887 ± 0.009753
```

Tested by running examples through the old and the new CRF and making sure the values match. Also I tested changes to the tagger model by training a tagger with CRF and mask, with CRF and no mask, and no CRF. All models successfully trained.