### PR TITLE
Correct Glorot initialization for conv kernels

### DIFF
--- a/python/baseline/dy/dynety.py
+++ b/python/baseline/dy/dynety.py
@@ -228,7 +228,16 @@ def Convolution1d(fsz, cmotsz, dsz, pc, strides=(1, 1, 1, 1), name="conv"):
     :param strides: Tuple[int, int, int, int]
     """
     conv_pc = pc.add_subcollection(name=name)
-    weight = conv_pc.add_parameters((1, fsz, dsz, cmotsz), name='weight')
+    fan_in = dsz * fsz
+    fan_out = cmotsz * fsz
+    # Pytorch and Dynet have a gain param that has suggested values based on
+    # the nonlinearity type, this defaults to the one for relu atm.
+    glorot_bounds = 0.5 * np.sqrt(6 / (fan_in + fan_out))
+    weight = conv_pc.add_parameters(
+        (1, fsz, dsz, cmotsz),
+        init=dy.UniformInitializer(glorot_bounds),
+        name='weight'
+    )
     bias = conv_pc.add_parameters((cmotsz), name="bias")
 
     def conv(input_):

--- a/python/tests/test_dynety.py
+++ b/python/tests/test_dynety.py
@@ -247,6 +247,20 @@ def test_conv_output_shape_batched():
     output_ = conv(input_)
     assert output_.dim() == ((cmotsz,), batch_size)
 
+def test_conv_parameter_init_glorot():
+    dy.renew_cg()
+    pc = dy.ParameterCollection()
+    fsz = random.choice(FILTER_SIZES)
+    dsz = random.choice(SIZES)
+    cmotsz = random.choice(SIZES)
+    conv = Convolution1d(fsz, cmotsz, dsz, pc)
+    conv_weight = pc.parameters_list()[0]
+    gold = 0.5 * np.sqrt(6 / (fsz * dsz + fsz * cmotsz))
+    min_ = np.min(conv_weight.as_array())
+    max_ = np.max(conv_weight.as_array())
+    np.testing.assert_allclose(min_, -gold, atol=1e-5)
+    np.testing.assert_allclose(max_, gold, atol=1e-5)
+
 def test_embedded_dense_shape():
     dy.renew_cg()
     pc = dy.ParameterCollection()


### PR DESCRIPTION
While dynet defaults to using Glorot initialization it doesn't do it correctly for conv kernels (technically I don't think other frameworks do it correctly either) but this brings it in line with other frameworks.

With the old initialization dynet had parameters that ranged from +- 0.16 while pytorch parameters had a much smaller range of about +- 0.05

This hand calculates the bounds and just uses the uniform initializer.