### PR TITLE
Refactor the way we use RNN's in dynet

### DIFF
--- a/python/mead/tasks.py
+++ b/python/mead/tasks.py
@@ -309,7 +309,6 @@ class TaggerTask(Task):
             dy_params = _dynet.DynetParams()
             dy_params.from_args()
             dy_params.set_requested_gpus(1)
-            dy_params.set_requested_gpus(1)
             if 'autobatchsz' in self.config_params['train']:
                 self.config_params['model']['batched'] = False
                 dy_params.set_autobatch(True)


### PR DESCRIPTION
This is a change on the way I think we should handle RNNs in Dynet. While the closure format is really good for simple layers like Linear and Conv I don't think it scales well for RNN due to the many ways you can/might want to run them forward. Plus there are times where you want to do different things depending on if it is train or test time and the current set up would require different closures for LSTM, GRU, etc.

Dynet already offers a pretty good RNN abstraction with the RNNBuilder and RNNState objects. This PR add various functions that run different forwards. These functions take and RNN and inputs and various other things like length and initial state.

I tested classification LSTM/blstm, convchar and word LMs, the tagger and seq2seq by training them. They all trained correctly and seemed to be learning