### PR TITLE
Don't break the mro chain.

### DIFF
--- a/python/baseline/dy/classify/model.py
+++ b/python/baseline/dy/classify/model.py
@@ -8,7 +8,7 @@ from baseline.utils import listify
 from baseline.dy.dynety import *
 
 
-class WordClassifierBase(DynetModel, Classifier):
+class WordClassifierBase(Classifier, DynetModel):
 
     def __init__(
             self,

--- a/python/baseline/dy/lm/model.py
+++ b/python/baseline/dy/lm/model.py
@@ -2,7 +2,7 @@ from baseline.model import create_lang_model, LanguageModel
 from baseline.dy.dynety import *
 
 
-class BaseLanguageModel(DynetModel, LanguageModel):
+class BaseLanguageModel(LanguageModel, DynetModel):
     def __init__(self):
         super(BaseLanguageModel, self).__init__()
 

--- a/python/baseline/model.py
+++ b/python/baseline/model.py
@@ -22,7 +22,7 @@ class Classifier(object):
     Provide an interface to DNN classifiers that use word lookup tables.
     """
     def __init__(self):
-        pass
+        super(Classifier, self).__init__()
 
     def save(self, basename):
         """Save this model out
@@ -187,7 +187,7 @@ class Tagger(object):
     type of chunking (e.g. NER, POS chunks, slot-filling)
     """
     def __init__(self):
-        pass
+        super(Tagger, self).__init__()
 
     def save(self, basename):
         pass
@@ -244,7 +244,7 @@ class Tagger(object):
 class LanguageModel(object):
 
     def __init__(self):
-        pass
+        super(LanguageModel, self).__init__()
 
     def step(self, batch_time, context):
         pass
@@ -257,7 +257,7 @@ class EncoderDecoder(object):
         pass
 
     def __init__(self):
-        pass
+        super(EncoderDecoder, self).__init__()
 
     @staticmethod
     def create(src_vocab, dst_vocab, **kwargs):


### PR DESCRIPTION
The `__init__` for the base classes of the models didn't call `super`. This breaks the Method Order Resolution chain for constructors. This means that in the case of multiple inheritance later objects `__init__`s were never called. 