### PR TITLE
Xpctl tasksummary

### DIFF
--- a/docs/xpctl.md
+++ b/docs/xpctl.md
@@ -50,6 +50,8 @@ xpctl >
 
 #### Commands
 
+Details about any command can be found by `xpctl <command name> --help` on the terminal or `help <command-name>` inside the `xpctl` repl.
+ 
 ##### Set up and general info
 
 - **vars**:   Prints the value of system variables. 
@@ -61,7 +63,11 @@ xpctl >
 
 ##### Analysis
 
-- **results**: Provides a statistical summary of the results for a problem. A problem is defined by a (task, dataset) tuple. For each config used in the task, shows the average, min, max and std dev and number of experiments done using config. Optionally: 
+- **results**: Provides a statistical summary of the results for a problem. A problem is defined by a (task, dataset) tuple. For each config used in the task, shows the average, min, max and std dev and number of experiments done using config.
+ 
+  Usage: `results [OPTIONS] TASK DATASET`
+
+  Optionally: 
   - `--metrics`: choose metric(s) to show. results ll be sorted on the first metric. 
   - `--sort`: output all metrics but sort on one. 
   - `--n`: shows the last _n_ experimental results (per config). 
@@ -143,11 +149,52 @@ xpctl > results classify SST2 --metric f1 --metric acc --sort f1 --n 1
 ```
 
 - **details**: Shows the results for all experiments for a particular config (sha1). Optionally filter out by user(s), metric(s), or sort by one metric. Shows the results on the test data by default, provide event_type (train/valid/test) to see for other datasets. Optimally limit the number of results shown. 
+
+  Usage: `details [OPTIONS] TASK SHA1`
+  
+  Optionally: 
   - `--metrics`: choose metric(s) to filter the results on. results ll be sorted on the first metric. 
   - `--sort`: output all metrics but sort on one. 
   - `--n`: shows the last (by time) _n_ experimental results. 
   - `--event_type`: show results for train/dev/test datasets. defaults to _test_. 
 
+```
+xpctl > results tagger conll-iobes
+db mongo connection successful with [host]: research.digitalroots.com, [port]: 27017
+db mongo connection successful with [host]: research.digitalroots.com, [port]: 27017
+                                              acc                                               f1                                        
+                                         num_exps      mean       std       min       max num_exps      mean       std       min       max
+sha1                                                                                                                                      
+33aee90cc68beb1649bafc14015aa3827f159776      4.0  0.979112  0.000581  0.978292  0.979556      4.0  0.910722  0.001481  0.909091  0.912517
+5d482cd9cd5d3b03d115d6da848131f38bc6e529      1.0  0.979471       NaN  0.979471  0.979471      1.0  0.912186       NaN  0.912186  0.912186
+6edbdaa261620facab48c639385b513ae2feb868      1.0  0.979771       NaN  0.979771  0.979771      1.0  0.911538       NaN  0.911538  0.911538
+7f85e5c982491bf401b5fa83614ba4b0f94fe373      3.0  0.978571  0.000119  0.978464  0.978699      3.0  0.905433  0.001328  0.904122  0.906777
+89c8238a4154bb1cd652dfde7e687919a9317b68      3.0  0.979606  0.000527  0.978999  0.979942      3.0  0.910762  0.002732  0.907820  0.913220
+d96a35d18d6d68242a5bda05ff14938ce5c81269      1.0  0.981378       NaN  0.981378  0.981378      1.0  0.919784       NaN  0.919784  0.919784
+xpctl > details tagger 33aee90cc68beb1649bafc14015aa3827f159776
+db mongo connection successful with [host]: research.digitalroots.com, [port]: 27017
+db mongo connection successful with [host]: research.digitalroots.com, [port]: 27017
+                          id  username           label      dataset                                      sha1                       date       acc        f1
+44  5b2cdc2af5ed250de2b5dc45  dpressel  conll-iobes-tf  conll-iobes  33aee90cc68beb1649bafc14015aa3827f159776 2018-06-22 11:23:22.497571  0.978292  0.910056
+45  5b2cdc35f5ed250e6bd54c13  dpressel  conll-iobes-tf  conll-iobes  33aee90cc68beb1649bafc14015aa3827f159776 2018-06-22 11:23:33.690791  0.979492  0.912517
+46  5b2d0159f5ed2557e3db8859  dpressel  conll-iobes-tf  conll-iobes  33aee90cc68beb1649bafc14015aa3827f159776 2018-06-22 14:02:01.587844  0.979106  0.909091
+47  5b2d0169f5ed255b01e6da8c  dpressel  conll-iobes-tf  conll-iobes  33aee90cc68beb1649bafc14015aa3827f159776 2018-06-22 14:02:17.444505  0.979556  0.911225
+xpctl > details tagger 33aee90cc68beb1649bafc14015aa3827f159776 --sort f1
+db mongo connection successful with [host]: research.digitalroots.com, [port]: 27017
+db mongo connection successful with [host]: research.digitalroots.com, [port]: 27017
+                          id  username           label      dataset                                      sha1                       date       acc        f1
+45  5b2cdc35f5ed250e6bd54c13  dpressel  conll-iobes-tf  conll-iobes  33aee90cc68beb1649bafc14015aa3827f159776 2018-06-22 11:23:33.690791  0.979492  0.912517
+47  5b2d0169f5ed255b01e6da8c  dpressel  conll-iobes-tf  conll-iobes  33aee90cc68beb1649bafc14015aa3827f159776 2018-06-22 14:02:17.444505  0.979556  0.911225
+44  5b2cdc2af5ed250de2b5dc45  dpressel  conll-iobes-tf  conll-iobes  33aee90cc68beb1649bafc14015aa3827f159776 2018-06-22 11:23:22.497571  0.978292  0.910056
+46  5b2d0159f5ed2557e3db8859  dpressel  conll-iobes-tf  conll-iobes  33aee90cc68beb1649bafc14015aa3827f159776 2018-06-22 14:02:01.587844  0.979106  0.909091
+xpctl > details tagger 33aee90cc68beb1649bafc14015aa3827f159776 --sort f1 --n 2
+db mongo connection successful with [host]: research.digitalroots.com, [port]: 27017
+db mongo connection successful with [host]: research.digitalroots.com, [port]: 27017
+                          id  username           label      dataset                                      sha1                       date       acc        f1
+47  5b2d0169f5ed255b01e6da8c  dpressel  conll-iobes-tf  conll-iobes  33aee90cc68beb1649bafc14015aa3827f159776 2018-06-22 14:02:17.444505  0.979556  0.911225
+46  5b2d0159f5ed2557e3db8859  dpressel  conll-iobes-tf  conll-iobes  33aee90cc68beb1649bafc14015aa3827f159776 2018-06-22 14:02:01.587844  0.979106  0.909091
+xpctl > 
+```
 #### Updating the database
 
 - **updatelabel**: update the label for an experiment.

--- a/docs/xpctl.md
+++ b/docs/xpctl.md
@@ -32,7 +32,7 @@ In the `python` dir, run `./install_dev.sh xpctl`. Before installation, you can 
 
 ```
 
-_dbhost_ is typically `localhost` and _dbport_ is `27017`. Here `<username>`, `<password>` and `<dbhost>` should be passed as string. 
+_dbhost_ is typically `localhost` and _dbport_ is `y`. Here `<username>`, `<password>` and `<dbhost>` should be passed as string. 
 
 If you use [docker](docker.md), `xpctl` will be automatically installed.
  
@@ -41,7 +41,7 @@ If you use [docker](docker.md), `xpctl` will be automatically installed.
 **Starting**: use `--host`,`--port`,`--user` and `password` to specify the host, port, username and password for mongodb. Else, you can pass a config file with the option `--config`. `xpctl` assumes that the config file is located at `~/xpctlcred.json` (in which case you can just use the command `xpctl` w/o specifying any option) but it can be saved anywhere you want.
 ```
 (dl) home:home$ xpctl --host localhost
-setting dbhost to localhost dbport to 27017
+setting dbhost to localhost dbport to y
 db connection successful
 Starting xpctl...
 xpctl > 
@@ -55,7 +55,7 @@ xpctl >
 - **vars**:   Prints the value of system variables dbhost and dbport. 
 ```
 xpctl > vars
-dbhost: xxx.yyy.com, dbport: 27017
+dbhost: xxx.yyy.com, dbport: y
 xpctl >
 ```
 
@@ -95,7 +95,7 @@ xpctl > results classify test SST2 --metric acc
 
 ```
 (xpt2.7) testuser:~$ xpctl results tagger test wnut --metric f1 --metric acc --sort acc
-db connection successful with [host]: x.y.com, [port]: 27017
+db connection successful with [host]: x.y.com, [port]: y
                           id      username                                      label dataset                                      sha1                    date       acc        f1
 4   5a1611c038d2dd7832f7c47c    testuser                      bilstm-CRF-filt-1-2-3    wnut  39831513cb319984c9410a2c7da9429ec0bc745d 2017-11-23 00:09:33.455  0.939854  0.391667
 8   5a02665d6232a6030a275fc3          root     wnut-lowercased-gazetteer-5proj-unif-0    wnut  4073e6dff65340d954af3e66d36a6d144fca5825 2017-11-08 02:05:17.009  0.939287  0.386049
@@ -103,7 +103,7 @@ db connection successful with [host]: x.y.com, [port]: 27017
 
 ```
 (xpt2.7) testuser:~$ xpctl results tagger test wnut --metric f1 --metric acc --sort f1
-db connection successful with [host]: x.y.com, [port]: 27017
+db connection successful with [host]: x.y.com, [port]: y
                           id      username                                      label dataset                                      sha1                    date       acc        f1
 10  5a05f17c6232a638b53903b0  testuser             wnut-gazetteer-noproj-unif-0.1    wnut  ab7b1fed1f0206ad9ebf3887657f18051d99f643 2017-11-10 18:35:40.741  0.936957  0.402537
 6   5a0140636232a60282e0cb8d          root  wnut-lowercased-gazetteer-noproj-unif-0.1    wnut  231c11c31fa8389a192da9e84a1c19d7ada46613 2017-11-07 05:10:59.629  0.938211  0.395871
@@ -112,7 +112,7 @@ db connection successful with [host]: x.y.com, [port]: 27017
 
 ```
 (xpt2.7) testuser:~$ xpctl results tagger test wnut --metric f1
-db connection successful with [host]: x.y.com, [port]: 27017
+db connection successful with [host]: x.y.com, [port]: y
                           id      username                                      label dataset                                      sha1                    date        f1
 10  5a05f17c6232a638b53903b0  testuser             wnut-gazetteer-noproj-unif-0.1    wnut  ab7b1fed1f0206ad9ebf3887657f18051d99f643 2017-11-10 18:35:40.741  0.402537
 6   5a0140636232a60282e0cb8d          root  wnut-lowercased-gazetteer-noproj-unif-0.1    wnut  231c11c31fa8389a192da9e84a1c19d7ada46613 2017-11-07 05:10:59.629  0.395871
@@ -159,7 +159,7 @@ Options:
 
 - **delete**: deletes a record from the database and the associated model file from model-checkpoints if it exists.
 ```
-setting dbhost to xxx.yyy.com dbport to 27017
+setting dbhost to xxx.yyy.com dbport to y
 db connection successful
 Usage: xpctl delete [OPTIONS] TASK ID
   delete a record from database with the given object id. also delete the
@@ -191,8 +191,8 @@ Options:
 ```
 xpctl > putresult --user ijindal classify /home/ijindal/dev/work/baseline/python/mead/config/sst2.json /home/ijindal/dev/work/baseline/python/mead/reporting-4923.log  testClassify
 
-db mongo connection successful with [host]: research.digitalroots.com, [port]: 27017
-updating results for existing task [classify] in host [research.digitalroots.com]
+db mongo connection successful with [host]: x.x.x, [port]: y
+updating results for existing task [classify] in host [x.x.x]
 results updated, the new results are stored with the record id: 5b1aacb933ed5901dc545af8
 
 ```
@@ -215,7 +215,7 @@ Options:
 ```
  xpctl > putmodel classify 5b1aacb933ed5901dc545af8 /home/ijindal/dev/work/baseline/python/mead/classify-model-tf-4923/classify-model-tf-4923
 
- db mongo connection successful with [host]: research.digitalroots.com, [port]: 27017
+ db mongo connection successful with [host]: x.x.x, [port]: y
 writing model file: [/home/ijindal/dev/work/baseline/python/mead/classify-model-tf-4923/classify-model-tf-4923.saver] to store: [/data/model-checkpoints/67105e2108885c5ee08e211537fbda602f2ba254/1]
 writing model file: [/home/ijindal/dev/work/baseline/python/mead/classify-model-tf-4923/classify-model-tf-4923.model.index] to store: [/data/model-checkpoints/67105e2108885c5ee08e211537fbda602f2ba254/1]
 writing model file: [/home/ijindal/dev/work/baseline/python/mead/classify-model-tf-4923/classify-model-tf-4923.graph] to store: [/data/model-checkpoints/67105e2108885c5ee08e211537fbda602f2ba254/1]
@@ -242,8 +242,8 @@ Options:
 ```
 xpctl > getmodelloc classify 5b1aacb933ed5901dc545af8
 
-db mongo connection successful with [host]: research.digitalroots.com, [port]: 27017
-db mongo connection successful with [host]: research.digitalroots.com, [port]: 27017
+db mongo connection successful with [host]: x.x.x, [port]: y
+db mongo connection successful with [host]: x.x.x, [port]: y
 model loc is /data/model-checkpoints/67105e2108885c5ee08e211537fbda602f2ba254/1.zip
 
 ```
@@ -262,26 +262,107 @@ Here `sha1` is the model-checkpoint id.
 ```
 xpctl > config2json classify 67105e2108885c5ee08e211537fbda602f2ba254 /home/ijindal/dev/work/baseline/python/mead/c_SST2.json
 
-db mongo connection successful with [host]: research.digitalroots.com, [port]: 27017
-db mongo connection successful with [host]: research.digitalroots.com, [port]: 27017
+db mongo connection successful with [host]: x.x.x, [port]: y
+db mongo connection successful with [host]: x.x.x, [port]: y
 
 ```
 
 ##### Summary
 
-- **tasksummary**: provides a natural language summary for a task. 
+- **xpsummary**: Provides a statistical summary for an experiment. An experiment is defined by a (task, dataset, config) triple.
+
+```
+xpctl > help xpsummary
+Usage: xpsummary [OPTIONS] TASK DATASET SHA1
+
+  Provides a statistical summary for an experiment. An experiment is defined
+  by a (task, dataset, config) triple. Shows the average, min, max and std
+  dev for an experiment performed multiple times using the same config. Optionally provide event_type, i.e., train/ dev/ test. 
+
+Options:
+  --metric TEXT      list of metrics (prec, recall, f1, accuracy),[multiple]:
+                     --metric f1 --metric acc
+  --event_type TEXT  train/ dev/ test
+  --help             Show this message and exit.
+xpctl > 
+```
+```
+xpctl > xpsummary tagger conll 0d5627bfed6cd0435d362332935db8fad98dda39
+db mongo connection successful with [host]: x.x.x, [port]: y
+db mongo connection successful with [host]: x.x.x, [port]: y
+                                               f1                                              acc                                        
+                                         num_exps      mean       std       min       max num_exps      mean       std       min       max
+sha1                                                                                                                                      
+0d5627bfed6cd0435d362332935db8fad98dda39      2.0  0.905886  0.003213  0.903613  0.908158      2.0  0.980906  0.000636  0.980456  0.981356
+xpctl > xpsummary tagger conll 0d5627bfed6cd0435d362332935db8fad98dda39 --metric f1
+db mongo connection successful with [host]: x.x.x, [port]: y
+db mongo connection successful with [host]: x.x.x, [port]: y
+                                               f1                                        
+                                         num_exps      mean       std       min       max
+sha1                                                                                     
+0d5627bfed6cd0435d362332935db8fad98dda39      2.0  0.905886  0.003213  0.903613  0.908158
+xpctl > xpsummary tagger conll 0d5627bfed6cd0435d362332935db8fad98dda39 --event_type train
+db mongo connection successful with [host]: x.x.x, [port]: y
+db mongo connection successful with [host]: x.x.x, [port]: y
+                                         avg_loss                                        
+                                         num_exps      mean       std       min       max
+sha1                                                                                     
+0d5627bfed6cd0435d362332935db8fad98dda39    200.0  0.182984  0.311575  0.029169  2.681302
+xpctl > 
+```
+- **tasksummary**: Provides a statistical summary for a problem . A problem is defined by a (task, dataset) tuple.
 ```
 xpctl > help tasksummary
-Usage: tasksummary [OPTIONS] TASK DATASET METRIC
-  Provides a natural language summary for a task. This is almost equivalent
-  to the `best` command.
+Usage: tasksummary [OPTIONS] TASK DATASET
+
+  Provides a statistical summary for a problem . An problem is defined by a
+  (task, dataset) tuple. For each config used in the task, shows the
+  average, min, max and std dev and number of experiments done using the
+  config. Optionally: a. --metrics: choose metric(s) to show. results ll be
+  sorted on the first metric. b. --sort output all metrics but sort on one.
+
 Options:
-  --help  Show this message and exit.
+  --metric TEXT      list of metrics (prec, recall, f1, accuracy),[multiple]:
+                     --metric f1 --metric acc
+  --event_type TEXT  train/ dev/ test
+  --sort TEXT        specify one metric to sort the results
+  --help             Show this message and exit.
+xpctl > 
+
 ```
 
 ```
-xpctl > tasksummary classify sa180k macro_f1
-For dataset sa180k, the best f1 is 0.718 reported by root on 2017-09-08 17:24:32.963000. The sha1 for the config file is 6dac0ea88618ab67d6f5d690279c13f1ec305167.
+xpctl > tasksummary tagger conll 
+db mongo connection successful with [host]: x.x.x, [port]: y
+db mongo connection successful with [host]: x.x.x, [port]: y
+                                               f1                                              acc                                        
+                                         num_exps      mean       std       min       max num_exps      mean       std       min       max
+sha1                                                                                                                                      
+0a1dbc8cfa7eef3763c4246b57de75aada1e5d81      1.0  0.908834       NaN  0.908834  0.908834      1.0  0.980864       NaN  0.980864  0.980864
+0d5627bfed6cd0435d362332935db8fad98dda39      2.0  0.905886  0.003213  0.903613  0.908158      2.0  0.980906  0.000636  0.980456  0.981356
+56834f7ec17423f600f99ce446b0b2e5f1a186ab      1.0  0.900045       NaN  0.900045  0.900045      1.0  0.980104       NaN  0.980104  0.980104
+b42634a6a40cb08a257294ee1dfd47b3ac6d7f2f      1.0  0.825529       NaN  0.825529  0.825529      1.0  0.972304       NaN  0.972304  0.972304
+xpctl > tasksummary tagger conll --sort f1
+db mongo connection successful with [host]: x.x.x, [port]: y
+db mongo connection successful with [host]: x.x.x, [port]: y
+                                               f1                                              acc                                        
+                                         num_exps      mean       std       min       max num_exps      mean       std       min       max
+sha1                                                                                                                                      
+0a1dbc8cfa7eef3763c4246b57de75aada1e5d81      1.0  0.908834       NaN  0.908834  0.908834      1.0  0.980864       NaN  0.980864  0.980864
+0d5627bfed6cd0435d362332935db8fad98dda39      2.0  0.905886  0.003213  0.903613  0.908158      2.0  0.980906  0.000636  0.980456  0.981356
+56834f7ec17423f600f99ce446b0b2e5f1a186ab      1.0  0.900045       NaN  0.900045  0.900045      1.0  0.980104       NaN  0.980104  0.980104
+b42634a6a40cb08a257294ee1dfd47b3ac6d7f2f      1.0  0.825529       NaN  0.825529  0.825529      1.0  0.972304       NaN  0.972304  0.972304
+xpctl > tasksummary tagger conll --metric f1
+db mongo connection successful with [host]: x.x.x, [port]: y
+db mongo connection successful with [host]: x.x.x, [port]: y
+                                               f1                                        
+                                         num_exps      mean       std       min       max
+sha1                                                                                     
+0a1dbc8cfa7eef3763c4246b57de75aada1e5d81      1.0  0.908834       NaN  0.908834  0.908834
+0d5627bfed6cd0435d362332935db8fad98dda39      2.0  0.905886  0.003213  0.903613  0.908158
+56834f7ec17423f600f99ce446b0b2e5f1a186ab      1.0  0.900045       NaN  0.900045  0.900045
+b42634a6a40cb08a257294ee1dfd47b3ac6d7f2f      1.0  0.825529       NaN  0.825529  0.825529
+xpctl > 
 ```
 
 - **lbsummary**: provides a description of all tasks in the leaderboard. 
@@ -331,14 +412,14 @@ _ sometime later _ :
 
 ```
 (dl) testuser:xpctl$ xpctl best tagger test <test-dataset> f1
-setting dbhost to localhost dbport to 27017
+setting dbhost to localhost dbport to y
 db connection successful
 using metric: ['f1']
 total 2 results found, showing best 1 results
                          id    username label dataset                                      sha1                    date        f1
 1  59b9af747412df155562438d  testuser  test     <test-dataset>  7fbbd90b57395b003ab8476b6a17e747f8dfcba3 2017-09-13 22:21:35.322  0.860052
 (dl) testuser:xpctl$ xpctl putmodel --help
-setting dbhost to localhost dbport to 27017
+setting dbhost to localhost dbport to y
 db connection successful
 Usage: xpctl putmodel [OPTIONS] TASK ID CBASE
 
@@ -351,7 +432,7 @@ Options:
   --cstore TEXT  location of the model checkpoint store
   --help         Show this message and exit.
 (dl) testuser:xpctl$ xpctl getmodelloc --help
-setting dbhost to localhost dbport to 27017
+setting dbhost to localhost dbport to y
 db connection successful
 Usage: xpctl getmodelloc [OPTIONS] TASK ID
 
@@ -361,7 +442,7 @@ Options:
   --help  Show this message and exit.
 
 (dl) testuser:xpctl$ xpctl getmodelloc tagger 59b9af747412df155562438d
-setting dbhost to localhost dbport to 27017
+setting dbhost to localhost dbport to y
 db connection successful
 ['model storage loc for record id 59b9af747412df155562438d is /data/model-checkpoints/7fbbd90b57395b003ab8476b6a17e747f8dfcba3/1.zip']
 

--- a/docs/xpctl.md
+++ b/docs/xpctl.md
@@ -160,8 +160,8 @@ xpctl > results classify SST2 --metric f1 --metric acc --sort f1 --n 1
 
 ```
 xpctl > results tagger conll-iobes
-db mongo connection successful with [host]: research.digitalroots.com, [port]: 27017
-db mongo connection successful with [host]: research.digitalroots.com, [port]: 27017
+db mongo connection successful with [host]: x.x.x, [port]: num_port
+db mongo connection successful with [host]: x.x.x, [port]: num_port
                                               acc                                               f1                                        
                                          num_exps      mean       std       min       max num_exps      mean       std       min       max
 sha1                                                                                                                                      
@@ -172,24 +172,24 @@ sha1
 89c8238a4154bb1cd652dfde7e687919a9317b68      3.0  0.979606  0.000527  0.978999  0.979942      3.0  0.910762  0.002732  0.907820  0.913220
 d96a35d18d6d68242a5bda05ff14938ce5c81269      1.0  0.981378       NaN  0.981378  0.981378      1.0  0.919784       NaN  0.919784  0.919784
 xpctl > details tagger 33aee90cc68beb1649bafc14015aa3827f159776
-db mongo connection successful with [host]: research.digitalroots.com, [port]: 27017
-db mongo connection successful with [host]: research.digitalroots.com, [port]: 27017
+db mongo connection successful with [host]: x.x.x, [port]: num_port
+db mongo connection successful with [host]: x.x.x, [port]: num_port
                           id  username           label      dataset                                      sha1                       date       acc        f1
 44  5b2cdc2af5ed250de2b5dc45  dpressel  conll-iobes-tf  conll-iobes  33aee90cc68beb1649bafc14015aa3827f159776 2018-06-22 11:23:22.497571  0.978292  0.910056
 45  5b2cdc35f5ed250e6bd54c13  dpressel  conll-iobes-tf  conll-iobes  33aee90cc68beb1649bafc14015aa3827f159776 2018-06-22 11:23:33.690791  0.979492  0.912517
 46  5b2d0159f5ed2557e3db8859  dpressel  conll-iobes-tf  conll-iobes  33aee90cc68beb1649bafc14015aa3827f159776 2018-06-22 14:02:01.587844  0.979106  0.909091
 47  5b2d0169f5ed255b01e6da8c  dpressel  conll-iobes-tf  conll-iobes  33aee90cc68beb1649bafc14015aa3827f159776 2018-06-22 14:02:17.444505  0.979556  0.911225
 xpctl > details tagger 33aee90cc68beb1649bafc14015aa3827f159776 --sort f1
-db mongo connection successful with [host]: research.digitalroots.com, [port]: 27017
-db mongo connection successful with [host]: research.digitalroots.com, [port]: 27017
+db mongo connection successful with [host]: x.x.x, [port]: num_port
+db mongo connection successful with [host]: x.x.x, [port]: num_port
                           id  username           label      dataset                                      sha1                       date       acc        f1
 45  5b2cdc35f5ed250e6bd54c13  dpressel  conll-iobes-tf  conll-iobes  33aee90cc68beb1649bafc14015aa3827f159776 2018-06-22 11:23:33.690791  0.979492  0.912517
 47  5b2d0169f5ed255b01e6da8c  dpressel  conll-iobes-tf  conll-iobes  33aee90cc68beb1649bafc14015aa3827f159776 2018-06-22 14:02:17.444505  0.979556  0.911225
 44  5b2cdc2af5ed250de2b5dc45  dpressel  conll-iobes-tf  conll-iobes  33aee90cc68beb1649bafc14015aa3827f159776 2018-06-22 11:23:22.497571  0.978292  0.910056
 46  5b2d0159f5ed2557e3db8859  dpressel  conll-iobes-tf  conll-iobes  33aee90cc68beb1649bafc14015aa3827f159776 2018-06-22 14:02:01.587844  0.979106  0.909091
 xpctl > details tagger 33aee90cc68beb1649bafc14015aa3827f159776 --sort f1 --n 2
-db mongo connection successful with [host]: research.digitalroots.com, [port]: 27017
-db mongo connection successful with [host]: research.digitalroots.com, [port]: 27017
+db mongo connection successful with [host]: x.x.x, [port]: num_port
+db mongo connection successful with [host]: x.x.x, [port]: num_port
                           id  username           label      dataset                                      sha1                       date       acc        f1
 47  5b2d0169f5ed255b01e6da8c  dpressel  conll-iobes-tf  conll-iobes  33aee90cc68beb1649bafc14015aa3827f159776 2018-06-22 14:02:17.444505  0.979556  0.911225
 46  5b2d0159f5ed2557e3db8859  dpressel  conll-iobes-tf  conll-iobes  33aee90cc68beb1649bafc14015aa3827f159776 2018-06-22 14:02:01.587844  0.979106  0.909091

--- a/python/mead/config/conll-iobes.json
+++ b/python/mead/config/conll-iobes.json
@@ -30,7 +30,7 @@
         "label": "glove-6B-100"
     },
     "train": {
-        "epochs": 100,
+        "epochs": 2,
         "optim": "sgd",
         "decay": 0.05,
         "eta": 0.015,

--- a/python/mead/config/conll-iobes.json
+++ b/python/mead/config/conll-iobes.json
@@ -30,7 +30,7 @@
         "label": "glove-6B-100"
     },
     "train": {
-        "epochs": 2,
+        "epochs": 100,
         "optim": "sgd",
         "decay": 0.05,
         "eta": 0.015,

--- a/python/xpctl/cli.py
+++ b/python/xpctl/cli.py
@@ -125,7 +125,7 @@ def vars():
 @click.argument('task')
 @click.argument('id')
 def getmodelloc(task, id):
-    """get the model location for a particular task and record id"""
+    """Get the model location for a particular task and record id"""
     if not RepoManager.get().has_task(task):
         click.echo("no results for the specified task {}, use another task".format(task))
         return
@@ -145,15 +145,12 @@ def getmodelloc(task, id):
 @click.option('--event_type', default='test', help="train/ dev/ test")
 @click.option('--sort', help="specify one metric to sort the results")
 @click.option('--output', help='output file')
-@click.option('--n', help='number of experiments to aggregate')
+@click.option('--n', help='number of experiments to aggregate', type=int)
 @click.argument('task')
 @click.argument('dataset')
 def results(metric, event_type, sort, output, n, task, dataset):
     """
-    Provides a statistical summary for a problem . An problem is defined by a (task, dataset) tuple.
-    For each config used in the task, shows the average, min, max and std dev and number of experiments done using the
-    config. Optionally: a. --metrics: choose metric(s) to show. results ll be sorted on the first metric.
-    b. --sort output all metrics but sort on one.
+    Provides a statistical summary of the results for a problem . A problem is defined by a (task, dataset) tuple. For each config used in the task, shows the average, min, max and std dev and number of experiments done using config. Optionally: a. --metrics: choose metric(s) to show. results ll be sorted on the first metric. b. --sort output all metrics but sort on one. c. --n: limit number of experiments. d. event_type: show results for train/dev/valid datasets. e. output: put the results in an output file.
     """
     if not RepoManager.get().has_task(task):
         click.echo("no results for the specified task {}, use another task".format(task))
@@ -166,7 +163,7 @@ def results(metric, event_type, sort, output, n, task, dataset):
         return
     click.echo(results)
     if output is not None:
-        results.to_csv(output, index=True, index_label="experiment-id")
+        results.to_csv(os.path.expanduser(output), index=True, index_label="config-sha1")
 
 
 
@@ -179,8 +176,7 @@ def lbsummary(task):
     a taskname, it will show all users and datasets for that task.
     This is helpful because we often forget what datasets were
     used for a task, which are the necessary parameters for the commands
-    `results` and `best` and `tasksummary`. Shows
-    the summary for all available tasks if no option is specified.
+    `results` and `best` and `tasksummary`. Shows the summary for all available tasks if no option is specified.
     """
 
     if task is not None:
@@ -197,16 +193,12 @@ def lbsummary(task):
                                               "--metric acc")
 @click.option('--sort', help="specify one metric to sort the results")
 @click.option('--event_type', default='test', help="specify one metric to sort the results")
+@click.option('--n', help='number of experiments', type=int)
 @click.argument('task')
 @click.argument('sha1')
-def xpdetails(user, metric, sort, event_type, task, sha1):
+def details(user, metric, sort, event_type, task, sha1, n):
     """
-    Shows the results for event_type(tran/valid/test) on a particular task
-    (classify/ tagger) with a particular dataset (SST2, wnut).
-
-    Default behavior: **All** users, and metrics. Optionally supply user(s),
-    metric(s), a sort metric. use --metric f1 --metric acc for multiple metrics.
-    use one metric for the sort.
+    Shows the results for all experiments for a particular config (sha1). Optionally filter out by user(s), metric(s), or sort by one metric. Shows the results on the test data by default, provide event_type (train/valid/test) to see for other datasets.
     """
     if not RepoManager.get().has_task(task):
         click.echo("no results for the specified task {}, use another task".format(task))
@@ -217,7 +209,7 @@ def xpdetails(user, metric, sort, event_type, task, sha1):
         click.echo("we do not have results for the event type: {}".format(event_type))
         return
 
-    result_frame = RepoManager.get().experiment_details(user, metric, sort, task, event_type, sha1)
+    result_frame = RepoManager.get().experiment_details(user, metric, sort, task, event_type, sha1, n)
     if result_frame is not None:
         click.echo(result_frame)
     else:
@@ -240,7 +232,9 @@ def updatelabel(id, label, task):
 @click.argument('task')
 @click.argument('id')
 def delete(id, task):
-
+    '''
+    Deletes a record from the database and the associated model file from model-checkpoints if it exists.
+    '''
     prev = RepoManager.get().get_label(id, task)
     if prev is None:
         click.echo("The record {} doesn't exist in the database".format(id))
@@ -266,7 +260,9 @@ def delete(id, task):
 @click.argument('log')
 @click.argument('label')
 def putresult(user, log, task, config, label, cbase, cstore):
-
+    '''
+    Puts the results in a database. provide task name, config file, the reporting log gile and the label. optionally can put the model files in a persistent storage.
+    '''
     logf = log.format(task)
     if not os.path.exists(logf):
         click.echo("the log file at {} doesn't exist, provide a valid location".format(logf))
@@ -290,7 +286,9 @@ def putresult(user, log, task, config, label, cbase, cstore):
 @click.argument('id')
 @click.argument('cbase')
 def putmodel(task, id, cbase, cstore):
-
+    '''
+    Puts the baseline model files in persistent storage. provide task, id and model base (""tagger-model-tf-"). optionally provide the storage location (/data/model-checkpoints by default)
+    '''
     model_loc = RepoManager.get().put_model(id, task, cbase, cstore, click.echo)
     if model_loc is not None:
         click.echo("database updated with {}".format(model_loc))
@@ -304,7 +302,9 @@ def putmodel(task, id, cbase, cstore):
 @click.argument("sha1")
 @click.argument("filename")
 def config2json(task, sha1, filename):
-
+    '''
+    Exports the config file for an experiment as a json file.
+    '''
     if not RepoManager.get().has_task(task):
         click.echo("no results for the specified task {}, use another task".format(task))
         return

--- a/python/xpctl/cli.py
+++ b/python/xpctl/cli.py
@@ -263,19 +263,21 @@ def xpsummary(metric, event_type, task, dataset, sha1):
 @click.option('--metric', multiple=True, help="list of metrics (prec, recall, f1, accuracy),[multiple]: --metric f1 "
                                               "--metric acc")
 @click.option('--event_type', default='test', help="train/ dev/ test")
+@click.option('--sort', help="specify one metric to sort the results")
 @click.argument('task')
 @click.argument('dataset')
-def tasksummary(metric, event_type, task, dataset):
+def tasksummary(metric, event_type, sort, task, dataset):
     """
     Provides a statistical summary for a problem . An problem is defined by a (task, dataset) tuple.
     For each config used in the task, shows the average, min, max and std dev and number of experiments done using the
-    config.
+    config. Optionally: a. --metrics: choose metric(s) to show. results ll be sorted on the first metric.
+    b. --sort output all metrics but sort on one.
     """
     if not RepoManager.get().has_task(task):
         click.echo("no results for the specified task {}, use another task".format(task))
         return
     event_type = EVENT_TYPES[event_type]
-    task_summary = RepoManager.get().task_summary(task, metric, dataset, event_type)
+    task_summary = RepoManager.get().task_summary(task, dataset, event_type, metric, sort)
     if task_summary is None:
         click.echo("can't produce summary for the requested task {}".format(task))
         return

--- a/python/xpctl/cli.py
+++ b/python/xpctl/cli.py
@@ -241,10 +241,12 @@ def lbsummary(task):
 @click.option('--metric', multiple=True, help="list of metrics (prec, recall, f1, accuracy),[multiple]: --metric f1 "
                                               "--metric acc")
 @click.option('--event_type', default='test', help="train/ dev/ test")
+@click.option('--num_exps', help="number of experiments")
+@click.option('--output', help='output file')
 @click.argument('task')
 @click.argument('dataset')
 @click.argument('sha1')
-def xpsummary(metric, event_type, task, dataset, sha1):
+def xpsummary(metric, event_type, num_exps, output, task, dataset, sha1):
     """
     Provides a statistical summary for an experiment. An experiment is defined by a (task, dataset, config) triple.
     Shows the average, min, max and std dev for an experiment performed multiple times using the same config.
@@ -253,20 +255,23 @@ def xpsummary(metric, event_type, task, dataset, sha1):
         click.echo("no results for the specified task {}, use another task".format(task))
         return
     event_type = EVENT_TYPES[event_type]
-    experiment_summary = RepoManager.get().experiment_summary(task, metric, dataset, sha1, event_type)
+    experiment_summary = RepoManager.get().experiment_summary(task, metric, dataset, sha1, event_type, num_exps)
     if experiment_summary is None:
         click.echo("can't produce summary for the requested task {}".format(task))
         return
     click.echo(experiment_summary)
+    if output is not None:
+        experiment_summary.to_csv(output, index=True, index_label="result-id")
 
 @cli.command()
 @click.option('--metric', multiple=True, help="list of metrics (prec, recall, f1, accuracy),[multiple]: --metric f1 "
                                               "--metric acc")
 @click.option('--event_type', default='test', help="train/ dev/ test")
 @click.option('--sort', help="specify one metric to sort the results")
+@click.option('--output', help='output file')
 @click.argument('task')
 @click.argument('dataset')
-def tasksummary(metric, event_type, sort, task, dataset):
+def tasksummary(metric, event_type, sort, output, task, dataset):
     """
     Provides a statistical summary for a problem . An problem is defined by a (task, dataset) tuple.
     For each config used in the task, shows the average, min, max and std dev and number of experiments done using the
@@ -282,6 +287,8 @@ def tasksummary(metric, event_type, sort, task, dataset):
         click.echo("can't produce summary for the requested task {}".format(task))
         return
     click.echo(task_summary)
+    if output is not None:
+        task_summary.to_csv(output, index=True, index_label="experiment-id")
 
 # Edit database
 @cli.command()

--- a/python/xpctl/cli.py
+++ b/python/xpctl/cli.py
@@ -239,20 +239,22 @@ def lbsummary(task):
 
 
 @cli.command()
+@click.option('--metric', multiple=True, help="list of metrics (prec, recall, f1, accuracy),[multiple]: --metric f1 "
+                                              "--metric acc")
+@click.option('--event_type', default='test', help="train/ dev/ test")
 @click.argument('task')
 @click.argument('dataset')
-@click.argument('metric')
-def tasksummary(task, dataset, metric):
+@click.argument('sha1')
+def tasksummary(metric, event_type, task, dataset, sha1):
     """
     Provides a natural language summary for a task. This is almost equivalent
     to the `best` command.
     """
-    event_type = EVENT_TYPES["test"]
     if not RepoManager.get().has_task(task):
         click.echo("no results for the specified task {}, use another task".format(task))
         return
-
-    task_summary = RepoManager.get().task_summary(task, dataset, metric, event_type)
+    event_type = EVENT_TYPES[event_type]
+    task_summary = RepoManager.get().task_summary(task, metric, dataset, sha1, event_type)
     if task_summary is None:
         click.echo("can't produce summary for the requested task {}".format(task))
         return

--- a/python/xpctl/core.py
+++ b/python/xpctl/core.py
@@ -63,20 +63,6 @@ class ExperimentRepo(object):
         """
         pass
 
-    def nbest_by_metric(self, username, metric, dataset, task, num_results, event_type, ascending):
-        """Get the n-best results according to the specific metrics
-
-        :param username: (``str``) Name of user or None
-        :param metric: (``str``) The name of the metric to use for N-best
-        :param dataset: (``str``) The name of the dataset
-        :param task: (``str``) The name of the task
-        :param num_results: (``int``) The number of results (max) to retrieve from the repo
-        :param event_type: (``str``) The event types to retrieve from repo
-        :param ascending: (``bool``) Should we sort ascending or descending (depends on metric)
-        :return: The N-best data frame
-        """
-        pass
-
     def config2dict(self, task, sha1):
         """Convert a configuration stored in the repository to a string
 
@@ -197,5 +183,18 @@ class ExperimentRepo(object):
         * *label* -- (``str``) An optional, human-readable label name.  Defaults to sha1 of this configuration
 
         :return: The identifier assigned by the database
+        """
+        pass
+
+    def experiment_details(self, user, metric, sort, task, event_type, sha1):
+        """Get results from the database
+
+        :param user: (``str``) The username
+        :param metric: (``str``) The metric to use
+        :param sort: (``str``) The field to sort on
+        :param task: (``str``) The task
+        :param event_type: (``str``) event types to listen for
+        :param sha1: (``str``) sha1 of the config for the experiment
+        :return: A result DataFrame
         """
         pass

--- a/python/xpctl/core.py
+++ b/python/xpctl/core.py
@@ -186,7 +186,7 @@ class ExperimentRepo(object):
         """
         pass
 
-    def experiment_details(self, user, metric, sort, task, event_type, sha1):
+    def experiment_details(self, user, metric, sort, task, event_type, sha1, n):
         """Get results from the database
 
         :param user: (``str``) The username
@@ -195,6 +195,7 @@ class ExperimentRepo(object):
         :param task: (``str``) The task
         :param event_type: (``str``) event types to listen for
         :param sha1: (``str``) sha1 of the config for the experiment
+        :param n: (``int``) number of results to show.
         :return: A result DataFrame
         """
         pass

--- a/python/xpctl/core.py
+++ b/python/xpctl/core.py
@@ -134,7 +134,7 @@ class ExperimentRepo(object):
         """
         pass
 
-    def leaderboard_summary(self, task=None, event_types=None, print_fn=print):
+    def leaderboard_summary(self, task=None, event_type=None, print_fn=print):
         pass
 
     def get_label(self, id, task):

--- a/python/xpctl/helpers.py
+++ b/python/xpctl/helpers.py
@@ -3,6 +3,7 @@ import pymongo
 import pandas as pd
 import os
 from collections import OrderedDict
+import numpy as np
 
 __all__ = ["log2json", "order_json"]
 
@@ -27,3 +28,13 @@ def order_json(j):
             value = j[key]
         new[key] = value
     return new
+
+
+def expsummary(df):
+    return df.groupby("sha1").agg([len, np.mean, np.std, np.min, np.max]) \
+        .rename(columns={'len': 'num_exps', 'amean': 'mean', 'amin': 'min', 'amax': 'max'})
+
+
+def tasksummary(df):
+    return df.groupby("sha1").agg([len, np.mean, np.std, np.min, np.max])\
+        .rename(columns={'len': 'num_exps', 'amean': 'mean', 'amin': 'min', 'amax': 'max'})

--- a/python/xpctl/helpers.py
+++ b/python/xpctl/helpers.py
@@ -50,7 +50,7 @@ def df_get_results(result_frame, dataset, num_exps, metric, sort):
         for gname, rframe in result_frame.groupby("sha1"):
             rframe = rframe.copy()
             rframe['date'] =pd.to_datetime(rframe.date)
-            rframe = rframe.sort_values(by='date').head(int(num_exps))
+            rframe = rframe.sort_values(by='date', ascending=False).head(int(num_exps))
             df = df.append(rframe)
         result_frame = df
     result_frame = result_frame.drop(columns=["id"])
@@ -66,10 +66,14 @@ def df_get_results(result_frame, dataset, num_exps, metric, sort):
     return result_frame
 
 
-def df_experimental_details(result_frame, sha1, users, sort, metric):
+def df_experimental_details(result_frame, sha1, users, sort, metric, num_exps):
+    result_frame = result_frame[result_frame.sha1 == sha1]
     if result_frame.empty:
         return None
-    result_frame = result_frame[result_frame.sha1 == sha1]
+    if num_exps is not None:
+        result_frame = result_frame.copy()
+        result_frame['date'] =pd.to_datetime(result_frame.date)
+        result_frame = result_frame.sort_values(by='date', ascending=False).head(int(num_exps))
     if users is not None:
         df = pd.DataFrame()
         for user in users:

--- a/python/xpctl/helpers.py
+++ b/python/xpctl/helpers.py
@@ -30,11 +30,21 @@ def order_json(j):
     return new
 
 
-def expsummary(df):
+def sort_ascending(metric):
+    return metric == "avg_loss" or metric == "perplexity"
+
+
+def df_summary_exp(df):
     return df.groupby("sha1").agg([len, np.mean, np.std, np.min, np.max]) \
         .rename(columns={'len': 'num_exps', 'amean': 'mean', 'amin': 'min', 'amax': 'max'})
 
 
-def tasksummary(df):
-    return df.groupby("sha1").agg([len, np.mean, np.std, np.min, np.max])\
+def df_summary_task(df, metric=None, sort=None):
+    result_frame = df.groupby("sha1").agg([len, np.mean, np.std, np.min, np.max])\
         .rename(columns={'len': 'num_exps', 'amean': 'mean', 'amin': 'min', 'amax': 'max'})
+    metrics = list(metric)
+    if len(metric) == 1:
+        return result_frame.sort_values([(metrics[0], 'mean')], ascending=sort_ascending(metric))
+    if sort:
+        return result_frame.sort_values([(sort, 'mean')], ascending=sort_ascending(metric))
+    return result_frame

--- a/python/xpctl/mongo/backend.py
+++ b/python/xpctl/mongo/backend.py
@@ -206,7 +206,7 @@ class MongoRepo(ExperimentRepo):
             return result_frame.sort_values(sort, ascending=sort_ascending(metric))
         return result_frame
 
-    def experiment_summary(self, task, metric, dataset, sha1, event_type):
+    def experiment_summary(self, task, metric, dataset, sha1, event_type, num_exps):
         metrics = list(metric)
         coll = self.db[task]
         query = self._update_query({}, [], dataset)
@@ -219,6 +219,10 @@ class MongoRepo(ExperimentRepo):
             dsr = result_frame[(result_frame.dataset == dataset) & (result_frame.sha1 == sha1)]
             if dsr.empty:
                 return None
+            if num_exps is not None:
+                dsr = dsr.copy()
+                dsr['date'] = pd.to_datetime(dsr.date)
+                dsr = dsr.sort_values(by=['date']).head(int(num_exps))
             return df_summary_exp(dsr)
         return None
 

--- a/python/xpctl/mongo/backend.py
+++ b/python/xpctl/mongo/backend.py
@@ -179,14 +179,14 @@ class MongoRepo(ExperimentRepo):
         projection.update({event_type: 1})
         return projection
 
-    def experiment_details(self, user, metric, sort, task, event_type, sha1):
+    def experiment_details(self, user, metric, sort, task, event_type, sha1, n):
         metrics = listify(metric)
         coll = self.db[task]
         users = listify(user)
         query = self._update_query({}, users, [])
         projection = self._update_projection(event_type=event_type)
         result_frame = self._generate_data_frame(coll, metrics=metrics, query=query, projection=projection, event_type=event_type)
-        return df_experimental_details(result_frame, sha1, users, sort, metric)
+        return df_experimental_details(result_frame, sha1, users, sort, metric, n)
 
     def get_results(self, task, dataset, event_type, num_exps = None, metric=None, sort=None):
         metrics = listify(metric)


### PR DESCRIPTION
- **commands**
  - **syntax change**: `results <taskname> <datasetname>`. Provides a statistical summary of all experiments on that dataset, grouped by config sha1s. can be filtered on user(s), metric(s), number of experiment(s). can be sorted. shows results on the test data by default. provide the event_type option to see results on train/valid.
  - **addition**: `details <taskname> <sha1>`. Provides the detailed results for _one_experiment. can be filtered on user(s), metric(s), number of experiment(s). can be sorted. shows results on the test data by default. provide the event_type option to see results on train/valid. 
  - **deletion**: `best`, `tasksummary`.
- **test coverage**: mongo + postgresql.
- **docs updated**.     