### PR TITLE
hot fix export

### DIFF
--- a/python/mead/exporters.py
+++ b/python/mead/exporters.py
@@ -18,7 +18,7 @@ class Exporter(object):
 
 def create_exporter(task, exporter_type):
     if exporter_type == 'default':
-        return task.ExporterType
+        return task.ExporterType(task)
     else:
         mod = import_user_module("exporter", exporter_type)
         return mod.create_exporter(task, exporter_type)


### PR DESCRIPTION
In the [old version](https://github.com/dpressel/baseline/commit/7aa81aa0d3b6ffaee99db411ae81cd036b7b7199#diff-574bc936d01d83313333f8c22a05c26fL189) `create_exporter` returned the object but this was returning the class. This broke the default exporting process.