### PR TITLE
Move to variable scope

### DIFF
--- a/python/addons/classify_elmo.py
+++ b/python/addons/classify_elmo.py
@@ -177,7 +177,7 @@ class ELMoClassifier(Classifier):
         xavier_init = xavier_initializer(True, seed)
 
         # Use pre-trained embeddings from word2vec
-        with tf.name_scope("LUT"):
+        with tf.variable_scope("LUT"):
             W = tf.Variable(tf.constant(w2v.weights, dtype=tf.float32), name="W", trainable=finetune)
             e0 = tf.scatter_update(W, tf.constant(0, dtype=tf.int32, shape=[1]), tf.zeros(shape=[1, dsz]))
             with tf.control_dependencies([e0]):
@@ -206,7 +206,7 @@ class ELMoClassifier(Classifier):
                 [fully_connected],
                 weights_initializer=xavier_init):
 
-            with tf.name_scope("output"):
+            with tf.variable_scope("output"):
                 model.logits = tf.identity(fully_connected(stacked, nc, activation_fn=None), name="logits")
                 model.best = tf.argmax(model.logits, 1, name="best")
         model.sess = sess

--- a/python/addons/tagger_elmo.py
+++ b/python/addons/tagger_elmo.py
@@ -272,7 +272,7 @@ class RNNTaggerELMoModel(Tagger):
                 "sequence_len": model.lengths
             }, signature="tokens", as_dict=True)["elmo"]
 
-        with tf.name_scope("WordLUT"):
+        with tf.variable_scope("WordLUT"):
             Ww = tf.Variable(tf.constant(word_vec.weights, dtype=tf.float32), name="W")
             we0 = tf.scatter_update(Ww, tf.constant(0, dtype=tf.int32, shape=[1]), tf.zeros(shape=[1, word_vec.dsz]))
             with tf.control_dependencies([we0]):

--- a/python/addons/tagger_gazetteer.py
+++ b/python/addons/tagger_gazetteer.py
@@ -217,7 +217,7 @@ class RNNTaggerGazetteerModel(Tagger):
         model.gazette_vocab = gaz_vec.vocab
         seed = np.random.randint(10e8)
         if word_vec is not None:
-            with tf.name_scope("WordLUT"):
+            with tf.variable_scope("WordLUT"):
                 Ww = tf.Variable(tf.constant(word_vec.weights, dtype=tf.float32), name="W")
 
                 we0 = tf.scatter_update(Ww, tf.constant(0, dtype=tf.int32, shape=[1]), tf.zeros(shape=[1, word_vec.dsz]))
@@ -226,7 +226,7 @@ class RNNTaggerGazetteerModel(Tagger):
                     wembed = tf.nn.embedding_lookup(Ww, model.x, name="embeddings")
 
 
-        with tf.name_scope("GazLUT"):
+        with tf.variable_scope("GazLUT"):
             Wn = tf.Variable(tf.constant(gaz_vec.weights, dtype=tf.float32), name="W")
             ne0 = tf.scatter_update(Wn, tf.constant(0, dtype=tf.int32, shape=[1]), tf.zeros(shape=[1, gaz_vec.dsz]))
             with tf.control_dependencies([ne0]):

--- a/python/baseline/tf/classify/model.py
+++ b/python/baseline/tf/classify/model.py
@@ -381,7 +381,7 @@ class WordClassifierBase(Classifier):
                 model.mxwlen = int(kwargs.get('mxwlen', 40))
                 model.xch = kwargs.get('xch', tf.placeholder(tf.int32, [None, model.mxlen, model.mxwlen], name='xch'))
                 char_dsz = c2v.dsz
-                with tf.name_scope("CharLUT"):
+                with tf.variable_scope("CharLUT"):
                     Wch = tf.get_variable("Wch",
                                           initializer=tf.constant_initializer(c2v.weights, dtype=tf.float32,
                                                                               verify_shape=True),
@@ -398,7 +398,7 @@ class WordClassifierBase(Classifier):
             with tf.contrib.slim.arg_scope(
                     [fully_connected],
                     weights_initializer=xavier_init):
-                with tf.name_scope("output"):
+                with tf.variable_scope("output"):
                     model.logits = tf.identity(fully_connected(stacked, nc, activation_fn=None), name="logits")
                     model.best = tf.argmax(model.logits, 1, name="best")
         model.sess = sess

--- a/python/baseline/tf/lm/model.py
+++ b/python/baseline/tf/lm/model.py
@@ -87,7 +87,7 @@ class WordLanguageModel(AbstractLanguageModel):
         lm.word_vocab = word_vec.vocab
         vsz = word_vec.vsz + 1
 
-        with tf.name_scope("WordLUT"):
+        with tf.variable_scope("WordLUT"):
             Ww = tf.Variable(tf.constant(word_vec.weights, dtype=tf.float32), name="W")
             we0 = tf.scatter_update(Ww, tf.constant(0, dtype=tf.int32, shape=[1]), tf.zeros(shape=[1, word_vec.dsz]))
             with tf.control_dependencies([we0]):
@@ -161,14 +161,14 @@ class CharCompLanguageModel(AbstractLanguageModel):
         lm.pdrop_value = kwargs.get('pdrop', 0.5)
         lm.layers = kwargs.get('layers', kwargs.get('nlayers', 1))
         char_dsz = char_vec.dsz
-        with tf.name_scope("CharLUT"):
+        with tf.variable_scope("CharLUT"):
             Wch = tf.Variable(tf.constant(char_vec.weights, dtype=tf.float32), name="Wch", trainable=True)
             ech0 = tf.scatter_update(Wch, tf.constant(0, dtype=tf.int32, shape=[1]), tf.zeros(shape=[1, char_dsz]))
             word_char, wchsz = pool_chars(lm.xch, Wch, ech0, char_dsz, **kwargs)
 
         lm.use_words = kwargs.get('use_words', False)
         if lm.use_words:
-            with tf.name_scope("WordLUT"):
+            with tf.variable_scope("WordLUT"):
                 Ww = tf.Variable(tf.constant(word_vec.weights, dtype=tf.float32), name="W")
                 we0 = tf.scatter_update(Ww, tf.constant(0, dtype=tf.int32, shape=[1]), tf.zeros(shape=[1, word_vec.dsz]))
                 with tf.control_dependencies([we0]):

--- a/python/baseline/tf/seq2seq/model.py
+++ b/python/baseline/tf/seq2seq/model.py
@@ -231,7 +231,7 @@ class Seq2SeqModel(EncoderDecoder):
 
         with tf.variable_scope(tf.get_variable_scope(), reuse=tf.AUTO_REUSE):
 
-            with tf.name_scope("LUT"):
+            with tf.variable_scope("LUT"):
                 if type(src_vocab_embed) is not dict:
                     Wi = tf.get_variable("Wi", initializer=tf.constant_initializer(src_vocab_embed.weights, dtype=tf.float32, verify_shape=True), shape=[len(model.vocab1), model.dsz])
                 else:
@@ -242,7 +242,7 @@ class Seq2SeqModel(EncoderDecoder):
                     Wo = tf.get_variable("Wo",initializer=tf.random_uniform_initializer(-unif, unif), shape=[len(model.vocab2), model.dsz])
                 embed_in = tf.nn.embedding_lookup(Wi, model.src)
 
-            with tf.name_scope("Recurrence"):
+            with tf.variable_scope("Recurrence"):
                 rnn_enc_tensor, final_encoder_state = model.encode(embed_in, model.src)
                 batch_sz = tf.shape(rnn_enc_tensor)[0]
                 with tf.variable_scope("dec", reuse=tf.AUTO_REUSE):
@@ -295,7 +295,7 @@ class Seq2SeqModel(EncoderDecoder):
                     else:
                         model.preds = final_outputs.rnn_output
                         best = final_outputs.sample_id
-            with tf.name_scope("Output"):
+            with tf.variable_scope("Output"):
                 model.best = tf.identity(best, name='best')
                 if beam_width > 1:
                     model.probs = tf.no_op(name='probs')
@@ -322,7 +322,7 @@ class Seq2SeqModel(EncoderDecoder):
         return cell
 
     def encode(self, embed_in, src):
-        with tf.name_scope('encode'):
+        with tf.variable_scope('encode'):
             # List to tensor, reform as (T, B, W)
             if self.rnntype == 'blstm':
                 nlayers_bi = int(self.nlayers / 2)

--- a/python/baseline/tf/tagger/model.py
+++ b/python/baseline/tf/tagger/model.py
@@ -253,7 +253,7 @@ class RNNTaggerModel(Tagger):
         model.char_vocab = char_vec.vocab
         seed = np.random.randint(10e8)
         if word_vec is not None:
-            with tf.name_scope("WordLUT"):
+            with tf.variable_scope("WordLUT"):
                 Ww = tf.Variable(tf.constant(word_vec.weights, dtype=tf.float32), name="W")
 
                 we0 = tf.scatter_update(Ww, tf.constant(0, dtype=tf.int32, shape=[1]), tf.zeros(shape=[1, word_vec.dsz]))

--- a/python/baseline/tf/tfy.py
+++ b/python/baseline/tf/tfy.py
@@ -267,7 +267,7 @@ def highway_conns(inputs, wsz_all, n):
 
 
 def embed(x, vsz, dsz, initializer, finetune=True, scope="LUT"):
-    with tf.name_scope(scope):
+    with tf.variable_scope(scope):
         W = tf.get_variable("W",
                             initializer=initializer,
                             shape=[vsz, dsz], trainable=finetune)


### PR DESCRIPTION
This PR moves from using `tf.name_scope` to `tf.variable_scope` when variables are created with `tf.get_variable` rather then `tf.Variable`.

This pr means that models trained between June 30th and now will need to be retrained if you want to export them (but they can still be loaded with `load_model` in baseline).

This change restores the naming convention for tensor we used to use `LUT/W` rather then just `W`