### PR TITLE
EMA with assign

### DIFF
--- a/python/baseline/tf/classify/train.py
+++ b/python/baseline/tf/classify/train.py
@@ -1,11 +1,11 @@
+import os
 import tensorflow as tf
 from baseline.confusion import ConfusionMatrix
 from baseline.progress import create_progress_bar
 from baseline.reporting import basic_reporting
 from baseline.utils import listify, get_model_file
-from baseline.tf.tfy import optimizer
+from baseline.tf.tfy import optimizer, _add_ema
 from baseline.train import EpochReportingTrainer, create_trainer
-import os
 
 
 class ClassifyTrainerTf(EpochReportingTrainer):
@@ -16,9 +16,21 @@ class ClassifyTrainerTf(EpochReportingTrainer):
         self.loss = model.create_loss()
         self.test_loss = model.create_test_loss()
         self.model = model
-        self.global_step, self.train_op = optimizer(self.loss, colocate_gradients_with_ops=True, **kwargs)
+        self.global_step, train_op = optimizer(self.loss, colocate_gradients_with_ops=True, **kwargs)
+        decay = kwargs.get('ema_decay', None)
+        if decay is not None:
+            self.ema = True
+            ema_op, self.ema_load, self.ema_restore = _add_ema(model, float(decay))
+            with tf.control_dependencies([ema_op]):
+                self.train_op = tf.identity(train_op)
+        else:
+            self.ema = False
+            self.train_op = train_op
 
     def _train(self, loader):
+
+        if self.ema:
+            self.sess.run(self.ema_restore)
 
         total_loss = 0
         steps = len(loader)
@@ -35,6 +47,9 @@ class ClassifyTrainerTf(EpochReportingTrainer):
         return metrics
 
     def _test(self, loader, **kwargs):
+
+        if self.ema:
+            self.sess.run(self.ema_load)
 
         cm = ConfusionMatrix(self.model.labels)
         steps = len(loader)
@@ -70,31 +85,32 @@ class ClassifyTrainerTf(EpochReportingTrainer):
 def fit(model, ts, vs, es=None, **kwargs):
     """
     Train a classifier using TensorFlow
-    
+
     :param model: The model to train
     :param ts: A training data set
     :param vs: A validation data set
     :param es: A test data set, can be None
-    :param kwargs: 
+    :param kwargs:
         See below
-    
+
     :Keyword Arguments:
         * *do_early_stopping* (``bool``) --
           Stop after evaluation data is no longer improving.  Defaults to True
-        
+
         * *epochs* (``int``) -- how many epochs.  Default to 20
         * *outfile* -- Model output file, defaults to classifier-model.pyth
-        * *patience* -- 
+        * *patience* --
            How many epochs where evaluation is no longer improving before we give up
         * *reporting* --
            Callbacks which may be used on reporting updates
         * Additional arguments are supported, see :func:`baseline.tf.optimize` for full list
-    :return: 
+    :return:
     """
     do_early_stopping = bool(kwargs.get('do_early_stopping', True))
     verbose = bool(kwargs.get('verbose', False))
     epochs = int(kwargs.get('epochs', 20))
     model_file = get_model_file(kwargs, 'classify', 'tf')
+    ema = True if kwargs.get('ema_decay') is not None else False
 
     if do_early_stopping:
         early_stopping_metric = kwargs.get('early_stopping_metric', 'acc')
@@ -103,7 +119,7 @@ def fit(model, ts, vs, es=None, **kwargs):
 
     reporting_fns = listify(kwargs.get('reporting', basic_reporting))
     print('reporting', reporting_fns)
-    
+
     trainer = create_trainer(ClassifyTrainerTf, model, **kwargs)
     tables = tf.tables_initializer()
     model.sess.run(tables)

--- a/python/baseline/tf/tfy.py
+++ b/python/baseline/tf/tfy.py
@@ -1,8 +1,66 @@
-import tensorflow as tf
+import os
 import numpy as np
+import tensorflow as tf
 from tensorflow.python.layers import core as layers_core
 from baseline.utils import lookup_sentence, beam_multinomial, crf_mask as crf_m
-import os
+
+
+def _add_ema(model, decay):
+    """Create ops needed to track EMA when training.
+
+    :param model: The model with a `.sess` we want to track.
+    :param decay: float, Decay to use in the EMA
+
+    :returns:
+        ema_op: The update op. This applies the ema to each variable. Should be
+           set as a control dependency on the training op.
+        load: Op to copy emas to the variables.
+        restore_var: Op to copy the original variables back from the EMA ones.
+
+    Note:
+        If you run the load op multiple times then the backup variables will be
+        replaced by the ema variables.
+
+        Currently there was a bug I haven't been able to fix. I haven't found why
+        but sometimes when you run it with a tf.cond you get this error.
+        `tensorflow.python.framework.errors_impl.InvalidArgumentError: Retval[0] does not have value`
+        The stop gap is to remove this which means if you run load multiple times
+        it will over write the backup variables with ema values.
+
+        The load op is set up to automatically save the normal parameters when
+        you load the ema's in.
+    """
+    ema = tf.train.ExponentialMovingAverage(decay=decay)
+    model_vars = model.sess.graph.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES)
+    with tf.variable_scope("BackupVariables"):
+        backup_vars = [
+            tf.get_variable(
+                var.op.name,
+                dtype=var.value().dtype,
+                trainable=False,
+                initializer=var.initialized_value()
+            ) for var in model_vars
+        ]
+    ema_op = ema.apply(model_vars)
+
+    save_back_up = tf.group(*(
+        tf.assign(back, var.read_value())
+        for var, back in zip(model_vars, backup_vars)
+    ), name='save_backups')
+
+    with tf.control_dependencies([save_back_up]):
+        load = tf.group(*(
+            tf.assign(var, ema.average(var).read_value())
+            for var in model_vars
+        ), name="load_ema")
+
+    restore_vars = tf.group(*(
+        tf.assign(var, back.read_value())
+        for var, back in zip(model_vars, backup_vars)
+    ), name="restore_backups")
+
+    return ema_op, load, restore_vars
+
 
 def crf_mask(vocab, span_type, s_idx, e_idx, pad_idx=None):
     """Create a CRF Mask.

--- a/python/tests/test_parallel_conv.py
+++ b/python/tests/test_parallel_conv.py
@@ -1,4 +1,5 @@
 try:
+    import os
     import random
     import unittest
     from mock import patch, MagicMock
@@ -8,6 +9,7 @@ try:
 except ImportError:
     raise unittest.SkipTest('Failed to import tensorflow')
 
+os.environ['CUDA_VISIBLE_DEVICES'] = ''
 
 class ParallelConvTest(tf.test.TestCase):
 

--- a/python/tests/test_tf_ema.py
+++ b/python/tests/test_tf_ema.py
@@ -1,0 +1,101 @@
+import os
+import pytest
+import numpy as np
+tf = pytest.importorskip('tensorflow')
+from baseline.tf.tfy import _add_ema
+
+os.environ['CUDA_VISIBLE_DEVICES'] = ''
+
+
+class Model:
+    def __init__(self):
+        self.sess = tf.Session()
+        with self.sess.graph.as_default():
+            self.w = tf.Variable(100, dtype=tf.float32)
+            self.w2 = tf.Variable(12, dtype=tf.float32)
+            self.w3 = tf.Variable(64, dtype=tf.float32, trainable=False)
+            self.train_vars = [self.w, self.w2]
+            self.x = tf.placeholder(tf.float32, [None])
+            self.y = tf.placeholder(tf.float32, [None])
+            self.y_ = tf.multiply(self.x, self.w)
+
+            self.loss = tf.reduce_sum(tf.square(tf.subtract(self.y, self.y_)))
+            self.opt = tf.train.GradientDescentOptimizer(learning_rate=0.001)
+
+
+@pytest.fixture
+def model():
+    tf.reset_default_graph()
+    m = Model()
+    with m.sess.graph.as_default():
+       ema_op, load, restore = _add_ema(m, 0.99)
+       with tf.control_dependencies([ema_op]):
+            train_op = m.opt.minimize(m.loss)
+    yield m, train_op, load, restore
+    m.sess.close()
+
+
+def test_ema_is_graph(model):
+    m, _, _, _ = model
+    for var in m.train_vars:
+        m.sess.graph.get_tensor_by_name("{}/ExponentialMovingAverage:0".format(var.name[:-2]))
+    with pytest.raises(KeyError):
+        m.sess.graph.get_tensor_by_name("{}/ExponentialMovingAverage:0".format(m.w3.name[:-2]))
+    assert True
+
+
+def test_trainable_in_backup(model):
+    m, _, _, _ = model
+    for var in m.train_vars:
+        m.sess.graph.get_tensor_by_name("BackupVariables/{}".format(var.name))
+    assert True
+
+
+def test_restore(model):
+    m, _, _, restore = model
+    m.sess.run(tf.global_variables_initializer())
+    old = m.sess.run(m.w)
+    m.sess.run(tf.assign(m.w, tf.constant(3.0)))
+    over = m.sess.run(m.w)
+    m.sess.run(restore)
+    new = m.sess.run(m.w)
+    assert old != over
+    assert over != new
+    assert old == new
+
+
+def test_load_saves_before_write(model):
+    m, _, load, _ = model
+    m.sess.run(tf.global_variables_initializer())
+    old_backup = m.sess.run(m.sess.graph.get_tensor_by_name("BackupVariables/Variable:0"))
+    m.sess.run(tf.assign(m.w, tf.constant(3.0)))
+    gold = m.sess.run(m.w)
+    m.sess.run(load)
+    new_backup = m.sess.run(m.sess.graph.get_tensor_by_name("BackupVariables/Variable:0"))
+    assert old_backup != new_backup
+    assert new_backup == gold
+
+
+# def test_load_twice_does_not_overwirte(model):
+#     m, _, load, _ = model
+#     m.sess.run(tf.global_variables_initializer())
+#     m.sess.run(tf.assign(m.w, tf.constant(3.0)))
+#     gold = m.sess.run(m.w)
+#     m.sess.run(load)
+#     wrong = m.sess.run(m.w)
+#     m.sess.run(load)
+#     backup = m.sess.run(m.sess.graph.get_tensor_by_name("BackupVariables/Variable:0"))
+#     assert backup != wrong
+#     assert backup == gold
+
+
+def test_ema_update_on_step(model):
+    m, train_op, load, _ = model
+    m.sess.run(tf.global_variables_initializer())
+    m.sess.run([train_op], {m.x: [1], m.y: [0]})
+    m.sess.run([train_op], {m.x: [1], m.y: [0]})
+    w = m.sess.run(m.w)
+    m.sess.run(load)
+    new_w = m.sess.run(m.w)
+    with pytest.raises(AssertionError):
+        np.testing.assert_allclose(w, new_w)


### PR DESCRIPTION
The PR add Exponential Moving Average training to Tensorflow Classify using assigns rather than `tf.train.saver`. The downside of this is that you need 3 copies for the variables rather than just two.
It seems a bit cleaner than the old way though.

The actual ema operations are created with the function _add_ema in tfy, ema calculation is done with a tf.control_dependencies in the trainer, and using the ema values are controlled with the other two return values

This is how the EMA works for training:

 * Before training the restore op is run
 * The model is trained
 * Before testing the load operation is run

Currently checkpoints include both the normal and ema values.

Exported models only have the final results (no ema values).

Tested by training and exporting.