### PR TITLE
Remove tensorflow dependency

### DIFF
--- a/python/baseline/tf/seq2seq/model.py
+++ b/python/baseline/tf/seq2seq/model.py
@@ -302,7 +302,7 @@ class Seq2SeqModel(EncoderDecoder):
                 else:
                     model.probs = tf.map_fn(lambda x: tf.nn.softmax(x, name='probs'), model.preds)
 
-            writer = tf.summary.FileWriter('blah', model.sess.graph)
+            # writer = tf.summary.FileWriter('blah', model.sess.graph)
             return model
 
     def set_saver(self, saver):

--- a/python/mead/tasks.py
+++ b/python/mead/tasks.py
@@ -8,7 +8,6 @@ import os
 from mead.downloader import EmbeddingDownloader, DataDownloader
 from mead.mime_type import mime_type
 from baseline.utils import export, read_config_file, read_json, write_json
-from mead.tf.exporters import ClassifyTensorFlowExporter, TaggerTensorFlowExporter, Seq2SeqTensorFlowExporter
 
 __all__ = []
 exporter = export(__all__)
@@ -236,6 +235,7 @@ class ClassifierTask(Task):
                 print('TensorFlow backend')
                 import baseline.tf.classify as classify
                 from baseline.data import reverse_2nd as rev2nd
+                from mead.tf.exporters import ClassifyTensorFlowExporter
                 self.ExporterType = ClassifyTensorFlowExporter
 
         self.task = classify
@@ -326,6 +326,7 @@ class TaggerTask(Task):
             print('TensorFlow backend')
             self.config_params['preproc']['trim'] = False
             import baseline.tf.tagger as tagger
+            from mead.tf.exporters import TaggerTensorFlowExporter
             self.ExporterType = TaggerTensorFlowExporter
 
         self.task = tagger
@@ -420,6 +421,7 @@ class EncoderDecoderTask(Task):
             else:
                 import baseline.tf.seq2seq as seq2seq
                 self.config_params['preproc']['show_ex'] = baseline.tf.show_examples_tf
+                from mead.tf.exporters import Seq2SeqTensorFlowExporter
                 self.ExporterType = Seq2SeqTensorFlowExporter
 
         self.task = seq2seq


### PR DESCRIPTION
Recent change to exporters imported tensorflow unconditionally byt importing `mead.tf.exporters`. This moves the imports so they are only done when using tensorflow as a backend.

Tested by training a pytorch model without tensorflow installed (how I found the problem) and by training and exporting tensorflow models for classification, tagging, and seq2seq