### PR TITLE
Log in real json

### DIFF
--- a/python/baseline/utils.py
+++ b/python/baseline/utils.py
@@ -1,10 +1,11 @@
 import os
 import sys
+import json
+import logging
 import importlib
 from functools import partial, update_wrapper, wraps
 import numpy as np
 import addons
-import json
 
 __all__ = []
 
@@ -26,6 +27,14 @@ def export(obj, all_list=None):
 
 exporter = export(__all__)
 
+
+class JSONFormatter(logging.Formatter):
+    def format(self, record):
+        try:
+            if isinstance(record.msg, (list, dict)):
+                record.msg = json.dumps(record.msg)
+        finally:
+            return super(JSONFormatter, self).format(record)
 
 @exporter
 def crf_mask(vocab, span_type, s_idx, e_idx, pad_idx=None):

--- a/python/mead/config/logging.json
+++ b/python/mead/config/logging.json
@@ -1,17 +1,24 @@
 {
     "version": 1,
     "disable_existing_loggers": false,
+    "formatters": {
+        "json": {
+           "()": "baseline.utils.JSONFormatter"
+        }
+    },
     "handlers": {
         "console": {
             "class": "logging.StreamHandler",
             "level": "DEBUG",
-            "stream": "ext://sys.stdout"
+            "stream": "ext://sys.stdout",
+            "formatter": "json"
         },
         "reporting_file_handler": {
             "class": "logging.FileHandler",
             "level": "INFO",
 	        "mode": "w",
             "filename": "reporting.log",
+            "formatter": "json",
             "encoding": "utf8"
         },
         "info_file_handler": {


### PR DESCRIPTION
This PR updates our logging so that logs are written in real json rather than the `__str__` representation of python dicts.

Old style:
`{'tick_type': 'STEP', 'tick': 1539, 'phase': 'Train', 'avg_loss': 0.30835773745010703, 'example': None}`

New style:
`{"tick_type": "STEP", "tick": 3078, "phase": "Train", "avg_loss": 0.20367752328573147, "example": null}`

Logs that don't contain objects that can be converted to json (`list` or `dict`) are handled normally. Logs that fail to json serialize fall back to the normal string representation.