### PR TITLE
install packages for xpctl sql database

### DIFF
--- a/python/install_dev.sh
+++ b/python/install_dev.sh
@@ -25,7 +25,7 @@ if [ $? != 0 ]; then
     exit 1
 fi
 
-pip install -e .[test]
+pip install -e .[test,sql,mongo]
 if [ $? != 0 ]; then
     echo "$package failed to install."
     exit 1

--- a/python/setup_xpctl.py
+++ b/python/setup_xpctl.py
@@ -62,7 +62,14 @@ def main():
             ],
         },
         extras_require={
-            'test': []
+            'test': [],
+            'mongo': [
+                'pymongo',
+            ],
+            'sql': [
+                'SQLAlchemy',
+                'psycopg2-binary',
+            ]
         },
         classifiers={
             'Development Status :: 2 - Pre-Alpha',


### PR DESCRIPTION
This installs the packages needed for the sql database.

When the package is eventually on pypi then people will be able to choose which backend to use like

`pip install xpctl[mongo]` or `pip install xpctl[sql]`

when installing the dev version both backends are installed