### PR TITLE
Reorganize code that reads config files

### DIFF
--- a/python/baseline/utils.py
+++ b/python/baseline/utils.py
@@ -245,19 +245,40 @@ def lowercase(x):
 
 
 @exporter
-def read_json(filepath, default_value={}):
+def read_json(filepath, default_value=None, strict=False):
     """Read a JSON file in.  If no file is found and default value is set, return that instead.  Otherwise error
 
-    :param filepath: A file to load
-    :param default_value: If the file doesnt exist, an alternate object to return, or if None, throw FileNotFoundError
-    :return: A JSON object
+    :param filepath: str, A file to load
+    :param default_value: If the file doesn't exist, return return this. Defaults to an empty dict.
+    :param strict: bool, If true raise an error on file not found.
+
+    :return: dict, The read JSON object
     """
     if not os.path.exists(filepath):
-        if default_value is None:
+        if strict:
             raise FileNotFoundError('No file [] found'.format(filepath))
-        return default_value
+        return default_value if default_value is not None else {}
     with open(filepath) as f:
         return json.load(f)
+
+
+@exporter
+def read_yaml(filepath, default_value=None, strict=False):
+    """Read a JSON file in.  If no file is found and default value is set, return that instead.  Otherwise error
+
+    :param filepath: str, A file to load
+    :param default_value: If the file doesn't exist, return return this. Defaults to an empty dict.
+    :param strict: bool, If true raise an error on file not found.
+
+    :return: dict, The read yaml object
+    """
+    if not os.path.exists(filepath):
+        if strict:
+            raise FileNotFoundError('No file [] found'.format(filepath))
+        return default_value if default_value is not None else {}
+    with open(filepath) as f:
+        import yaml
+        return yaml.load(f)
 
 
 @exporter
@@ -267,11 +288,9 @@ def read_config_file(config_file):
     :param config_file: (``str``) A path to a config file which should be a JSON file, or YAML if pyyaml is installed
     :return: (``dict``) An object
     """
-    with open(config_file) as f:
-        if config_file.endswith('.yml'):
-            import yaml
-            return yaml.load(f)
-        return json.load(f)
+    if config_file.endswith('.yml'):
+        return read_yaml(config_file, strict=True)
+    return read_json(config_file, strict=True)
 
 
 @exporter

--- a/python/tests/test_read_files.py
+++ b/python/tests/test_read_files.py
@@ -1,0 +1,67 @@
+import mock
+import pytest
+
+from baseline.utils import read_config_file, read_json, read_yaml
+
+@pytest.fixture
+def gold_data():
+    return {
+        "a": 1,
+        "b": {
+            "c": 2,
+        },
+    }
+
+
+def test_read_json(gold_data):
+    data = read_json("test_data/test_json.json")
+    assert data == gold_data
+
+def test_read_json_default_value():
+    gold_default = {}
+    data = read_json("test_data/not_there.json")
+    assert data == gold_default
+
+def test_read_json_given_default():
+    gold_default = "default"
+    data = read_json("test_data/not_there.json", gold_default)
+    assert data == gold_default
+
+def test_read_json_strict():
+    with pytest.raises(FileNotFoundError):
+        read_json("test_data/not_there.json", strict=True)
+
+def test_read_yaml(gold_data):
+    pytest.importorskip('yaml')
+    data = read_yaml("test_data/test_yaml.yml")
+    assert data == gold_data
+
+def test_read_yaml_default_value():
+    pytest.importorskip('yaml')
+    gold_default = {}
+    data = read_yaml("test_data/not_there.yml")
+    assert data == gold_default
+
+def test_read_yaml_given_default():
+    pytest.importorskip('yaml')
+    gold_default = "default"
+    data = read_yaml("test_data/not_there.yml", gold_default)
+    assert data == gold_default
+
+def test_read_yaml_strict():
+    pytest.importorskip('yaml')
+    with pytest.raises(FileNotFoundError):
+        read_yaml("test_data/not_there.yml", strict=True)
+
+def test_read_config_json_dispatch():
+    file_name = 'example.json'
+    with mock.patch('baseline.utils.read_json') as read_patch:
+        read_config_file(file_name)
+    read_patch.assert_called_once_with(file_name, strict=True)
+
+def test_read_config_ymal_dispatch():
+    pytest.importorskip('yaml')
+    file_name = 'example.yml'
+    with mock.patch('baseline.utils.read_yaml') as read_patch:
+        read_config_file(file_name)
+    read_patch.assert_called_once_with(file_name, strict=True)

--- a/python/xpctl/cli.py
+++ b/python/xpctl/cli.py
@@ -54,7 +54,7 @@ def read_cred(config_file):
     passwd = None
 
     try:
-        j = read_json(config_file, None)
+        j = read_json(config_file, strict=True)
         dbtype = j.get('dbtype')
         dbhost = j.get('dbhost')
         dbport = j.get('dbport')


### PR DESCRIPTION
Updated `read_json` so that decision to throw and error is based on a parameter rather than a specific default value.

Updated `read_config_file` to use this code.

Updated `read_json` so the default value returned (a dict) is safe. old code:
```python
>>> from baseline.utils import read_json
>>> x = read_json("example")
>>> x
{}
>>> x['a'] = 12
>>> y = read_json("example")
>>> y
{'a': 12}
```

new code:
```python
>>> from baseline.utils import read_json
>>> x = read_json("example")
>>> x
{}
>>> x['a'] = 12
>>> y = read_json("example")
>>> y
{}
```

Tested the only case that was relaying on the `None` for error case by triggering it (`xpctl lbsummary`) on master and my branch and the results where the same when the file it was reading was there and when it wasn't.