### PR TITLE
Update tests

### DIFF
--- a/python/baseline/pytorch/classify/model.py
+++ b/python/baseline/pytorch/classify/model.py
@@ -40,7 +40,6 @@ class WordClassifierBase(nn.Module, Classifier):
         model.lut = pytorch_embedding(word_embeddings, finetune)
         model.vocab = {}
         model.vocab['word'] = word_embeddings.vocab
-        model.vdrop = bool(kwargs.get('variational_dropout', False))
 
         if model.char_dsz > 0:
             model.char_lut = pytorch_embedding(char_embeddings)

--- a/python/tests/README.md
+++ b/python/tests/README.md
@@ -1,0 +1,24 @@
+# Writing tests
+
+## Versions
+
+Support python 2 and 3 in your tests. This means using the `mock` backport library to import `MagicMock` or `patch` rather than `unittest.mock`
+
+
+## Frameworks
+
+There are a lot of optional dependencies that baseline has (various deep learning frameworks, pyyaml, etc). Then writing tests that depend on these libraries use `import_name = pytest.importorskip('import_name')` so that these tests will be skipped if the dependency is not installed.
+
+
+## Accessing test data
+
+When accessing test data on disk make sure the paths are based on the location of the test file rather than relative paths based on the current working directory. This lets pytest be run from anywhere.
+
+```python
+import os
+
+file_loc = os.path.realpath(os.path.dirname(__file__))
+data_loc = os.path.join(file_loc, 'test_data')
+
+file_path = os.path.join(data_loc, 'file_name')
+```

--- a/python/tests/test_read_files.py
+++ b/python/tests/test_read_files.py
@@ -1,3 +1,4 @@
+import os
 import mock
 import pytest
 
@@ -6,52 +7,54 @@ from baseline.utils import read_config_file, read_json, read_yaml
 @pytest.fixture
 def gold_data():
     return {
-        "a": 1,
-        "b": {
-            "c": 2,
+        'a': 1,
+        'b': {
+            'c': 2,
         },
     }
 
+data_loc = os.path.realpath(os.path.dirname(__file__))
+data_loc = os.path.join(data_loc, 'test_data')
 
 def test_read_json(gold_data):
-    data = read_json("test_data/test_json.json")
+    data = read_json(os.path.join(data_loc, 'test_json.json'))
     assert data == gold_data
 
 def test_read_json_default_value():
     gold_default = {}
-    data = read_json("test_data/not_there.json")
+    data = read_json(os.path.join(data_loc, 'not_there.json'))
     assert data == gold_default
 
 def test_read_json_given_default():
-    gold_default = "default"
-    data = read_json("test_data/not_there.json", gold_default)
+    gold_default = 'default'
+    data = read_json(os.path.join(data_loc, 'not_there.json'), gold_default)
     assert data == gold_default
 
 def test_read_json_strict():
     with pytest.raises(FileNotFoundError):
-        read_json("test_data/not_there.json", strict=True)
+        read_json(os.path.join('not_there.json'), strict=True)
 
 def test_read_yaml(gold_data):
     pytest.importorskip('yaml')
-    data = read_yaml("test_data/test_yaml.yml")
+    data = read_yaml(os.path.join(data_loc, 'test_yaml.yml'))
     assert data == gold_data
 
 def test_read_yaml_default_value():
     pytest.importorskip('yaml')
     gold_default = {}
-    data = read_yaml("test_data/not_there.yml")
+    data = read_yaml(os.path.join(data_loc, 'not_there.yml'))
     assert data == gold_default
 
 def test_read_yaml_given_default():
     pytest.importorskip('yaml')
-    gold_default = "default"
-    data = read_yaml("test_data/not_there.yml", gold_default)
+    gold_default = 'default'
+    data = read_yaml(os.path.join('not_there.yml'), gold_default)
     assert data == gold_default
 
 def test_read_yaml_strict():
     pytest.importorskip('yaml')
     with pytest.raises(FileNotFoundError):
-        read_yaml("test_data/not_there.yml", strict=True)
+        read_yaml(os.path.join('not_there.yml'), strict=True)
 
 def test_read_config_json_dispatch():
     file_name = 'example.json'


### PR DESCRIPTION
This PR updates tests so that they don't fail when run from a different directory. It also add a quick document about best practices for tests.

This also removes the `vdrop` from pytorch classify models for now because pytorch variational dropout only happens on the outputs of RNNs not on the internal hidden states or the internal outputs. The RNN is being used as an encoder so only the last hidden state is used so right now variational dropout doesn't work for pytorch classify. The only way to get an effect would be to have each RNN layer as its own object with Variational Dropout between them. This would be less effective at leveraging cudnn for speed.