### PR TITLE
Update trainer so everything can take env variables rather than files

### DIFF
--- a/python/mead/trainer.py
+++ b/python/mead/trainer.py
@@ -17,6 +17,11 @@ def main():
     args, reporting_args = parser.parse_known_args()
 
     config_params = read_config_stream(args.config)
+    args.settings = read_config_stream(args.settings)
+    args.datasets = read_config_stream(args.datasets)
+    args.embeddings = read_config_stream(args.embeddings)
+    args.logging = read_config_stream(args.logging)
+
     if args.gpus is not None:
         config_params['model']['gpus'] = args.gpus
     if args.reporting is not None:

--- a/python/mead/utils.py
+++ b/python/mead/utils.py
@@ -1,23 +1,37 @@
 import os
 import json
-from copy import deepcopy
-from collections import OrderedDict
-from baseline.utils import export, str2bool
-from mead.mime_type import mime_type
 import hashlib
 import zipfile
 import argparse
+from copy import deepcopy
+from collections import OrderedDict
+from baseline.utils import export, str2bool, read_config_file
+from mead.mime_type import mime_type
 
 __all__ = []
 exporter = export(__all__)
 
 
 @exporter
-def index_by_label(dataset_file):
-    with open(dataset_file) as f:
-        datasets_list = json.load(f)
-        datasets = dict((x["label"], x) for x in datasets_list)
-        return datasets
+def read_config_file_or_json(config, name=''):
+    if isinstance(config, (dict, list)):
+        return config
+    elif os.path.exists(config):
+        return read_config_file(config)
+    raise Exception('Expected {} config file or a JSON object.'.format(name))
+
+
+@exporter
+def get_mead_settings(mead_settings_config):
+    if mead_settings_config is None:
+        return {}
+    return read_config_file_or_json(mead_settings_config, 'mead settings')
+
+
+@exporter
+def index_by_label(object_list):
+    objects = {x['label']: x for x in object_list}
+    return objects
 
 
 @exporter

--- a/python/tests/test_read_files.py
+++ b/python/tests/test_read_files.py
@@ -1,8 +1,10 @@
 import os
+import json
 import mock
 import pytest
+from baseline.utils import read_config_file, read_json, read_yaml, read_config_stream
+from mead.utils import read_config_file_or_json, get_mead_settings
 
-from baseline.utils import read_config_file, read_json, read_yaml
 
 @pytest.fixture
 def gold_data():
@@ -13,31 +15,46 @@ def gold_data():
         },
     }
 
+
+@pytest.fixture
+def env(gold_data):
+    env_name = 'TEST'
+    os.environ[env_name] = json.dumps(gold_data)
+    yield '$' + env_name
+    del os.environ[env_name]
+
+
 data_loc = os.path.realpath(os.path.dirname(__file__))
 data_loc = os.path.join(data_loc, 'test_data')
+
 
 def test_read_json(gold_data):
     data = read_json(os.path.join(data_loc, 'test_json.json'))
     assert data == gold_data
+
 
 def test_read_json_default_value():
     gold_default = {}
     data = read_json(os.path.join(data_loc, 'not_there.json'))
     assert data == gold_default
 
+
 def test_read_json_given_default():
     gold_default = 'default'
     data = read_json(os.path.join(data_loc, 'not_there.json'), gold_default)
     assert data == gold_default
 
+
 def test_read_json_strict():
     with pytest.raises(IOError):
         read_json(os.path.join('not_there.json'), strict=True)
+
 
 def test_read_yaml(gold_data):
     pytest.importorskip('yaml')
     data = read_yaml(os.path.join(data_loc, 'test_yaml.yml'))
     assert data == gold_data
+
 
 def test_read_yaml_default_value():
     pytest.importorskip('yaml')
@@ -45,16 +62,19 @@ def test_read_yaml_default_value():
     data = read_yaml(os.path.join(data_loc, 'not_there.yml'))
     assert data == gold_default
 
+
 def test_read_yaml_given_default():
     pytest.importorskip('yaml')
     gold_default = 'default'
     data = read_yaml(os.path.join('not_there.yml'), gold_default)
     assert data == gold_default
 
+
 def test_read_yaml_strict():
     pytest.importorskip('yaml')
     with pytest.raises(IOError):
         read_yaml(os.path.join('not_there.yml'), strict=True)
+
 
 def test_read_config_json_dispatch():
     file_name = 'example.json'
@@ -62,9 +82,51 @@ def test_read_config_json_dispatch():
         read_config_file(file_name)
     read_patch.assert_called_once_with(file_name, strict=True)
 
+
 def test_read_config_ymal_dispatch():
     pytest.importorskip('yaml')
     file_name = 'example.yml'
     with mock.patch('baseline.utils.read_yaml') as read_patch:
         read_config_file(file_name)
     read_patch.assert_called_once_with(file_name, strict=True)
+
+
+def test_read_config_file_or_json_json(gold_data):
+    data = read_config_file_or_json(gold_data)
+    assert data == gold_data
+
+
+def test_read_config_file_or_json_list(gold_data):
+    input_ = [gold_data, '12']
+    data = read_config_file_or_json(input_)
+    assert data == input_
+
+
+def test_read_config_file_or_json_file():
+    file_name = os.path.join(data_loc, 'test_json.json')
+    with mock.patch('mead.utils.read_config_file') as read_patch:
+        read_config_file_or_json(file_name)
+    read_patch.assert_called_once_with(file_name)
+
+
+def test_read_config_file_or_json_missing_file():
+    with pytest.raises(Exception):
+        data = read_config_file_or_json(os.path.join(data_loc, 'not_there.json'))
+
+
+def test_read_config_stream_file():
+    file_name = os.path.join(data_loc, 'test_json.json')
+    with mock.patch('baseline.utils.read_config_file') as read_patch:
+        read_config_stream(file_name)
+    read_patch.assert_called_once_with(file_name)
+
+
+def test_read_config_stream_env(env, gold_data):
+    data = read_config_stream(env)
+    assert data == gold_data
+
+
+def test_read_config_stream_str(gold_data):
+    input_ = json.dumps(gold_data)
+    data = read_config_stream(input_)
+    assert data == gold_data


### PR DESCRIPTION
This PR updates mead so that the main command line args (config, settings, datasets, embeddings, and logging) can be read from environment variables.

It also allows from them to be passed to mead as dicts rather than only files.

It also pulls the json, file check, exception into its own function.

It also adds some unittests for these new functions.