### PR TITLE
flipping the way extra args work

### DIFF
--- a/python/mead/trainer.py
+++ b/python/mead/trainer.py
@@ -1,7 +1,7 @@
 import argparse
-import mead
-from mead.utils import convert_path
 from baseline.utils import read_config_stream
+import mead
+from mead.utils import convert_path, parse_extra_args
 
 
 def main():
@@ -20,7 +20,8 @@ def main():
     if args.gpus is not None:
         config_params['model']['gpus'] = args.gpus
     if args.reporting is not None:
-        config_params['reporting'] = args.reporting
+        reporting = parse_extra_args(args.reporting, reporting_args)
+        config_params['reporting'] = reporting
 
     task_name = config_params.get('task', 'classify') if args.task is None else args.task
     print('Task: [{}]'.format(task_name))

--- a/python/tests/test_dynety.py
+++ b/python/tests/test_dynety.py
@@ -317,7 +317,7 @@ def test_embedding_lookup():
     pc = dy.ParameterCollection()
     gold = np.random.randn(200, 100)
     embed = Embedding(12, 12, pc, embedding_weight=gold)
-    idx = random.randint(0, len(gold))
+    idx = random.randint(0, len(gold) - 1)
     vector = embed([idx])
     gold_v = gold[idx, :]
     np.testing.assert_allclose(gold_v, vector[0].npvalue())

--- a/python/tests/test_parse_extra_args.py
+++ b/python/tests/test_parse_extra_args.py
@@ -1,0 +1,67 @@
+import pytest
+from mead.utils import parse_extra_args
+
+
+def test_all_base_name_appear():
+    base_names = ['a', 'b']
+    reporting = parse_extra_args(base_names, [])
+    for name in base_names:
+        assert name in reporting
+
+
+def test_all_special_names_grabbed():
+    base_names = ['a', 'b']
+    special_names = ['a:one', 'a:two']
+    gold_special_names = ['one', 'two']
+    reporting = parse_extra_args(base_names, special_names)
+    for gold in gold_special_names:
+        assert gold in reporting['a']
+
+
+def test_nothing_if_no_special():
+    base_names = ['a', 'b']
+    special_names = ['a:one', 'a:two']
+    reporting = parse_extra_args(base_names, special_names)
+    assert {} == reporting['b']
+
+
+def test_special_names_multiple_bases():
+    base_names = ['a', 'b']
+    special_names = ['a:one', 'b:two']
+    reporting = parse_extra_args(base_names, special_names)
+    assert 'one' in reporting['a']
+    assert 'two' not in reporting['a']
+    assert 'two' in reporting['b']
+    assert 'one' not in reporting['b']
+
+
+def test_special_shared_across_base():
+    base_names = ['a', 'b']
+    special_names = ['--b:one', 'b', '--a:one', 'a']
+    reporting = parse_extra_args(base_names, special_names)
+    for name in base_names:
+        assert 'one' in reporting[name]
+        assert reporting[name]['one'] == name
+
+
+# This depends on `argparse` atm which should be mocked out eventually
+def test_values_are_grabbed():
+    base_names = ['a', 'b']
+    special_names = ['--a:xxx', 'xxx', '--a:yyy', 'yyy', '--b:zzz', 'zzz']
+    reporting = parse_extra_args(base_names, special_names)
+    for name in base_names:
+        for special, value in reporting[name].items():
+            assert special == value
+
+def test_extra_things_ignored():
+    base_names = ['b']
+    special_names = ['a:one']
+    reporting = parse_extra_args(base_names, special_names)
+    assert {} == reporting['b']
+
+
+def test_no_base_names():
+    base_names = []
+    special_names = ["--visdom:name", "sst2"]
+    reporting = parse_extra_args(base_names, special_names)
+    assert {} == reporting


### PR DESCRIPTION
This PR changes the way the extra command line args are used. Rather than passing the command line arg into mead where it data is parsed out and added to the default data that is read from the settings file we parse the arguments immediately and then add in the default from the settings file.

I was able to run jobs using visdom and xpctl reporting and was able to override defaults.