### PR TITLE
Move utils

### DIFF
--- a/python/baseline/utils.py
+++ b/python/baseline/utils.py
@@ -2,22 +2,25 @@ import os
 import sys
 import json
 import logging
+import hashlib
+import zipfile
 import importlib
+from copy import deepcopy
+from collections import OrderedDict
 from functools import partial, update_wrapper, wraps
 import numpy as np
 import addons
-import json
-import hashlib
-import zipfile
 
 
 __all__ = []
+
 
 def parameterize(func):
     @wraps(func)
     def decorator(*args, **kwargs):
         return lambda x: func(x, *args, **kwargs)
     return decorator
+
 
 @parameterize
 def export(obj, all_list=None):
@@ -28,6 +31,7 @@ def export(obj, all_list=None):
     """
     all_list.append(obj.__name__)
     return obj
+
 
 exporter = export(__all__)
 
@@ -40,6 +44,7 @@ class JSONFormatter(logging.Formatter):
         except TypeError:
             pass
         return super(JSONFormatter, self).format(record)
+
 
 @exporter
 def crf_mask(vocab, span_type, s_idx, e_idx, pad_idx=None):
@@ -58,6 +63,7 @@ def crf_mask(vocab, span_type, s_idx, e_idx, pad_idx=None):
     if span_type.upper() == "IOBES":
         mask = iobes_mask(vocab, start, end, pad)
     return mask
+
 
 def iob_mask(vocab, start, end, pad=None):
     small = 0
@@ -98,6 +104,7 @@ def iob_mask(vocab, start, end, pad=None):
                     if to.startswith("B-"):
                         mask[vocab[to], vocab[from_]] = small
     return mask
+
 
 def iob2_mask(vocab, start, end, pad=None):
     small = 0
@@ -829,3 +836,84 @@ def verbose_output(verbose, confusion_matrix):
         print(confusion_matrix)
     if outfile is not None:
         confusion_matrix.save(outfile)
+
+
+@exporter
+def order_json(data):
+    """Sort json to a consistent order.
+    When you hash json that has the some content but is different orders you get
+    different fingerprints.
+    In:  hashlib.sha1(json.dumps({'a': 12, 'b':14}).encode('utf-8')).hexdigest()
+    Out: '647aa7508f72ece3f8b9df986a206d95fd9a2caf'
+    In:  hashlib.sha1(json.dumps({'b': 14, 'a':12}).encode('utf-8')).hexdigest()
+    Out: 'a22215982dc0e53617be08de7ba9f1a80d232b23'
+    This function sorts json by key so that hashes are consistent.
+    Note:
+        In our configs we only have lists where the order doesn't matter so we
+        can sort them for consistency. This would have to change if we add a
+        config field that needs order we will need to refactor this.
+    :param data: dict, The json data.
+    :returns:
+        collections.OrderedDict: The data in a consistent order (keys sorted alphabetically).
+    """
+    new = OrderedDict()
+    for (key, value) in sorted(data.items(), key=lambda x: x[0]):
+        if isinstance(value, dict):
+            value = order_json(value)
+        elif isinstance(value, list):
+            value = sorted(value)
+        new[key] = value
+    return new
+
+
+KEYS = {
+    ('conll_output',),
+    ('visdom',),
+    ('visdom_name',),
+    ('model', 'gpus'),
+    ('test_thresh',),
+    ('reporting',),
+    ('num_valid_to_show',),
+    ('train', 'verbose'),
+    ('train', 'model_base'),
+    ('train', 'model_zip'),
+    ('test_batchsz')
+}
+
+
+@exporter
+def remove_extra_keys(config, keys=KEYS):
+    """Remove config items that don't effect the model.
+    When base most things off of the sha1 hash of the model configs but there
+    is a problem. Some things in the config file don't effect the model such
+    as the name of the `conll_output` file or if you are using `visdom`
+    reporting. This strips out these kind of things so that as long as the model
+    parameters match the sha1 will too.
+    :param config: dict, The json data.
+    :param keys: Set[Tuple[str]], The keys to remove.
+    :returns:
+        dict, The data with certain keys removed.
+    """
+    c = deepcopy(config)
+    for key in keys:
+        x = c
+        for k in key[:-1]:
+            x = x.get(k)
+            if x is None:
+                break
+        else:
+            _ = x.pop(key[-1], None)
+    return c
+
+
+@exporter
+def hash_config(config):
+    """Hash a json config with sha1.
+    :param config: dict, The config to hash.
+    :returns:
+        str, The sha1 hash.
+    """
+    stripped_config = remove_extra_keys(config)
+    sorted_config = order_json(stripped_config)
+    json_bytes = json.dumps(sorted_config).encode('utf-8')
+    return hashlib.sha1(json_bytes).hexdigest()

--- a/python/mead/utils.py
+++ b/python/mead/utils.py
@@ -1,5 +1,7 @@
 import os
 import json
+from copy import deepcopy
+from collections import OrderedDict
 from baseline.utils import export, str2bool
 from mead.mime_type import mime_type
 import hashlib
@@ -54,3 +56,84 @@ def modify_reporting_hook_settings(reporting_settings, reporting_args_mead, repo
     for key in vars(args):
         this_hook, var = key.split(":")
         reporting_settings[this_hook].update({var: vars(args)[key]})
+
+
+@exporter
+def order_json(data):
+    """Sort json to a consistent order.
+    When you hash json that has the some content but is different orders you get
+    different fingerprints.
+    In:  hashlib.sha1(json.dumps({'a': 12, 'b':14}).encode('utf-8')).hexdigest()
+    Out: '647aa7508f72ece3f8b9df986a206d95fd9a2caf'
+    In:  hashlib.sha1(json.dumps({'b': 14, 'a':12}).encode('utf-8')).hexdigest()
+    Out: 'a22215982dc0e53617be08de7ba9f1a80d232b23'
+    This function sorts json by key so that hashes are consistent.
+    Note:
+        In our configs we only have lists where the order doesn't matter so we
+        can sort them for consistency. This would have to change if we add a
+        config field that needs order we will need to refactor this.
+    :param data: dict, The json data.
+    :returns:
+        collections.OrderedDict: The data in a consistent order (keys sorted alphabetically).
+    """
+    new = OrderedDict()
+    for (key, value) in sorted(data.items(), key=lambda x: x[0]):
+        if isinstance(value, dict):
+            value = order_json(value)
+        elif isinstance(value, list):
+            value = sorted(value)
+        new[key] = value
+    return new
+
+
+KEYS = {
+    ('conll_output',),
+    ('visdom',),
+    ('visdom_name',),
+    ('model', 'gpus'),
+    ('test_thresh',),
+    ('reporting',),
+    ('num_valid_to_show',),
+    ('train', 'verbose'),
+    ('train', 'model_base'),
+    ('train', 'model_zip'),
+    ('test_batchsz')
+}
+
+
+@exporter
+def remove_extra_keys(config, keys=KEYS):
+    """Remove config items that don't effect the model.
+    When base most things off of the sha1 hash of the model configs but there
+    is a problem. Some things in the config file don't effect the model such
+    as the name of the `conll_output` file or if you are using `visdom`
+    reporting. This strips out these kind of things so that as long as the model
+    parameters match the sha1 will too.
+    :param config: dict, The json data.
+    :param keys: Set[Tuple[str]], The keys to remove.
+    :returns:
+        dict, The data with certain keys removed.
+    """
+    c = deepcopy(config)
+    for key in keys:
+        x = c
+        for k in key[:-1]:
+            x = x.get(k)
+            if x is None:
+                break
+        else:
+            _ = x.pop(key[-1], None)
+    return c
+
+
+@exporter
+def hash_config(config):
+    """Hash a json config with sha1.
+    :param config: dict, The config to hash.
+    :returns:
+        str, The sha1 hash.
+    """
+    stripped_config = remove_extra_keys(config)
+    sorted_config = order_json(stripped_config)
+    json_bytes = json.dumps(sorted_config).encode('utf-8')
+    return hashlib.sha1(json_bytes).hexdigest()

--- a/python/tests/test_hash_utils.py
+++ b/python/tests/test_hash_utils.py
@@ -1,0 +1,129 @@
+import random
+from copy import deepcopy
+import mock
+import pytest
+from baseline.utils import remove_extra_keys, order_json, hash_config
+
+
+@pytest.fixture
+def data():
+    return {
+        'a': 1,
+        'b': {
+            'c': 2,
+            'd': 3,
+        },
+        'e': 4,
+    }
+
+
+@pytest.fixture
+def mixed():
+    return {
+        'e': 4,
+        'b': {
+            'd': 3,
+            'c': 2,
+        },
+        'a': 1,
+    }
+
+
+def test_hash_config_fixes_json(data):
+    with mock.patch('baseline.utils.remove_extra_keys') as strip_mock:
+        strip_mock.return_value = data
+        with mock.patch('baseline.utils.order_json') as order_mock:
+           order_mock.return_value = data
+           hash_config(data)
+    strip_mock.assert_called_once_with(data)
+    order_mock.assert_called_once_with(data)
+
+
+def test_order_json_e2e(data, mixed):
+    res = order_json(mixed)
+    assert res == data
+
+
+def test_order_json_sorts_list():
+    l = list(range(10))
+    random.shuffle(l)
+    data = {'a': l}
+    gold_data = {'a': list(range(10))}
+    res = order_json(data)
+    assert res == gold_data
+
+
+def test_remove_first_layer(data):
+    gold = deepcopy(data)
+    del gold['a']
+    keys = {('a',)}
+    res = remove_extra_keys(data, keys)
+    assert res == gold
+
+
+def test_remove_multiple_first(data):
+    gold = {'a': 1}
+    keys = {('b',), ('e',)}
+    res = remove_extra_keys(data, keys)
+    assert res == gold
+
+
+def test_remove_nested_key(data):
+    gold = deepcopy(data)
+    del gold['b']['c']
+    keys = {('b', 'c')}
+    res = remove_extra_keys(data, keys)
+    assert res == gold
+
+
+def test_remove_multiple_nested(data):
+    gold = deepcopy(data)
+    gold['b'] = {}
+    keys = {('b', 'c'), ('b', 'd')}
+    res = remove_extra_keys(data, keys)
+    assert res == gold
+
+
+def test_remove_mixed_keys(data):
+    gold = deepcopy(data)
+    del gold['b']['c']
+    del gold['a']
+    keys = {('b', 'c'), ('a',)}
+    res = remove_extra_keys(data, keys)
+    assert res == gold
+
+
+def test_remove_single_missing(data):
+    gold = deepcopy(data)
+    keys = {('x',)}
+    res = remove_extra_keys(data, keys)
+    assert res == gold
+
+
+def test_remove_nested_missing_first(data):
+    gold = deepcopy(data)
+    keys = {('x', 'c')}
+    res = remove_extra_keys(data, keys)
+    assert res == gold
+
+
+def test_remove_nested_missing_last(data):
+    gold = deepcopy(data)
+    keys = {('b', 'x')}
+    res = remove_extra_keys(data, keys)
+    assert res == gold
+
+
+def test_remove_nested_missing_both(data):
+    gold = deepcopy(data)
+    keys = {('y', 'x')}
+    res = remove_extra_keys(data, keys)
+    assert res == gold
+
+
+def test_remove_one_missing_one_good(data):
+    gold = deepcopy(data)
+    del gold['a']
+    keys = {('x', 'y'), ('a',)}
+    res = remove_extra_keys(data, keys)
+    assert res == gold

--- a/python/tests/test_hash_utils.py
+++ b/python/tests/test_hash_utils.py
@@ -2,7 +2,7 @@ import random
 from copy import deepcopy
 import mock
 import pytest
-from baseline.utils import remove_extra_keys, order_json, hash_config
+from mead.utils import remove_extra_keys, order_json, hash_config
 
 
 @pytest.fixture
@@ -30,9 +30,9 @@ def mixed():
 
 
 def test_hash_config_fixes_json(data):
-    with mock.patch('baseline.utils.remove_extra_keys') as strip_mock:
+    with mock.patch('mead.utils.remove_extra_keys') as strip_mock:
         strip_mock.return_value = data
-        with mock.patch('baseline.utils.order_json') as order_mock:
+        with mock.patch('mead.utils.order_json') as order_mock:
            order_mock.return_value = data
            hash_config(data)
     strip_mock.assert_called_once_with(data)

--- a/python/xpctl/helpers.py
+++ b/python/xpctl/helpers.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 import numpy as np
 from baseline.utils import listify
 
-__all__ = ["log2json", "order_json"]
+__all__ = ["log2json"]
 
 
 def log2json(log_file):
@@ -14,19 +14,6 @@ def log2json(log_file):
             x = line.replace("'", '"')
             s.append(json.loads(x))
     return s
-
-
-def order_json(j):
-    new = OrderedDict()
-    for key in sorted(j.keys()):
-        if isinstance(j[key], dict):
-            value = order_json(j[key])
-        elif isinstance(j[key], list):
-            value = sorted(j[key])
-        else:
-            value = j[key]
-        new[key] = value
-    return new
 
 
 def sort_ascending(metric):

--- a/python/xpctl/mongo/backend.py
+++ b/python/xpctl/mongo/backend.py
@@ -5,13 +5,12 @@ import pymongo
 import datetime
 import socket
 import json
-import hashlib
 import getpass
-from baseline.utils import export, listify
+from baseline.utils import export, listify, hash_config
 from xpctl.core import ExperimentRepo, store_model
 from bson.objectid import ObjectId
 from baseline.version import __version__
-from xpctl.helpers import order_json, df_get_results, df_experimental_details, get_experiment_label
+from xpctl.helpers import df_get_results, df_experimental_details, get_experiment_label
 
 __all__ = []
 exporter = export(__all__)
@@ -55,7 +54,7 @@ class MongoRepo(ExperimentRepo):
         print_fn = kwargs.get('print_fn', print)
         hostname = kwargs.get('hostname', socket.gethostname())
         username = kwargs.get('username', getpass.getuser())
-        config_sha1 = hashlib.sha1(json.dumps(order_json(config_obj)).encode('utf-8')).hexdigest()
+        config_sha1 = hash_config(config_obj)
         label = get_experiment_label(config_obj, task, **kwargs)
 
         post = {

--- a/python/xpctl/mongo/backend.py
+++ b/python/xpctl/mongo/backend.py
@@ -6,7 +6,8 @@ import datetime
 import socket
 import json
 import getpass
-from baseline.utils import export, listify, hash_config
+from baseline.utils import export, listify
+from mead.utils import hash_config
 from xpctl.core import ExperimentRepo, store_model
 from bson.objectid import ObjectId
 from baseline.version import __version__

--- a/python/xpctl/sql/backend.py
+++ b/python/xpctl/sql/backend.py
@@ -6,12 +6,11 @@ import pymongo
 import datetime
 import socket
 import json
-import hashlib
 import getpass
-from baseline.utils import export, listify
+from baseline.utils import export, listify, hash_config
 from bson.objectid import ObjectId
 from baseline.version import __version__
-from xpctl.helpers import order_json, df_get_results, df_experimental_details
+from xpctl.helpers import df_get_results, df_experimental_details
 
 __all__ = []
 exporter = export(__all__)
@@ -107,7 +106,7 @@ class SQLRepo(ExperimentRepo):
         now = datetime.datetime.utcnow().isoformat()
         hostname = kwargs.get('hostname', socket.gethostname())
         username = kwargs.get('username', getpass.getuser())
-        config_sha1 = hashlib.sha1(json.dumps(order_json(config_obj)).encode('utf-8')).hexdigest()
+        config_sha1 = hash_config(config_obj)
         label = get_experiment_label(config_obj, task, **kwargs)
         checkpoint_base = kwargs.get('checkpoint_base', None)
         checkpoint_store = kwargs.get('checkpoint_store', None)

--- a/python/xpctl/sql/backend.py
+++ b/python/xpctl/sql/backend.py
@@ -7,7 +7,8 @@ import datetime
 import socket
 import json
 import getpass
-from baseline.utils import export, listify, hash_config
+from baseline.utils import export, listify
+from mead.utils import hash_config
 from bson.objectid import ObjectId
 from baseline.version import __version__
 from xpctl.helpers import df_get_results, df_experimental_details


### PR DESCRIPTION
This PR moves utilities for hashing configs into baseline. It also adds some unittests and switches xpctl to using these for hashing.

I was able to train models and save results to local xpctl so it doesn't seem broken.