### PR TITLE
dont create placeholder unless we need it

### DIFF
--- a/python/baseline/tf/classify/model.py
+++ b/python/baseline/tf/classify/model.py
@@ -375,7 +375,7 @@ class ClassifierModelBase(ClassifierModel):
 
             seed = np.random.randint(10e8)
             init = tf.random_uniform_initializer(-0.05, 0.05, dtype=tf.float32, seed=seed)
-            word_embeddings = model.embed()
+            word_embeddings = model.embed(**kwargs)
             input_sz = word_embeddings.shape[-1]
             pooled = model.pool(word_embeddings, input_sz, init, **kwargs)
             stacked = model.stacked(pooled, init, **kwargs)
@@ -393,15 +393,16 @@ class ClassifierModelBase(ClassifierModel):
         # writer = tf.summary.FileWriter('blah', sess.graph)
         return model
 
-    def embed(self):
+    def embed(self, **kwargs):
         """This method performs "embedding" of the inputs.  The base method here then concatenates along depth
         dimension to form word embeddings
 
         :return: A 3-d vector where the last dimension is the concatenated dimensions of all embeddings
         """
         all_embeddings_out = []
-        for embedding in self.embeddings.values():
-            embeddings_out = embedding.encode()
+        for k, embedding in self.embeddings.items():
+            x = kwargs.get(k, None)
+            embeddings_out = embedding.encode(x)
             all_embeddings_out += [embeddings_out]
         word_embeddings = tf.concat(values=all_embeddings_out, axis=2)
         return word_embeddings

--- a/python/baseline/tf/embeddings.py
+++ b/python/baseline/tf/embeddings.py
@@ -92,7 +92,6 @@ class LookupTableEmbeddings(TensorFlowEmbeddings):
         self.finetune = kwargs.get('finetune', True)
         self.name = name
         self.scope = kwargs.get('scope', '{}/LUT'.format(self.name))
-        self.x = kwargs.get(self.name, self.create_placeholder(name))
         self.weights = kwargs.get('weights')
         if self.weights is None:
             unif = kwargs.get('unif', 0.1)
@@ -105,7 +104,9 @@ class LookupTableEmbeddings(TensorFlowEmbeddings):
         :return: The sub-graph output
         """
         if x is None:
-            x = self.x
+            x = LookupTableEmbeddings.create_placeholder(self.name)
+        self.x = x
+
         return embed(x,
                      self.vsz,
                      self.dsz,
@@ -140,7 +141,6 @@ class CharBoWEmbeddings(TensorFlowEmbeddings):
         self.weights = kwargs.get('weights')
         self.params = kwargs
         self.wsz = None
-        self.xch = kwargs.get(self.name, tf.placeholder(tf.int32, [None, None, None], name=self.name))
         if self.weights is None:
             unif = kwargs.get('unif', 0.1)
             self.weights = np.random.uniform(-unif, unif, (self.vsz, self.dsz))
@@ -150,7 +150,8 @@ class CharBoWEmbeddings(TensorFlowEmbeddings):
 
     def encode(self, x=None):
         if x is None:
-            x = self.x
+            x = CharBoWEmbeddings.create_placeholder(self.name)
+        self.x = x
         return tf.reduce_sum(embed(x,
                                    self.get_vsz(),
                                    self.get_dsz(),
@@ -177,7 +178,7 @@ class CharConvEmbeddings(TensorFlowEmbeddings):
         self.weights = kwargs.get('weights')
         self.params = kwargs
         self.wsz = None
-        self.x = kwargs.get(self.name, tf.placeholder(tf.int32, [None, None, None], name=self.name))
+        self.x = None
         if self.weights is None:
             unif = kwargs.get('unif', 0.1)
             self.weights = np.random.uniform(-unif, unif, (self.vsz, self.dsz))
@@ -187,7 +188,8 @@ class CharConvEmbeddings(TensorFlowEmbeddings):
 
     def encode(self, x=None):
         if x is None:
-            x = self.x
+            x = CharConvEmbeddings.create_placeholder(self.name)
+        self.x = x
         with tf.variable_scope(self.scope):
             Wch = tf.get_variable("Wch",
                                   initializer=tf.constant_initializer(self.weights, dtype=tf.float32, verify_shape=True),


### PR DESCRIPTION
This fixes multi-GPU runs which were broken in v1 branch as the embeddings were refactored up and out of the model.

In the data-parallel case, we were feeding in keyword arguments, but because we didnt defer the placeholder creation until the application `encode(x)` we were always creating  placeholders, and we were also not allowing the override from the keyword args in the model