### PR TITLE
update topk

### DIFF
--- a/python/baseline/utils.py
+++ b/python/baseline/utils.py
@@ -519,22 +519,11 @@ def lookup_sentence(rlut, seq, reverse=False, padchar=''):
 
 @exporter
 def topk(k, probs):
-    """Get a sparse index (dictionary of top values).
+    """Get a sparse index (dictionary of top values)."""
+    idx = np.argpartition(probs, probs.size-k)[-k:]
+    sort = idx[np.argsort(probs[idx])][::-1]
+    return dict(zip(sort, probs[sort]))
 
-    Note:
-        mutates input for efficiency
-    """
-    # This would be better:
-    # idx = (-probs).argsort()[:k]
-    lut = {}
-    i = 0
-
-    while i < k:
-        idx = np.argmax(probs)
-        lut[idx] = probs[idx]
-        probs[idx] = -1e9
-        i += 1
-    return lut
 
 @exporter
 def beam_multinomial(k, probs):

--- a/python/tests/test_sample.py
+++ b/python/tests/test_sample.py
@@ -1,0 +1,41 @@
+import pytest
+import numpy as np
+from baseline.utils import topk
+
+@pytest.fixture
+def setup():
+    input_ = np.random.rand(100)
+    k = np.random.randint(2, 20)
+    top = np.random.choice(np.arange(len(input_)), size=k, replace=False)
+    add = np.max(input_) + np.arange(1, len(top) + 1)
+    input_[top] = add
+    return input_, top, k
+
+
+def test_k_drawn(setup):
+    input_, top, k = setup
+    result = topk(k, input_)
+    assert len(result) == k
+
+
+def test_k_are_correct(setup):
+    input_, top, k = setup
+    result = topk(k, input_)
+    for x in top:
+        assert x in result
+
+
+def test_k_in_order(setup):
+    input_, top, k = setup
+    result = topk(k, input_)
+    start = -1e4
+    for x in top:
+        assert result[x] > start
+        start = result[x]
+
+
+def test_k_values_are_correct(setup):
+    input_, top, k = setup
+    result = topk(k, input_)
+    for k, v in result.items():
+        assert v == input_[k]


### PR DESCRIPTION
Updated topk to use numpy, runs in `O(n + k log k)`, adds some tests.

Old: top 10 from 1000 `17.6 µs ± 80.6 ns`
New: top 10 from 1000 `8.8 µs ± 46.9 ns`

A solution with np.argsort does a full `O(n log n)` sort so it actually ends up slower than the python version `25.1 µs ± 359 ns`