### PR TITLE
Plugin dec

### DIFF
--- a/python/addons/reporting_xpctl.py
+++ b/python/addons/reporting_xpctl.py
@@ -6,7 +6,7 @@ import socket
 import os
 
 
-@plugin('create_reporting_hook')
+@plugin('reporting_hook')
 class XPCtlReporting(ReportingHook):
     def __init__(self, **kwargs):
         super(XPCtlReporting, self).__init__(**kwargs)

--- a/python/addons/reporting_xpctl.py
+++ b/python/addons/reporting_xpctl.py
@@ -1,11 +1,12 @@
 from baseline.reporting import ReportingHook
 from xpctl.core import ExperimentRepo
-from baseline.utils import read_config_file
+from baseline.utils import read_config_file, plugin
 import getpass
 import socket
 import os
 
 
+@plugin('create_reporting_hook')
 class XPCtlReporting(ReportingHook):
     def __init__(self, **kwargs):
         super(XPCtlReporting, self).__init__(**kwargs)
@@ -67,7 +68,3 @@ class XPCtlReporting(ReportingHook):
         elif os.path.exists(".graph".format(non_zip)):
             return non_zip
         return None
-
-
-def create_reporting_hook(**kwargs):
-    return XPCtlReporting(**kwargs)

--- a/python/baseline/utils.py
+++ b/python/baseline/utils.py
@@ -45,7 +45,7 @@ def optional_params(func):
 
 @exporter
 @optional_params
-def plugin(cls, name='create_model'):
+def plugin(cls, name='model'):
     """Automatically create a plugin hook for the decorated model.
 
     addons/model.py
@@ -57,12 +57,20 @@ def plugin(cls, name='create_model'):
     >>> type(a)
     <model.A object as ...>
     """
-    def create(*args, **kwargs):
-        return cls(*args, **kwargs)
-
     import inspect
     g = inspect.stack()[2][0].f_globals
-    g[name] = create
+    if hasattr(cls, 'create'):
+        def create(*args, **kwargs):
+            return cls.create(*args, **kwargs)
+    else:
+        def create(*args, **kwargs):
+            return cls(*args, **kwargs)
+    g['create_{}'.format(name)] = create
+
+    if hasattr(cls, 'load'):
+        def load(*args, **kwargs):
+            return cls.load(*args, **kwargs)
+        g['load_{}'.format(name)] = load
 
     return cls
 

--- a/python/baseline/utils.py
+++ b/python/baseline/utils.py
@@ -35,6 +35,33 @@ def export(obj, all_list=None):
 exporter = export(__all__)
 
 
+@exporter
+@parameterize
+def plugin(func, g, name='create_model'):
+    """Automatically create a plugin hook for the decorated model.
+
+    Note: Needs to be passed globals().
+
+    addons/model.py
+        @plugin(globals())
+        class A: pass
+
+    >>> from model import create_model
+    >>> a = create_model()
+    >>> type(a)
+    <model.A object as ...>
+    """
+    def create(*args, **kwargs):
+        return func(*args, **kwargs)
+    g[name] = create
+
+    @wraps(func)
+    def make(*args, **kwargs):
+
+        return func(*args, **kwargs)
+    return make
+
+
 @contextmanager
 def redirect(from_stream, to_stream):
     original_from = from_stream.fileno()


### PR DESCRIPTION
This PR adds a plugin decorator that creates a create and load hook for the decorated class.

When the class has a `create` classmethod that is used, otherwise it calls the constructor directly.

When the class has a `load` classmethod that is added.

You can pass a name to it so that instead of using `create_model` you can have `create_reporting_hook` or `create_embeddings`. Do we want to have different hooks for different types of addons? Seems like just a create/load would be simpler.