### PR TITLE
Fix reporting

### DIFF
--- a/docs/reporting.md
+++ b/docs/reporting.md
@@ -2,11 +2,11 @@
 
 A `reporting hook` for baseline is a class that has three methods: `init`, `step` and `done`. The `step` method determines how the metrics in the training/validation/test step will be stored. For example, The `ConsoleReporting` prints out the results on the console.
 
-You can use the reporting hooks in two ways: 
+You can use the reporting hooks in two ways:
 
-- **mead config file**: The config file should have a field called "reporting". Eg: 
+- **mead config file**: The config file should have a field called "reporting". Eg:
 
-```
+```json
  "train": {
 	"epochs": 2,
 	"optim": "adadelta",
@@ -17,9 +17,7 @@ You can use the reporting hooks in two ways:
     },
     "reporting":["visdom","xpctl"]
 }
-
-
-```  
+```
 
 - pass in the reporting hooks as arguments of `mead-train` or `python/mead/trainer.py`: `mead-train --config sst2.json --reporting visdom console`
 
@@ -28,12 +26,14 @@ Following reporting hooks are implemented:
 - **console**: prints results to the console.
 - **log** (default): saves results to a log file.
 - **visdom** : shows graphs in the visdom interface.
-- **tensorboard**: shows graphs in the tensorboard interface.  
+- **tensorboard**: shows graphs in the tensorboard interface.
 - **xpctl**: stores the results in an [xpctl](xpctl.md) database.
 
 Each reporting hook can be instantiated with their own parameters. These parameters can be specified in `python/mead/config/mead-settings.json`. For example, the `xpctl` reporting hook requires the credentials for the database and whether the model checkpoint files are to be saved or not. The `visdom` reporting hook can optionally take the name of the environment. The following is an example `python/mead/config/mead-settings.json`:
 
-```
+If the reporting hook is a user defined add-on it is convenient to include a `module` field that is the name of the python module the hook is defined in. Otherwise the module must be included in the `modules` section of the mead config for the hook to be loaded.
+
+```json
 {
  "datacache": "<path to home>/.bl-data",
   "reporting_hooks":{
@@ -42,16 +42,18 @@ Each reporting hook can be instantiated with their own parameters. These paramet
     },
     "xpctl": {
       "cred": "<path to the xpctl cred file>",
-      "save_model": true
+      "save_model": true,
+      "module": "reporting_xpctl"
     }
   }
 }
 
-``` 
+```
+
 You can also change/add these parameters during run time, eg:, the following command `mead-train --config sst2.json --visdom:name main` will change the  _name_ parameter for `visdom` from _test_ to _main_. You need to use namespacing for this: all parameters to be used by the `visdom` hook should start with `visdom:`.
 
 Following `baseline`'s design philosophy, you can always write your own reporting hooks and put them in a place accessible by your `PYTHONPATH`. These files should be named like `reporting_x.py` where x=name of the hook. An example can be found at [`reporting_xpctl.py`](../python/addons/reporting_xpctl.py) which provides a reporting hook for `xpctl`.
- 
+
 ### Using visdom
 
 Here are step-by-step instructions for seeing training progress with visdom:
@@ -70,3 +72,14 @@ Here are step-by-step instructions for seeing training progress with visdom:
 ### Using tensorboard
 
 *TODO*
+
+
+#### Source of Truth for Reporting Hooks
+
+There are a few places in mead that reporting hooks can be configured:
+
+ * In mead-settings there is a section called `reporting_hooks` This is the default values for setting on the reporting hooks. Values here will always be included in config unless overridden.
+ * In mead-config there is a section called `reporting` this is a list of active hooks. Hook options cannot be defined here.
+ * From the command lines the `--reporting` flag is a list of active hooks. Command line arguments of the form `--hook:option value` will overwrite the default values in the mead-settings.
+
+The main take-away is that `--reporting` and the `reporting` section of mead config are used to decide which hooks are active. `reporting_hooks` and `--hook:option value` args are used to set parameters of the hook with command line arguments overriding the defaults in mead-settings.

--- a/python/addons/reporting_xpctl.py
+++ b/python/addons/reporting_xpctl.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import os
 import getpass
 import socket

--- a/python/mead/tasks.py
+++ b/python/mead/tasks.py
@@ -233,6 +233,11 @@ class Task(object):
                     if report_arg not in reporting[report_type]:
                         reporting[report_type][report_arg] = report_val
         reporting_hooks = list(reporting.keys())
+        for settings in reporting.values():
+            try:
+                import_user_module(settings.get('module', ''))
+            except (ImportError, ValueError):
+                pass
 
         self.reporting = baseline.create_reporting(reporting_hooks,
                                                    reporting,

--- a/python/mead/trainer.py
+++ b/python/mead/trainer.py
@@ -1,5 +1,6 @@
 import argparse
 from copy import deepcopy
+from itertools import chain
 from baseline.utils import read_config_stream
 import mead
 from mead.utils import convert_path, parse_extra_args
@@ -25,9 +26,11 @@ def main():
 
     if args.gpus is not None:
         config_params['model']['gpus'] = args.gpus
-    if args.reporting is not None:
-        reporting = parse_extra_args(args.reporting, reporting_args)
-        config_params['reporting'] = reporting
+
+    cmd_hooks = args.reporting if args.reporting is not None else []
+    config_hooks = config_params.get('reporting') if config_params.get('reporting') is not None else []
+    reporting = parse_extra_args(set(chain(cmd_hooks, config_hooks)), reporting_args)
+    config_params['reporting'] = reporting
 
     task_name = config_params.get('task', 'classify') if args.task is None else args.task
     print('Task: [{}]'.format(task_name))


### PR DESCRIPTION
This PR updated reporting hooks to handle hooks set to active in the config as we all allowing for import based on the settings so that we don't need `"modules": ["reporting_xpctl"],` in every config.