### PR TITLE
Guarantee offsets for <PAD>, <GO>, <EOS>, <UNK>

### DIFF
--- a/python/addons/tagger_elmo.py
+++ b/python/addons/tagger_elmo.py
@@ -9,6 +9,7 @@ from baseline.model import TaggerModel, create_tagger_model, load_tagger_model
 import tensorflow as tf
 import tensorflow_hub as hub
 import numpy as np
+from baseline.utils import Offsets
 
 
 class RNNTaggerModelELMoModel(TaggerModel):
@@ -144,7 +145,7 @@ class RNNTaggerModelELMoModel(TaggerModel):
                 trainable=True
             )
 
-            self.mask = crf_mask(self.labels, self.span_type, self.labels['<GO>'], self.labels['<EOS>'], self.labels.get('<PAD>'))
+            self.mask = crf_mask(self.labels, self.span_type, Offsets.GO, Offsets.EOS, Offsets.PAD)
             self.inv_mask = tf.cast(tf.equal(self.mask, 0), tf.float32) * tf.constant(-1e4)
 
             self.A = tf.add(tf.multiply(A, self.mask), self.inv_mask, name="transitions")
@@ -189,7 +190,7 @@ class RNNTaggerModelELMoModel(TaggerModel):
             probv, tranv = self.sess.run([self.probs, self.A], feed_dict=feed_dict)
             batch_sz, _, label_sz = probv.shape
             start = np.full((batch_sz, 1, label_sz), -1e4)
-            start[:, 0, self.labels['<GO>']] = 0
+            start[:, 0, Offsets.GO] = 0
             probv = np.concatenate([start, probv], 1)
 
             for pij, sl in zip(probv, lengths):

--- a/python/baseline/dy/tagger/model.py
+++ b/python/baseline/dy/tagger/model.py
@@ -5,6 +5,7 @@ from baseline.model import (
 )
 import numpy as np
 from baseline.dy.dynety import CRF, Linear, DynetModel, rnn_forward
+from baseline.utils import Offsets
 
 
 class TaggerModelBase(DynetModel, TaggerModel):
@@ -23,7 +24,7 @@ class TaggerModelBase(DynetModel, TaggerModel):
 
         if self.do_crf:
             vocab = labels if self.crf_mask else None
-            self.crf = CRF(nc, pc=self.pc, idxs=(labels['<GO>'], labels['<EOS>']),
+            self.crf = CRF(nc, pc=self.pc, idxs=(Offsets.GO, Offsets.EOS),
                            vocab=vocab, span_type=self.span_type)
 
         self.activation_type = kwargs.get('activation', 'tanh')

--- a/python/baseline/pytorch/seq2seq/model.py
+++ b/python/baseline/pytorch/seq2seq/model.py
@@ -3,6 +3,7 @@ import torch.nn as nn
 from torch.autograd import Variable
 from baseline.pytorch.torchy import *
 from baseline.model import EncoderDecoderModel, register_model
+from baseline.utils import Offsets
 import os
 
 
@@ -19,8 +20,6 @@ class Seq2SeqModel(nn.Module, EncoderDecoderModel):
         """
         super(Seq2SeqModel, self).__init__()
         self.beam_sz = kwargs.get('beam', 1)
-        self.GO = kwargs.get('GO')
-        self.EOS = kwargs.get('EOS')
         self.gpu = kwargs.get('gpu', True)
         src_dsz, tgt_dsz = self.init_embed(src_embeddings, tgt_embedding)
         self.src_lengths_key = kwargs.get('src_lengths_key')
@@ -227,10 +226,8 @@ class Seq2SeqModel(nn.Module, EncoderDecoderModel):
 
             context, h_i = self.encode(inputs, src_len)
             src_mask = sequence_mask(src_len)
-            GO = self.GO
-            EOS = self.EOS
 
-            paths = [[GO] for _ in range(K)]
+            paths = [[Offsets.GO] for _ in range(K)]
             # K
             scores = torch.FloatTensor([0. for _ in range(K)])
             if self.gpu:

--- a/python/baseline/pytorch/seq2seq/model.py
+++ b/python/baseline/pytorch/seq2seq/model.py
@@ -242,7 +242,7 @@ class Seq2SeqModel(nn.Module, EncoderDecoderModel):
             for i in range(mxlen):
                 lst = [path[-1] for path in paths]
                 dst = torch.LongTensor(lst).type(inputs[src_field].data.type())
-                mask_eos = dst == EOS
+                mask_eos = dst == Offsets.EOS
                 mask_pad = dst == 0
                 dst = dst.view(1, K)
                 var = torch.autograd.Variable(dst)

--- a/python/baseline/pytorch/tagger/model.py
+++ b/python/baseline/pytorch/tagger/model.py
@@ -1,5 +1,6 @@
 from baseline.pytorch.torchy import *
 from baseline.pytorch.crf import *
+from baseline.utils import Offsets
 from baseline.model import TaggerModel
 from baseline.model import register_model
 import torch.autograd
@@ -93,11 +94,11 @@ class TaggerModelBase(nn.Module, TaggerModel):
                 assert model.span_type is not None, "A crf mask cannot be used without providing `span_type`"
                 model.crf = CRF(
                     len(labels),
-                    (model.labels.get("<GO>"), model.labels.get("<EOS>")), batch_first=False,
-                    vocab=model.labels, span_type=model.span_type, pad_idx=model.labels.get("<PAD>")
+                    (Offsets.GO, Offsets.EOS), batch_first=False,
+                    vocab=model.labels, span_type=model.span_type, pad_idx=Offsets.PAD
                 )
             else:
-                model.crf = CRF(len(labels), (model.labels.get("<GO>"), model.labels.get("<EOS>")), batch_first=False)
+                model.crf = CRF(len(labels), (Offsets.GO, Offsets.EOS), batch_first=False)
         model.crit = SequenceCriterion(LossFn=nn.CrossEntropyLoss)
         print(model)
         return model

--- a/python/baseline/reader.py
+++ b/python/baseline/reader.py
@@ -3,7 +3,7 @@ import numpy as np
 from collections import Counter
 import re
 import codecs
-from baseline.utils import import_user_module, revlut, export, optional_params
+from baseline.utils import import_user_module, revlut, export, optional_params, Offsets
 from baseline.vectorizers import Dict1DVectorizer, GOVectorizer
 import os
 
@@ -57,7 +57,6 @@ def _build_vocab_for_col(col, files, vectorizers):
 
     for key in vectorizers.keys():
         vocabs[key] = Counter()
-        vocabs[key]['<EOS>'] = 100000  # In case freq cutoffs
 
     for file in files:
         if file is None:
@@ -180,8 +179,12 @@ class SeqPredictReader(object):
     def __init__(self, vectorizers, trim=False):
         self.vectorizers = vectorizers
         self.trim = trim
-        # TODO: Add <UNK>: 1?
-        self.label2index = {"<PAD>": 0, "<GO>": 1, "<EOS>": 2}
+        #self.label2index = {"<PAD>": 0, "<GO>": 1, "<EOS>": 2}
+        self.label2index = {
+            Offsets.VALUES[Offsets.PAD]: Offsets.PAD,
+            Offsets.VALUES[Offsets.GO]: Offsets.GO,
+            Offsets.VALUES[Offsets.EOS]: Offsets.EOS
+        }
         self.label_vectorizer = Dict1DVectorizer(fields='y', mxlen=-1)
 
     def build_vocab(self, files):
@@ -189,7 +192,6 @@ class SeqPredictReader(object):
         vocabs = {}
         for key in self.vectorizers.keys():
             vocabs[key] = Counter()
-            vocabs[key]['<UNK>'] = 100000  # In case freq cutoffs
 
         labels = Counter()
         for file in files:
@@ -349,7 +351,6 @@ class TSVSeqLabelReader(SeqLabelReader):
         vocab = dict()
         for k in self.vectorizers.keys():
             vocab[k] = Counter()
-            vocab[k]['<UNK>'] = 100000  # In case freq cutoffs
 
         for file in files:
             if file is None:
@@ -419,7 +420,7 @@ class LineSeqReader(object):
         for key in self.vectorizers.keys():
             vocabs[key] = Counter()
             vocabs[key] = Counter()
-            vocabs[key]['<UNK>'] = 100000  # In case freq cutoffs
+
         for file in files:
             if file is None:
                 continue

--- a/python/baseline/tf/tagger/model.py
+++ b/python/baseline/tf/tagger/model.py
@@ -9,7 +9,8 @@ from baseline.utils import ls_props, read_json, write_json
 from baseline.tf.embeddings import *
 from baseline.version import __version__
 from baseline.model import register_model
-from baseline.utils import listify
+from baseline.utils import listify, Offsets
+
 
 class TaggerModelBase(TaggerModel):
 
@@ -184,7 +185,7 @@ class TaggerModelBase(TaggerModel):
                 trainable=True
             )
 
-            self.mask = crf_mask(self.labels, self.span_type, self.labels['<GO>'], self.labels['<EOS>'], self.labels.get('<PAD>'))
+            self.mask = crf_mask(self.labels, self.span_type, Offsets.GO, Offsets.EOS, Offsets.PAD)
             self.inv_mask = tf.cast(tf.equal(self.mask, 0), tf.float32) * tf.constant(-1e4)
 
             self.A = tf.add(tf.multiply(A, self.mask), self.inv_mask, name="transitions")
@@ -198,7 +199,7 @@ class TaggerModelBase(TaggerModel):
         bsz = probs_shape[0]
         lsz = len(self.labels)
         np_gos = np.full((1, 1, lsz), -1e4, dtype=np.float32)
-        np_gos[:, :, self.labels['<GO>']] = 0
+        np_gos[:, :, Offsets.GO] = 0
         gos = tf.constant(np_gos)
         start = tf.tile(gos, [bsz, 1, 1])
         probv = tf.concat([start, self.probs], axis=1)

--- a/python/baseline/tf/tfy.py
+++ b/python/baseline/tf/tfy.py
@@ -2,7 +2,7 @@ import os
 import numpy as np
 import tensorflow as tf
 from tensorflow.python.layers import core as layers_core
-from baseline.utils import lookup_sentence, beam_multinomial, crf_mask as crf_m
+from baseline.utils import lookup_sentence, beam_multinomial, crf_mask as crf_m, Offsets
 import math
 
 
@@ -354,8 +354,6 @@ def show_examples_tf(model, es, rlut1, rlut2, vocab, mxlen, sample, prob_clip, m
     si = np.random.randint(0, len(es))
 
     batch_dict = es[si]
-    GO = vocab['<GO>']
-    EOS = vocab['<EOS>']
     i = 0
     src_lengths_key = model.src_lengths_key
     src_key = src_lengths_key.split('_')[0]
@@ -382,7 +380,7 @@ def show_examples_tf(model, es, rlut1, rlut2, vocab, mxlen, sample, prob_clip, m
         src_i = src_i[np.newaxis, :]
         example[src_key] = src_i
         example[src_lengths_key] = np.array([src_len_i])
-        next_value = GO
+        next_value = Offsets.GO
         for j in range(mxlen):
             tgt_i[0, j] = next_value
             tgt_len_i = np.array([j+1])
@@ -395,7 +393,7 @@ def show_examples_tf(model, es, rlut1, rlut2, vocab, mxlen, sample, prob_clip, m
                 # sampled from
                 next_value = beam_multinomial(prob_clip, output)
 
-            if next_value == EOS:
+            if next_value == Offsets.EOS:
                 break
 
         sent = lookup_sentence(rlut2, tgt_i.squeeze())

--- a/python/baseline/utils.py
+++ b/python/baseline/utils.py
@@ -46,6 +46,13 @@ exporter = export(__all__)
 
 
 @exporter
+class Offsets:
+    """Support pre 3.4"""
+    PAD, GO, EOS, UNK, OFFSET = range(0, 5)
+    VALUES = ["<PAD>", "<GO>", "<EOS>", "<UNK>"]
+
+
+@exporter
 def register(cls, registry, name=None, error=''):
     if name is None:
         name = cls.__name__

--- a/python/baseline/vectorizers.py
+++ b/python/baseline/vectorizers.py
@@ -1,5 +1,5 @@
 import numpy as np
-from baseline.utils import export, optional_params, listify, register
+from baseline.utils import export, optional_params, listify, register, Offsets
 import collections
 
 
@@ -118,11 +118,9 @@ class GOVectorizer(Vectorizer):
         return counter
 
     def run(self, tokens, vocab):
-        GO = vocab['<GO>']
-        EOS = vocab['<EOS>']
         vec1d, valid_length = self.vectorizer.run(tokens, vocab)
-        vec1d = np.concatenate([[GO], vec1d])
-        vec1d[valid_length] = EOS
+        vec1d = np.concatenate([[Offsets.GO], vec1d])
+        vec1d[valid_length] = Offsets.EOS
         return vec1d, valid_length + 1
 
     def get_dims(self):

--- a/python/mead/tasks.py
+++ b/python/mead/tasks.py
@@ -560,8 +560,6 @@ class EncoderDecoderTask(Task):
                                           self.config_params.get('test_batchsz', 1))
 
     def _create_model(self):
-        self.config_params['model']['GO'] = self.feat2tgt['<GO>']
-        self.config_params['model']['EOS'] = self.feat2tgt['<EOS>']
         self.config_params['model']["unif"] = self.config_params["unif"]
         model = self.config_params['model']
         unif = self.config_params.get('unif', 0.1)

--- a/python/mead/tf/exporters.py
+++ b/python/mead/tf/exporters.py
@@ -4,7 +4,7 @@ from tensorflow.python.framework.errors_impl import NotFoundError
 import mead.exporters
 from mead.exporters import register_exporter
 from baseline.tf.embeddings import *
-from baseline.utils import export, read_json, ls_props
+from baseline.utils import export, read_json, ls_props, Offsets
 from collections import namedtuple
 
 FIELD_NAME = 'text/tokens'
@@ -186,7 +186,7 @@ class TaggerTensorFlowExporter(TensorFlowExporter):
         values, indices = tf.nn.top_k(softmax_output, 1)
 
         start_np = np.full((1, 1, len(labels)), -1e4, dtype=np.float32)
-        start_np[:, 0, labels['<GO>']] = 0
+        start_np[:, 0, Offsets.GO] = 0
         start = tf.constant(start_np)
         model.probs = tf.concat([start, model.probs], 1)
 
@@ -269,8 +269,6 @@ class Seq2SeqTensorFlowExporter(TensorFlowExporter):
             raise RuntimeError("state file not found or is empty")
 
         model_params["src_lengths_key"] = state["src_lengths_key"]
-        model_params['GO'] = state['GO']
-        model_params['EOS'] = state['EOS']
 
         # Re-create the embeddings sub-graph
         embeddings = self.init_embeddings(state[self.SOURCE_STATE_EMBED_KEY].items(), basename)


### PR DESCRIPTION
This change guarantees special tokens <PAD>, <GO>, <EOS> and <UNK> in that order.
It creates an `Offsets` object in `baseline/utils.py` that provides the offsets and their values.
Also refactored `baseline/w2v.py` to generically preset these vectors and removed quirky
constructor params from seq2seq modules to simplify things.
Additionally, we ensure that the first 3 Offsets are also in the label vectorizer for tagging