### PR TITLE
Dy tagger

### DIFF
--- a/python/baseline/dy/dynety.py
+++ b/python/baseline/dy/dynety.py
@@ -59,7 +59,7 @@ def Linear(osz, isz, pc, name="linear"):
     weight = linear_pc.add_parameters((osz, isz), name="weight")
     bias = linear_pc.add_parameters(osz, name="bias")
 
-    def linear(input_):
+    def linear(input_, _=None):
         """
         :param input_: dy.Expression ((isz,), B)
 
@@ -89,9 +89,9 @@ def HighwayConnection(funcs, sz, pc, name="highway"):
         weights.append(highway_pc.add_parameters((sz, sz), name="weight-{}".format(i)))
         biases.append(highway_pc.add_parameters((sz), init=dy.ConstInitializer(-2), name="bias-{}".format(i)))
 
-    def highway(input_):
+    def highway(input_, train):
         for func, weight, bias in zip(funcs, weights, biases):
-            proj = dy.rectify(func(input_))
+            proj = dy.rectify(func(input_, train))
             transform = dy.logistic(dy.affine_transform([bias, weight, input_]))
             input_ = dy.cmult(transform, proj) + dy.cmult(input_, 1 - transform)
         return input_
@@ -100,9 +100,9 @@ def HighwayConnection(funcs, sz, pc, name="highway"):
 
 
 def SkipConnection(funcs, *args, **kwargs):
-    def skip(input_):
+    def skip(input_, train):
         for func in funcs:
-            proj = func(input_)
+            proj = func(input_, train)
             input_ = input_ + proj
         return input_
     return skip
@@ -181,7 +181,7 @@ def rnn_encode(rnn, input_, lengths):
     return dy.concatenate_to_batch(final_states)
 
 
-def Convolution1d(fsz, cmotsz, dsz, pc, strides=(1, 1, 1, 1), name="conv"):
+def Convolution1d(fsz, cmotsz, dsz, pc, strides=(1, 1, 1, 1), activation_type="relu", name="conv"):
     """1D Convolution.
 
     :param fsz: int, Size of conv filter.
@@ -202,8 +202,9 @@ def Convolution1d(fsz, cmotsz, dsz, pc, strides=(1, 1, 1, 1), name="conv"):
         name='weight'
     )
     bias = conv_pc.add_parameters((cmotsz), name="bias")
+    act = dynet_activation(activation_type)
 
-    def conv(input_):
+    def conv(input_, _=None):
         """Perform the 1D conv.
 
         :param input: dy.Expression ((1, T, dsz), B)
@@ -211,17 +212,18 @@ def Convolution1d(fsz, cmotsz, dsz, pc, strides=(1, 1, 1, 1), name="conv"):
         Returns:
             dy.Expression ((cmotsz,), B)
         """
-        # TODO: should be True, right?
         c = dy.conv2d_bias(input_, weight, bias, strides, is_valid=False)
-        activation = dy.rectify(c)
-        # dy.max_dim(x, d=0) is currently slow (see https://github.com/clab/dynet/issues/1011)
-        # So we do the max using max pooling instead.
-        ((_, seq_len, _), _) = activation.dim()
-        pooled = dy.maxpooling2d(activation, [1, seq_len, 1], strides)
-        mot = dy.reshape(pooled, (cmotsz,))
-        return mot
+        return act(c)
 
     return conv
+
+
+def mot_pool(x, strides=(1, 1, 1, 1)):
+    # dy.max_dim(x, d=0) is currently slow (see https://github.com/clab/dynet/issues/1011)
+    # So we do the max using max pooling instead.
+    ((_, seq_len, cmotsz), _) = x.dim()
+    pooled = dy.maxpooling2d(x, [1, seq_len, 1], strides)
+    return dy.reshape(pooled, (cmotsz,))
 
 
 def dynet_activation(name='relu'):
@@ -234,33 +236,32 @@ def dynet_activation(name='relu'):
     return dy.rectify
 
 
-def ConvEncoder(insz, outsz, filtsz, pc, activation_type='relu', name="conv-encoder"):
-    conv_pc = pc.add_subcollection(name=name)
-    fan_in = insz * filtsz
-    fan_out = outsz * filtsz
-    # Pytorch and Dynet have a gain param that has suggested values based on
-    # the nonlinearity type, this defaults to the one for relu atm.
-    glorot_bounds = 0.5 * np.sqrt(6.0 / (fan_in + fan_out))
-    weight = conv_pc.add_parameters(
-        (1, filtsz, insz, outsz),
-        init=dy.UniformInitializer(glorot_bounds),
-        name='weight'
-    )
-    bias = conv_pc.add_parameters((outsz), name="bias")
-    act = dynet_activation(activation_type)
+def ConvEncoder(filtsz, outsz, insz, pdrop, pc, layers=1, activation_type='relu'):
+    conv = Convolution1d(filtsz, outsz, insz, pc, activation_type=activation_type)
 
-    def encode(input_):
-        c = dy.conv2d_bias(input_, weight, bias, (1, 1, 1, 1), is_valid=False)
-        activation = act(c)
-        return activation
+    def encode(input_, train):
+        x = conv(input_)
+        x = dy.dropout(x, pdrop) if train else x
+        return x
 
     return encode
 
 
-def ConvEncoderStack(insz, outsz, filtsz, pdrop, pc, layers=1, activation_type='relu')
-    first_layer = ConvEncoder(insz, outsz, filtsz, pc, activation_type)
-    later_layers = [ConvEncoder(outsz, outsz, filtsz, pc, activation_type) for _ in range(layers - 1)]
-    
+def ConvEncoderStack(filtsz, outsz, insz, pdrop, pc, layers=1, activation_type='relu'):
+    first_layer = ConvEncoder(filtsz, outsz, insz, pdrop, pc, activation_type=activation_type)
+    later_layers = [ConvEncoder(filtsz, outsz, outsz, pdrop, pc, activation_type) for _ in range(layers - 1)]
+    residual = SkipConnection(later_layers)
+
+    def encode(input_, train):
+        dims = tuple([1] + list(input_.dim()[0]))
+        input_ = dy.reshape(input_, dims)
+        x = first_layer(input_, train)
+        x = residual(x, train)
+        new_shape = x.dim()[0]
+        x = dy.reshape(x, new_shape[1:])
+        return x
+
+    return encode
 
 
 def ParallelConv(filtsz, cmotsz, dsz, pc, strides=(1, 1, 1, 1), name="parallel-conv"):
@@ -269,12 +270,12 @@ def ParallelConv(filtsz, cmotsz, dsz, pc, strides=(1, 1, 1, 1), name="parallel-c
     conv_pc = pc.add_subcollection(name=name)
     convs = [Convolution1d(fsz, cmot, dsz, conv_pc, strides, name="conv-{}".format(fsz)) for fsz, cmot in zip(filtsz, cmotsz)]
 
-    def conv(input_):
+    def conv(input_, _=None):
         dims = tuple([1] + list(input_.dim()[0]))
         input_ = dy.reshape(input_, dims)
         mots = []
         for conv in convs:
-            mots.append(conv(input_))
+            mots.append(mot_pool(conv(input_)))
         return dy.concatenate(mots)
 
     return conv

--- a/python/baseline/dy/dynety.py
+++ b/python/baseline/dy/dynety.py
@@ -234,7 +234,7 @@ def dynet_activation(name='relu'):
     return dy.rectify
 
 
-def ConvEncoder(insz, outsz, filtsz, pdrop, pc, activation_type='relu', name="conv-encoder"):
+def ConvEncoder(insz, outsz, filtsz, pc, activation_type='relu', name="conv-encoder"):
     conv_pc = pc.add_subcollection(name=name)
     fan_in = insz * filtsz
     fan_out = outsz * filtsz
@@ -252,8 +252,15 @@ def ConvEncoder(insz, outsz, filtsz, pdrop, pc, activation_type='relu', name="co
     def encode(input_):
         c = dy.conv2d_bias(input_, weight, bias, (1, 1, 1, 1), is_valid=False)
         activation = act(c)
-        return [x for x in activation]
+        return activation
 
+    return encode
+
+
+def ConvEncoderStack(insz, outsz, filtsz, pdrop, pc, layers=1, activation_type='relu')
+    first_layer = ConvEncoder(insz, outsz, filtsz, pc, activation_type)
+    later_layers = [ConvEncoder(outsz, outsz, filtsz, pc, activation_type) for _ in range(layers - 1)]
+    
 
 
 def ParallelConv(filtsz, cmotsz, dsz, pc, strides=(1, 1, 1, 1), name="parallel-conv"):

--- a/python/baseline/dy/embeddings.py
+++ b/python/baseline/dy/embeddings.py
@@ -106,7 +106,7 @@ class CharConvEmbeddings(DyNetEmbeddings):
 
         def call(input_):
             x = parallel_conv(input_)
-            return gating(x)
+            return gating(x, None)
 
         return call, cmotsz_total
 

--- a/python/baseline/dy/tagger/model.py
+++ b/python/baseline/dy/tagger/model.py
@@ -81,6 +81,7 @@ class TaggerModelBase(DynetModel, TaggerModel):
     def compute_unaries(self, batch_dict):
         embed_list = self.embed(batch_dict)
         exps = self.encode(embed_list)
+        exit()
         return exps
 
     def encode(self, embed_list):
@@ -155,3 +156,22 @@ class RNNTaggerModel(TaggerModelBase):
 
     def encode(self, embed_list):
         return [self.output(out) for out in rnn_forward(self.rnn, embed_list)]
+
+
+@register_model(task='tagger', name='cnn')
+class CNNTaggerModel(TaggerModelBase):
+
+    def __init__(self, *args, **kwargs):
+        super(CNNTaggerModel, self).__init__(*args, **kwargs)
+
+    def init_envoder(self, input_sz, **kwargs):
+        layers = int(kwargs.get('layers', 1))
+        pdrop = float(kwargs.get('dropout', 0.5))
+        filesz = kwargs.get('wfiltsz', 5)
+        activation_type = kwargs.get('activation_type', 'relu')
+        hsz = int(kwargs['hsz'])
+        self.encoder = ConvEncoderStack(input_sz, hsz, filtsz, pdrop, layers, activation_type)
+        return hsz
+
+    def encode(self, embed_list):
+        pass

--- a/python/baseline/pytorch/torchy.py
+++ b/python/baseline/pytorch/torchy.py
@@ -264,8 +264,6 @@ class ConvEncoder(nn.Module):
         super(ConvEncoder, self).__init__()
         self.outsz = outsz
         pad = filtsz//2
-        print(insz.shape)
-        exit()
         self.conv = nn.Conv1d(insz, outsz, filtsz, padding=pad)
         self.act = pytorch_activation(activation_type)
         self.dropout = nn.Dropout(pdrop)

--- a/python/baseline/pytorch/torchy.py
+++ b/python/baseline/pytorch/torchy.py
@@ -264,6 +264,8 @@ class ConvEncoder(nn.Module):
         super(ConvEncoder, self).__init__()
         self.outsz = outsz
         pad = filtsz//2
+        print(insz.shape)
+        exit()
         self.conv = nn.Conv1d(insz, outsz, filtsz, padding=pad)
         self.act = pytorch_activation(activation_type)
         self.dropout = nn.Dropout(pdrop)


### PR DESCRIPTION
This PR adds a ConvEncoder to the Dynet tagger.

This moves the max over time pooling out of the Convolution1d function for more re-useability

A Quirk of this is that now we have dynet layers that have dropout inside them. This is handled easily in pytorch with the cascading in the `nn.Modules` that all dropout layers just know if they should doropout. In dynet we need to pass train into each of them. 