### PR TITLE
labels now have a mxlen

### DIFF
--- a/python/baseline/reader.py
+++ b/python/baseline/reader.py
@@ -176,16 +176,16 @@ class MultiFileParallelCorpusReader(ParallelCorpusReader):
 @exporter
 class SeqPredictReader(object):
 
-    def __init__(self, vectorizers, trim=False):
+    def __init__(self, vectorizers, trim=False, mxlen=-1, **kwargs):
+        super(SeqPredictReader, self).__init__()
         self.vectorizers = vectorizers
         self.trim = trim
-        #self.label2index = {"<PAD>": 0, "<GO>": 1, "<EOS>": 2}
         self.label2index = {
             Offsets.VALUES[Offsets.PAD]: Offsets.PAD,
             Offsets.VALUES[Offsets.GO]: Offsets.GO,
             Offsets.VALUES[Offsets.EOS]: Offsets.EOS
         }
-        self.label_vectorizer = Dict1DVectorizer(fields='y', mxlen=-1)
+        self.label_vectorizer = Dict1DVectorizer(fields='y', mxlen=mxlen)
 
     def build_vocab(self, files):
 
@@ -240,7 +240,7 @@ class SeqPredictReader(object):
 class CONLLSeqReader(SeqPredictReader):
 
     def __init__(self, vectorizers, trim=False, **kwargs):
-        super(CONLLSeqReader, self).__init__(vectorizers, trim)
+        super(CONLLSeqReader, self).__init__(vectorizers, trim, **kwargs)
         self.named_fields = kwargs.get('named_fields', {})
 
     def read_examples(self, tsfile):

--- a/python/mead/tasks.py
+++ b/python/mead/tasks.py
@@ -171,6 +171,7 @@ class Task(object):
         self._create_vectorizers()
         reader_params = self.config_params['loader']
         reader_params['clean_fn'] = reader_params.get('clean_fn', self.config_params['preproc'].get('clean_fn'))
+        reader_params['mxlen'] = self.vectorizers[self.primary_key].mxlen
         return baseline.reader.create_reader(self.task_name(), self.vectorizers, self.config_params['preproc'].get('trim', False), **reader_params)
 
     def _setup_task(self):
@@ -607,6 +608,7 @@ class LanguageModelingTask(Task):
         reader_params = self.config_params['loader']
         reader_params['nctx'] = reader_params.get('nctx', self.config_params.get('nctx', self.config_params['nbptt']))
         reader_params['clean_fn'] = reader_params.get('clean_fn', self.config_params['preproc'].get('clean_fn'))
+        reader_params['mxlen'] = self.vectorizers[self.primary_key].mxlen
         return baseline.reader.create_reader(self.task_name(), self.vectorizers, self.config_params['preproc'].get('trim', False), **reader_params)
 
     def _create_backend(self):


### PR DESCRIPTION
When a mxlen was used for tagger input it was not being applied to tagger labels (`y`). This caused size mismatches in the tensorflow crf.