### PR TITLE
Feature/tensorboard

### DIFF
--- a/python/baseline/reporting.py
+++ b/python/baseline/reporting.py
@@ -84,10 +84,18 @@ class LoggingReporting(ReportingHook):
 
 @register_reporting(name='tensorboard')
 class TensorBoardReporting(ReportingHook):
+    """Log results to tensorboard.
+
+    Writes tensorboard logs to a directory specified in the `mead-settings`
+    section for tensorboard. Otherwise it defaults to `runs`.
+    """
     def __init__(self, **kwargs):
         super(TensorBoardReporting, self).__init__(**kwargs)
         from tensorboardX import SummaryWriter
-        log_dir = kwargs.get('log_dir', 'runs')
+        base_dir = kwargs.get('base_dir', '.')
+        log_dir = os.path.expanduser(kwargs.get('log_dir', 'runs'))
+        if not os.path.isabs(log_dir):
+            log_dir = os.path.join(base_dir, log_dir)
         log_dir = os.path.join(log_dir, str(os.getpid()))
         flush_secs = int(kwargs.get('flush_secs', 2))
         self._log = SummaryWriter(log_dir, flush_secs=flush_secs)

--- a/python/mead/tasks.py
+++ b/python/mead/tasks.py
@@ -238,7 +238,7 @@ class Task(object):
 
         self.reporting = baseline.create_reporting(reporting_hooks,
                                                    reporting,
-                                                   {'config_file': self.config_file, 'task': self.__class__.task_name()})
+                                                   {'config_file': self.config_file, 'task': self.__class__.task_name(), 'base_dir': self.get_basedir()})
 
         self.config_params['train']['reporting'] = [x.step for x in self.reporting]
         logging.basicConfig(level=logging.DEBUG)

--- a/python/setup_baseline.py
+++ b/python/setup_baseline.py
@@ -71,7 +71,9 @@ def main():
             'requests',
         ],
         extras_require={
-            'test': ['pytest', 'mock', 'contextdecorator', 'pytest-forked']
+            'test': ['pytest', 'mock', 'contextdecorator', 'pytest-forked'],
+            'report': ['visdom', 'tensorboardX'],
+            'yaml': ['pyyaml'],
         },
         entry_points={
             'console_scripts': [

--- a/python/tests/test_reporting_hooks.py
+++ b/python/tests/test_reporting_hooks.py
@@ -1,0 +1,60 @@
+import os
+import string
+import pytest
+from mock import patch
+import numpy as np
+import baseline.reporting
+from baseline.reporting import TensorBoardReporting
+
+
+def random_str(len_=None, min_=5, max_=21):
+    if len_ is None:
+        len_ = np.random.randint(min_, max_)
+    choices = list(string.ascii_letters + string.digits)
+    return ''.join([np.random.choice(choices) for _ in range(len_)])
+
+
+@pytest.fixture
+def patches():
+    pid = np.random.randint(0, 10)
+    with patch('baseline.reporting.os.getpid') as pid_patch:
+        pid_patch.return_value = pid
+        with patch('tensorboardX.SummaryWriter') as write_patch:
+            yield pid_patch, pid, write_patch
+
+
+def test_no_base_dir(patches):
+    p_patch, pid, w_patch = patches
+    log_dir = random_str()
+    _ = TensorBoardReporting(log_dir=log_dir, flush_secs=2)
+    gold = os.path.join('.', log_dir, str(pid))
+    w_patch.assert_called_once_with(gold, flush_secs=2)
+
+
+def test_relative_log_dir(patches):
+    p_patch, pid, w_patch = patches
+    log_dir = random_str()
+    base_dir = random_str()
+    _ = TensorBoardReporting(log_dir=log_dir, flush_secs=2, base_dir=base_dir)
+    gold = os.path.join(base_dir, log_dir, str(pid))
+    w_patch.assert_called_once_with(gold, flush_secs=2)
+
+
+def test_user_log_dir(patches):
+    p_patch, pid, w_patch = patches
+    log_dir = random_str()
+    log_dir = os.path.join("~", log_dir)
+    base_dir = random_str()
+    _ = TensorBoardReporting(log_dir=log_dir, flush_secs=2, base_dir=base_dir)
+    gold = os.path.join(os.path.expanduser(log_dir), str(pid))
+    w_patch.assert_called_once_with(gold, flush_secs=2)
+
+
+def test_absolute_log_dir(patches):
+    p_patch, pid, w_patch = patches
+    log_dir = random_str()
+    log_dir = os.path.join("/example", log_dir)
+    base_dir = random_str()
+    _ = TensorBoardReporting(log_dir=log_dir, flush_secs=2, base_dir=base_dir)
+    gold = os.path.join(log_dir, str(pid))
+    w_patch.assert_called_once_with(gold, flush_secs=2)

--- a/python/tests/test_reporting_hooks.py
+++ b/python/tests/test_reporting_hooks.py
@@ -2,6 +2,7 @@ import os
 import string
 import pytest
 from mock import patch
+pytest.importorskip('tensorboardX')
 import numpy as np
 import baseline.reporting
 from baseline.reporting import TensorBoardReporting


### PR DESCRIPTION
Update tensorboard reporting to work again and to use tensorboardX. It seems more full featured.

This PR sets the log dir to be within the basedir where the model weights and vocabs are written when the log dir is a relative directory. If the log dir is absolute then it is used as it.

This makes sense to me because it tensorboard logs from various tasks grouped together seems odd. However it is a bit of a departure for somethings like `reporting-{pid}.log` which is written into `cwd`