### PR TITLE
Feature/global train flag

### DIFF
--- a/python/addons/classify_elmo.py
+++ b/python/addons/classify_elmo.py
@@ -65,11 +65,11 @@ class ELMoClassifierModel(ClassifierModel):
             results.append(outcomes)
         return results
 
-    def make_input(self, batch_dict, do_dropout=False):
+    def make_input(self, batch_dict, train=False):
         x = batch_dict['x']
         y = batch_dict['y']
         lengths = batch_dict['lengths']
-        pkeep = 1.0 - self.pdrop_value if do_dropout else 1
+        pkeep = 1.0 - self.pdrop_value if train else 1
         return {self.x: x, self.lengths: lengths, self.y: fill_y(len(self.labels), y), self.pkeep: pkeep}
 
     def get_labels(self):

--- a/python/addons/demolib.py
+++ b/python/addons/demolib.py
@@ -128,7 +128,7 @@ class NStepProgressClassifyTrainerTf(Trainer):
         total_loss = 0
         steps = len(loader)
         for batch_dict in loader:
-            feed_dict = self.model.make_input(batch_dict, do_dropout=True)
+            feed_dict = self.model.make_input(batch_dict, train=True)
             _, step, lossv = self.sess.run([self.train_op, self.global_step, self.loss], feed_dict=feed_dict)
             total_loss += lossv
             if step % self.nsteps == 0:

--- a/python/addons/tagger_elmo.py
+++ b/python/addons/tagger_elmo.py
@@ -40,7 +40,7 @@ class RNNTaggerModelELMoModel(TaggerModel):
         with open(basename + '-char.vocab', 'w') as f:
             json.dump(self.char_vocab, f)
 
-    def make_input(self, batch_dict, do_dropout=False):
+    def make_input(self, batch_dict, train=False):
         x = batch_dict['x']
         x_lc = batch_dict['x_lc']
         #np.set_printoptions(threshold=20)
@@ -48,7 +48,7 @@ class RNNTaggerModelELMoModel(TaggerModel):
         xch = batch_dict['xch']
         lengths = batch_dict['lengths']
 
-        pkeep = 1.0-self.pdrop_value if do_dropout else 1.0
+        pkeep = 1.0-self.pdrop_value if train else 1.0
         feed_dict = {self.x: x, self.x_lc: x_lc, self.xch: xch, self.lengths: lengths, self.pkeep: pkeep}
         if y is not None:
             feed_dict[self.y] = y

--- a/python/addons/tagger_gazetteer.py
+++ b/python/addons/tagger_gazetteer.py
@@ -37,14 +37,14 @@ class RNNTaggerModelGazetteerModel(Tagger):
         with open(basename + '-gaz.vocab', 'w') as f:
             json.dump(self.gazette_vocab, f)
 
-    def make_input(self, batch_dict, do_dropout=False):
+    def make_input(self, batch_dict, train=False):
         x = batch_dict['x']
         y = batch_dict.get('y', None)
         xch = batch_dict['xch']
         lengths = batch_dict['lengths']
         word_gazette = batch_dict["gaz"]
 
-        pkeep = 1.0-self.pdrop_value if do_dropout else 1.0
+        pkeep = 1.0-self.pdrop_value if train else 1.0
         feed_dict = {self.x: x, self.xch: xch, self.gaz: word_gazette, self.lengths: lengths, self.pkeep: pkeep}
         if y is not None:
             feed_dict[self.y] = y

--- a/python/baseline/pytorch/classify/model.py
+++ b/python/baseline/pytorch/classify/model.py
@@ -50,7 +50,6 @@ class ClassifierModelBase(nn.Module, ClassifierModel):
         """Transform a `batch_dict` into something usable in this model
 
         :param batch_dict: (``dict``) A dictionary containing all inputs to the embeddings for this model
-        :param do_dropout: (``bool``) Should we do dropout.  Defaults to False
         :return:
         """
         example_dict = dict({})

--- a/python/baseline/tf/classify/model.py
+++ b/python/baseline/tf/classify/model.py
@@ -64,7 +64,6 @@ class ClassifyParallelModel(ClassifierModel):
 
                 kwargs_single = copy.deepcopy(kwargs)
                 kwargs_single['sess'] = sess
-                kwargs_single['training'] = 1
 
                 for k, split_operation in split_operations.items():
                     kwargs_single[k] = split_operation[i]
@@ -220,7 +219,7 @@ class ClassifierModelBase(ClassifierModel):
         """Transform a `batch_dict` into a TensorFlow `feed_dict`
 
         :param batch_dict: (``dict``) A dictionary containing all inputs to the embeddings for this model
-        :param do_dropout: (``bool``) Should we do dropout.  Defaults to False
+        :param train: (``bool``) Are we training.  Defaults to False
         :return:
         """
         y = batch_dict.get('y', None)
@@ -298,7 +297,6 @@ class ClassifierModelBase(ClassifierModel):
 
         else:
             model.lengths = None
-        model.training = tf.get_default_graph().get_tensor_by_name('training:0')
         model.probs = tf.get_default_graph().get_tensor_by_name('output/probs:0')
 
         model.best = tf.get_default_graph().get_tensor_by_name('output/best:0')

--- a/python/baseline/tf/classify/model.py
+++ b/python/baseline/tf/classify/model.py
@@ -375,7 +375,6 @@ class ClassifierModelBase(ClassifierModel):
         nc = len(labels)
         model.y = kwargs.get('y', tf.placeholder(tf.int32, [None, nc], name="y"))
         # This only exists to make exporting easier
-        model.training = kwargs.get('training', tf.placeholder_with_default(0, shape=(), name="training"))
         model.pdrop_value = kwargs.get('dropout', 0.5)
         # This only exists to make exporting easier
 

--- a/python/baseline/tf/classify/train.py
+++ b/python/baseline/tf/classify/train.py
@@ -38,7 +38,7 @@ class ClassifyTrainerTf(EpochReportingTrainer):
         steps = len(loader)
         pg = create_progress_bar(steps)
         for batch_dict in loader:
-            feed_dict = self.model.make_input(batch_dict, do_dropout=True)
+            feed_dict = self.model.make_input(batch_dict, True)
             _, step, lossv = self.sess.run([self.train_op, self.global_step, self.loss], feed_dict=feed_dict)
             total_loss += lossv
             pg.update()

--- a/python/baseline/tf/lm/model.py
+++ b/python/baseline/tf/lm/model.py
@@ -19,7 +19,7 @@ class LanguageModelBase(LanguageModel):
     def pkeep(self):
         """This property is provided for models that wish to access the default `pdrop_value` property.
 
-        The property here uses `pdrop_value` and the `training` flag to determine how much dropout to apply (if any)
+        The property here uses `pdrop_value` and the `TRAIN_FLAG` to determine how much dropout to apply (if any)
 
         :return:
         """
@@ -103,7 +103,6 @@ class LanguageModelBase(LanguageModel):
         lm.y = kwargs.get('y', tf.placeholder(tf.int32, [None, None], name="y"))
         lm.batchsz = kwargs['batchsz']
         lm.sess = kwargs.get('sess', tf.Session())
-        lm.training = kwargs.get('training', tf.placeholder(tf.int32, name="training"))
         lm.pdrop_value = kwargs.get('pdrop', 0.5)
         lm.hsz = kwargs['hsz']
         lm.tgt_key = kwargs.get('tgt_key')

--- a/python/baseline/tf/lm/model.py
+++ b/python/baseline/tf/lm/model.py
@@ -10,11 +10,20 @@ from google.protobuf import text_format
 class LanguageModelBase(LanguageModel):
 
     def __init__(self):
-        self.pkeep = None
         self.saver = None
         self.layers = None
         self.hsz = None
         self.probs = None
+
+    @property
+    def pkeep(self):
+        """This property is provided for models that wish to access the default `pdrop_value` property.
+
+        The property here uses `pdrop_value` and the `training` flag to determine how much dropout to apply (if any)
+
+        :return:
+        """
+        return 1.0 - self.pdrop_value * TRAIN_FLAG()
 
     def save_using(self, saver):
         self.saver = saver
@@ -67,10 +76,9 @@ class LanguageModelBase(LanguageModel):
             loss = tf.reduce_sum(example_loss) / self.batchsz
             return loss
 
-    def make_input(self, batch_dict, do_dropout=False):
+    def make_input(self, batch_dict, train=False):
 
-        pkeep = 1.0 - self.pdrop_value if do_dropout else 1.0
-        feed_dict = {self.pkeep: pkeep}
+        feed_dict = new_placeholder_dict(train)
 
         for key in self.embeddings.keys():
 
@@ -95,9 +103,8 @@ class LanguageModelBase(LanguageModel):
         lm.y = kwargs.get('y', tf.placeholder(tf.int32, [None, None], name="y"))
         lm.batchsz = kwargs['batchsz']
         lm.sess = kwargs.get('sess', tf.Session())
-        lm.pkeep = kwargs.get('pkeep', tf.placeholder(tf.float32, name="pkeep"))
-        pdrop = kwargs.get('pdrop', 0.5)
-        lm.pdrop_value = pdrop
+        lm.training = kwargs.get('training', tf.placeholder(tf.int32, name="training"))
+        lm.pdrop_value = kwargs.get('pdrop', 0.5)
         lm.hsz = kwargs['hsz']
         lm.tgt_key = kwargs.get('tgt_key')
         if lm.tgt_key is None:

--- a/python/baseline/tf/seq2seq/model.py
+++ b/python/baseline/tf/seq2seq/model.py
@@ -85,13 +85,14 @@ class Seq2SeqParallelModel(EncoderDecoderModel):
         losses = []
         sess = tf.Session(config=tf.ConfigProto(allow_soft_placement=True, log_device_placement=False))
         with tf.device(tf.DeviceSpec(device_type="CPU")):
-            self.inference = create_fn(src_embeddings, tgt_embedding, sess=sess, mx_tgt_len=self.mx_tgt_len, pkeep=self.pkeep, id=1, **kwargs)
+            self.inference = create_fn(src_embeddings, tgt_embedding, sess=sess,
+                                       mx_tgt_len=self.mx_tgt_len, training=0, id=1, **kwargs)
         for i in range(gpus):
             with tf.device(tf.DeviceSpec(device_type='GPU', device_index=i)):
 
                 kwargs_single = copy.deepcopy(kwargs)
                 kwargs_single['sess'] = sess
-                kwargs_single['pkeep'] = self.pkeep
+                kwargs_single['training'] = 1
                 kwargs_single['id'] = i + 1
                 for k, split_operation in split_operations.items():
                     kwargs_single[k] = split_operation[i]
@@ -124,15 +125,18 @@ class Seq2SeqParallelModel(EncoderDecoderModel):
         """
         return self.inference.step(batch_dict)
 
-    def make_input(self, batch_dict, do_dropout=False):
-        if do_dropout is False:
+    def make_input(self, batch_dict, train=False):
+        if train is False:
             return self.inference.make_input(batch_dict)
+
+        feed_dict = new_placeholder_dict(train)
 
         tgt = batch_dict.get['tgt']
         tgt_len = batch_dict['tgt_len']
         mx_tgt_len = np.max(tgt_len)
-        pkeep = 1.0 - self.pdrop_value if do_dropout else 1.0
-        feed_dict = {self.pkeep: pkeep, "tgt:0": tgt, self.tgt_len: tgt_len, self.mx_tgt_len: mx_tgt_len}
+        feed_dict["tgt:0"] = tgt
+        feed_dict[self.tgt_len] = tgt_len
+        feed_dict[self.mx_tgt_len] = mx_tgt_len
 
         for key in self.parallel_params.keys():
             feed_dict["{}_parallel:0".format(key)] = batch_dict[key]
@@ -231,7 +235,7 @@ class EncoderDecoderModelBase(EncoderDecoderModel):
         model.id = kwargs.get('id', 0)
         model.sess = kwargs.get('sess', tf.Session())
         model.pdrop_value = kwargs.get('dropout', 0.5)
-        model.pkeep = kwargs.get('pkeep', tf.placeholder_with_default(1.0, shape=(), name="pkeep"))
+        model.training = kwargs.get('training', tf.placeholder_with_default(0, shape=(), name="training"))
         model.layers = kwargs.get('layers', 1)
         model.hsz = kwargs['hsz']
 
@@ -252,6 +256,16 @@ class EncoderDecoderModelBase(EncoderDecoderModel):
     @src_lengths_key.setter
     def src_lengths_key(self, value):
         self._src_lengths_key = value
+
+    @property
+    def pkeep(self):
+        """This property is provided for models that wish to access the default `pdrop_value` property.
+
+        The property here uses `pdrop_value` and the `training` flag to determine how much dropout to apply (if any)
+
+        :return:
+        """
+        return 1.0 - self.pdrop_value * TRAIN_FLAG()
 
     def create_encoder(self, **kwargs):
         return create_seq2seq_encoder(**kwargs)
@@ -330,10 +344,9 @@ class EncoderDecoderModelBase(EncoderDecoderModel):
         x = self.sess.run(self.decoder.probs, feed_dict=feed_dict)
         return x
 
-    def make_input(self, batch_dict, do_dropout=False):
+    def make_input(self, batch_dict, train=False):
 
-        pkeep = 1.0 - self.pdrop_value if do_dropout else 1.0
-        feed_dict = {self.pkeep: pkeep}
+        feed_dict = new_placeholder_dict(train)
 
         for key in self.src_embeddings.keys():
             feed_dict["{}:0".format(key)] = batch_dict[key]

--- a/python/baseline/tf/seq2seq/model.py
+++ b/python/baseline/tf/seq2seq/model.py
@@ -86,13 +86,12 @@ class Seq2SeqParallelModel(EncoderDecoderModel):
         sess = tf.Session(config=tf.ConfigProto(allow_soft_placement=True, log_device_placement=False))
         with tf.device(tf.DeviceSpec(device_type="CPU")):
             self.inference = create_fn(src_embeddings, tgt_embedding, sess=sess,
-                                       mx_tgt_len=self.mx_tgt_len, training=0, id=1, **kwargs)
+                                       mx_tgt_len=self.mx_tgt_len, id=1, **kwargs)
         for i in range(gpus):
             with tf.device(tf.DeviceSpec(device_type='GPU', device_index=i)):
 
                 kwargs_single = copy.deepcopy(kwargs)
                 kwargs_single['sess'] = sess
-                kwargs_single['training'] = 1
                 kwargs_single['id'] = i + 1
                 for k, split_operation in split_operations.items():
                     kwargs_single[k] = split_operation[i]
@@ -235,7 +234,6 @@ class EncoderDecoderModelBase(EncoderDecoderModel):
         model.id = kwargs.get('id', 0)
         model.sess = kwargs.get('sess', tf.Session())
         model.pdrop_value = kwargs.get('dropout', 0.5)
-        model.training = kwargs.get('training', tf.placeholder_with_default(0, shape=(), name="training"))
         model.layers = kwargs.get('layers', 1)
         model.hsz = kwargs['hsz']
 
@@ -261,7 +259,7 @@ class EncoderDecoderModelBase(EncoderDecoderModel):
     def pkeep(self):
         """This property is provided for models that wish to access the default `pdrop_value` property.
 
-        The property here uses `pdrop_value` and the `training` flag to determine how much dropout to apply (if any)
+        The property here uses `pdrop_value` and the `TRAIN_FLAG()` to determine how much dropout to apply (if any)
 
         :return:
         """

--- a/python/baseline/tf/seq2seq/train.py
+++ b/python/baseline/tf/seq2seq/train.py
@@ -49,7 +49,7 @@ class Seq2SeqTrainerTf(Trainer):
         for batch_dict in ts:
             start_time = time.time()
             steps += 1
-            feed_dict = self.model.make_input(batch_dict, do_dropout=True)
+            feed_dict = self.model.make_input(batch_dict, True)
             vals = self.model.sess.run(fetches, feed_dict=feed_dict)
             global_step = vals["global_step"]
             lossv = vals["loss"]

--- a/python/baseline/tf/tagger/model.py
+++ b/python/baseline/tf/tagger/model.py
@@ -22,6 +22,16 @@ class TaggerModelBase(TaggerModel):
     def lengths_key(self, value):
         self._lengths_key = value
 
+    @property
+    def pkeep(self):
+        """This property is provided for models that wish to access the default `pdrop_value` property.
+
+        The property here uses `pdrop_value` and the `training` flag to determine how much dropout to apply (if any)
+
+        :return:
+        """
+        return 1.0 - self.pdrop_value * TRAIN_FLAG()
+
     def save_values(self, basename):
         self.saver.save(self.sess, basename)
 
@@ -65,13 +75,13 @@ class TaggerModelBase(TaggerModel):
             x[drop_indices[0], drop_indices[1]] = TaggerModelBase.UNK
         return x
 
-    def make_input(self, batch_dict, do_dropout=False):
+    def make_input(self, batch_dict, train=False):
+        feed_dict = new_placeholder_dict(train)
+        for k in self.embeddings.keys():
+            feed_dict["{}:0".format(k)] = batch_dict[k]
         y = batch_dict.get('y', None)
 
-        feed_dict = {"{}:0".format(k): batch_dict[k] for k in self.embeddings.keys()}
         #feed_dict = {v.x: self.drop_inputs(k, batch_dict[k], do_dropout) for k, v in self.embeddings.items()}
-        pkeep = 1.0 - self.pdrop_value if do_dropout else 1.0
-        feed_dict[self.pkeep] = pkeep
 
         # Allow us to track a length, which is needed for BLSTMs
         feed_dict[self.lengths] = batch_dict[self.lengths_key]
@@ -140,7 +150,6 @@ class TaggerModelBase(TaggerModel):
         model.lengths = tf.get_default_graph().get_tensor_by_name('lengths:0')
 
         model.y = tf.get_default_graph().get_tensor_by_name('y:0')
-        model.pkeep = tf.get_default_graph().get_tensor_by_name('pkeep:0')
         model.probs = tf.get_default_graph().get_tensor_by_name('output/probs:0')
         model.best = tf.get_default_graph().get_tensor_by_name('output/best:0')
 
@@ -229,7 +238,6 @@ class TaggerModelBase(TaggerModel):
                 else:
                     self._create_word_level_decode()
 
-
         return all_loss
 
     def __init__(self):
@@ -271,7 +279,6 @@ class TaggerModelBase(TaggerModel):
         nc = len(labels)
         model.y = kwargs.get('y', tf.placeholder(tf.int32, [None, None], name="y"))
         # This only exists to make exporting easier
-        model.pkeep = kwargs.get('pkeep', tf.placeholder_with_default(1.0, shape=(), name="pkeep"))
         model.pdrop_value = kwargs.get('dropout', 0.5)
         model.dropin_value = kwargs.get('dropin', {})
         model.sess = kwargs.get('sess', tf.Session())

--- a/python/baseline/tf/tagger/model.py
+++ b/python/baseline/tf/tagger/model.py
@@ -78,7 +78,7 @@ class TaggerModelBase(TaggerModel):
     def make_input(self, batch_dict, train=False):
         feed_dict = new_placeholder_dict(train)
         for k in self.embeddings.keys():
-            feed_dict["{}:0".format(k)] = batch_dict[k]
+            feed_dict["{}:0".format(k)] = self.drop_inputs(k, batch_dict[k], train)
         y = batch_dict.get('y', None)
 
         #feed_dict = {v.x: self.drop_inputs(k, batch_dict[k], do_dropout) for k, v in self.embeddings.items()}

--- a/python/baseline/tf/tagger/model.py
+++ b/python/baseline/tf/tagger/model.py
@@ -68,6 +68,14 @@ class TaggerModelBase(TaggerModel):
     UNK = 1
     PAD = 0
 
+    @property
+    def dropin_value(self):
+        return self._dropin_value
+
+    @dropin_value.setter
+    def dropin_value(self, dict_value):
+        self._dropin_value = dict_value
+
     def drop_inputs(self, key, x, do_dropout):
         v = self.dropin_value.get(key, 0)
         if do_dropout and v > 0.0:

--- a/python/baseline/tf/tagger/train.py
+++ b/python/baseline/tf/tagger/train.py
@@ -119,7 +119,7 @@ class TaggerTrainerTf(EpochReportingTrainer):
         metrics = {}
         pg = create_progress_bar(steps)
         for batch_dict in ts:
-            feed_dict = self.model.make_input(batch_dict, do_dropout=True)
+            feed_dict = self.model.make_input(batch_dict, True)
             _, step, lossv = self.model.sess.run([self.train_op, self.global_step, self.loss], feed_dict=feed_dict)
             total_loss += lossv
             pg.update()

--- a/python/baseline/tf/tfy.py
+++ b/python/baseline/tf/tfy.py
@@ -6,6 +6,26 @@ from baseline.utils import lookup_sentence, beam_multinomial, crf_mask as crf_m,
 import math
 
 
+BASELINE_TF_TRAIN_FLAG = None
+
+
+def TRAIN_FLAG():
+    """Create a global training flag on first use"""
+    global BASELINE_TF_TRAIN_FLAG
+    if BASELINE_TF_TRAIN_FLAG is not None:
+        return BASELINE_TF_TRAIN_FLAG
+
+    BASELINE_TF_TRAIN_FLAG = tf.placeholder_with_default(0.0, shape=(), name="TRAIN_FLAG")
+    return BASELINE_TF_TRAIN_FLAG
+
+
+def new_placeholder_dict(train):
+    global BASELINE_TF_TRAIN_FLAG
+    if train:
+        return {BASELINE_TF_TRAIN_FLAG: 1}
+    return {}
+
+
 def _add_ema(model, decay):
     """Create ops needed to track EMA when training.
 

--- a/python/baseline/utils.py
+++ b/python/baseline/utils.py
@@ -445,7 +445,7 @@ def write_json(content, filepath):
 
 @exporter
 def ls_props(thing):
-    return [x for x in dir(thing) if isinstance(getattr(type(thing), x, None), property)]
+    return [x for x in dir(thing) if isinstance(getattr(type(thing), x, None), property) and not x.startswith('pkeep')]
 
 
 @exporter


### PR DESCRIPTION
- This change would create a global `TRAIN_FLAG()` method in `tfy.py` and an accompanying global singleton variable
- The downstream models `make_input()` second argument would be renamed from `do_dropout` to `train`
- The `.pkeep` attribute becomes a computed property of `1.0 - self.pdrop_value * TRAIN_FLAG()` which can optionally be used by models
- The `ls_props()` function knows not to list any `pkeep*` props so it doesnt accidentally write this computed property
- If a user wishes to add their own dropout values, these can follow the exact same pattern as the `.pkeep` pattern -- use `1.0 - my_dropout * TRAIN_FLAGS()` anywhere in any sub-graph