### PR TITLE
Feature/nstep

### DIFF
--- a/docs/baseline.md
+++ b/docs/baseline.md
@@ -69,3 +69,7 @@ If you have a problem where the input is the same as a `baseline` task, you can 
 
 Then pass `--model_type {model}` to the driver program for that task.  The driver program will look to see if it has an implementation within the library and will not find the one in its registry.  So it will import the module and call its `create_model` function with the arguments and use the provided model.
 
+
+#### A note about losses and reporting
+
+When tracking losses for reporting the average on the loss is undone and the total loss is tracked. At the end of the epoch this total loss is averaged over all of the examples seen. This allows for statistically correct reporting when the size of a batch is variable. NStep reporting can stride dev evaluations so it is possible for there to be a spike in nstep times if that step happens to have a dev set evaluation run during it.

--- a/docs/classify.md
+++ b/docs/classify.md
@@ -106,3 +106,13 @@ It was run on the latest code as of 8/24/2017, with 25 epochs with adadelta as a
 Note that these are randomly initialized and these numbers will vary
 (IOW, don't assume that one implementation is guaranteed to outperform the others from a single run).
 
+
+#### Losses and Reporting
+
+When training the loss that is optimized is the total loss averaged over the number of examples in the mini-batch.
+
+When reporting the loss reported every nsteps is the total loss averaged over the number of examples that appeared in these nsteps number of minibatches.
+
+When reporting the loss at the end of an epoch it is the total loss averaged over the number of examples seen in the whole epoch.
+
+Metrics like accuracy and f1 are computed at the example level.

--- a/docs/lm.md
+++ b/docs/lm.md
@@ -24,3 +24,11 @@ As noted above, the run above differs in that it uses pre-trained word vectors.
 | Word Med (Zaremba) | TensorFlow | 80.168 | 77.2213 |
 
 _TODO: Add LSTM Char Small Configuration results_
+
+#### Losses and Reporting
+
+The loss that is optimized is the total loss divided by the total number of tokens in the mini-batch (token level loss). This is different than how the loss is calculated in Tensorflow Tutorial but it is how the loss is calculated in awd-lm ([Merity et. al, 2017](https://arxiv.org/abs/1708.02182)), Elmo ([Peters et. al., 2018](https://arxiv.org/abs/1802.05365)), OpenAI GPT ([Radford et. al., 2018](https://s3-us-west-2.amazonaws.com/openai-assets/research-covers/language-unsupervised/language_understanding_paper.pdf)), and BERT ([Devlin et. al., 2018](https://arxiv.org/pdf/1810.04805.pdf))
+
+When reporting the loss every nsteps it is the total loss divided by the total number of tokens in the last nstep number of mini-batches. The perplexity is e to this loss.
+
+The epoch loss is the total loss averaged over the total number of tokens in the whole epoch. The perplexity is e to this loss. This results in token level perplexity which is standard reporting in the literature.

--- a/docs/seq2seq.md
+++ b/docs/seq2seq.md
@@ -22,3 +22,11 @@ The English-Vietnamese dataset is from https://nlp.stanford.edu/projects/nmt/ an
 | iwslt15-en-vi  |  BLEU  | adam   |  0.001   | TensorFlow | 25.21  | blstm   |      2 |     0.5 |   512  |  512  |    16  |
 | newstest2015.(de\|en) | BLEU | adam | 0.001  | TensorFlow | 27.92  | blstm   |      4 |     0.5 |   512  |  512  |    12  |
 
+
+#### Losses and Reporting
+
+The loss that is optimized is the total loss divided by the total number of non-masked tokens in the mini-batch (token level loss).
+
+When reporting the loss every nsteps it is the total loss divided by the total number of non-masked tokens in the last nstep number of mini-batches. The perplexity is e to this loss.
+
+The epoch loss is the total loss averaged over the total number of non-masked tokens in the whole epoch. The perplexity is e to this loss.

--- a/docs/tagging.md
+++ b/docs/tagging.md
@@ -79,4 +79,15 @@ You can write your own featurizer (`featurizer_<featurizer_type>.py`) and keep i
 python tag.py --input elmo-tester.conll --output elmo-tester-out.conll --model mead/elmo-2/tagger-model-tf-2658 --mxlen 60 --mxwlen 40 --model_type elmo --featurizer_type elmo
 ```
 
-We support loading tagger models defined in [TensorFlow](../python/baseline/tf/tagger/model.py) and [PyTorch](../python/baseline/pytorch/tagger/model.py). 
+We support loading tagger models defined in [TensorFlow](../python/baseline/tf/tagger/model.py) and [PyTorch](../python/baseline/pytorch/tagger/model.py).
+
+
+#### Losses and Reporting
+
+The loss that is optimized depends on if a Conditional Random Field (CRF) is used or not. If a CRF is used then the loss is the crf loss averaged over the number of examples in the mini-batch. When using a word level loss the loss is the sum of the cross entropy loss of each token averaged over the number of examples in the mini-batch. Both of these are batch level losses.
+
+When reporting the loss every nsteps for the crf the loss is the total crf loss divided by the number of examples in the last nstep number of mini-batches. For word level loss it is the total word level loss divided by the number of examples in the last nstep number of batches.
+
+The epoch loss is the total loss averaged over the total number of examples in the epoch.
+
+Accuracy is computed on the token level and F1 is computed on the span level.

--- a/python/addons/reporting_xpctl.py
+++ b/python/addons/reporting_xpctl.py
@@ -3,13 +3,13 @@ from __future__ import print_function
 import os
 import getpass
 import socket
-from baseline.reporting import ReportingHook
+from baseline.reporting import EpochReportingHook
 from mead.utils import read_config_file_or_json
 from xpctl.core import ExperimentRepo
 from baseline.reporting import register_reporting
 
 @register_reporting(name='xpctl')
-class XPCtlReporting(ReportingHook):
+class XPCtlReporting(EpochReportingHook):
     def __init__(self, **kwargs):
         super(XPCtlReporting, self).__init__(**kwargs)
         # throw exception if the next three can't be read from kwargs
@@ -27,7 +27,7 @@ class XPCtlReporting(ReportingHook):
         self.repo = ExperimentRepo().create_repo(**self.cred)
         self.log = []
 
-    def step(self, metrics, tick, phase, tick_type=None, **kwargs):
+    def _step(self, metrics, tick, phase, tick_type, **kwargs):
         """Write intermediate results to a logging memory object that ll be pushed to the xpctl repo
 
         :param metrics: A map of metrics to scores
@@ -36,11 +36,6 @@ class XPCtlReporting(ReportingHook):
         :param tick_type: The resolution of tick (`STEP`, `EPOCH`)
         :return:
         """
-        if tick_type is None:
-            tick_type = 'STEP'
-            if phase in ['Valid', 'Test']:
-                tick_type = 'EPOCH'
-
         msg = {'tick_type': tick_type, 'tick': tick, 'phase': phase}
         for k, v in metrics.items():
             msg[k] = v

--- a/python/baseline/dy/dynety.py
+++ b/python/baseline/dy/dynety.py
@@ -141,7 +141,7 @@ class Linear(DynetLayer):
         self.weight = self.pc.add_parameters((osz, isz), name="weight")
         self.bias = self.pc.add_parameters((osz,), name="bias")
 
-    def __call__(self, input_, train=None):
+    def __call__(self, input_, train=False):
         """
         :param input_: dy.Expression ((isz,), B)
 

--- a/python/baseline/dy/lm/train.py
+++ b/python/baseline/dy/lm/train.py
@@ -15,7 +15,6 @@ class LanguageModelTrainerDynet(Trainer):
         super(LanguageModelTrainerDynet, self).__init__()
         self.model = model
         self.optimizer = OptimizerManager(model, **kwargs)
-        self.log = logging.getLogger('baseline.timing')
         self.nsteps = kwargs.get('nsteps', 500)
 
     @staticmethod

--- a/python/baseline/dy/optz.py
+++ b/python/baseline/dy/optz.py
@@ -34,11 +34,13 @@ class CyclicLRSchedulerDyNet(CyclicLRScheduler):
     def __init__(self, *args, **kwargs):
         super(CyclicLRSchedulerDyNet, self).__init(*args, **kwargs)
 
+
 @register_lr_scheduler(name='piecewise')
 class PiecewiseDecaySchedulerDyNet(PiecewiseDecayScheduler):
 
     def __init__(self, *args, **kwargs):
         super(PiecewiseDecaySchedulerDyNet, self).__init__(*args, **kwargs)
+
 
 @register_lr_scheduler(name='zaremba')
 class ZarembaDecaySchedulerDyNet(ZarembaDecayScheduler):
@@ -52,6 +54,7 @@ class CosineDecaySchedulerDyNet(CosineDecayScheduler):
 
     def __init__(self, *args, **kwargs):
         super(CosineDecaySchedulerDyNet, self).__init__(*args, **kwargs)
+
 
 @register_lr_scheduler(name='invtime')
 class InverseTimeDecaySchedulerDyNet(InverseTimeDecayScheduler):
@@ -79,8 +82,16 @@ class OptimizerManager(object):
         self.lr_function = create_lr_scheduler(**kwargs)
         self._init_optimizer(model, **kwargs)
 
+    @property
+    def global_step(self):
+        return self._global_step
+
+    @global_step.setter
+    def global_step(self, value):
+        self._global_step = value
+
     def _init_optimizer(self, model, **kwargs):
-        mom = float(kwargs.get('mom',0.0))
+        mom = float(kwargs.get('mom', 0.0))
         optim = kwargs.get('optim', 'sgd')
         clip = kwargs.get('clip')
 
@@ -116,7 +127,3 @@ class OptimizerManager(object):
 
     def zero_grad(self):
         self.optimizer.zero_grad()
-
-
-
-

--- a/python/baseline/dy/optz.py
+++ b/python/baseline/dy/optz.py
@@ -99,7 +99,7 @@ class OptimizerManager(object):
         if optim == 'adadelta':
             self.optimizer = dy.AdadeltaTrainer(model.pc)
         elif optim == 'adam':
-            self.optimizer = dy.AdamTrainer(model.pc, beta_1=kwargs.get('beta1', 0.9), beta_2=kwargs.get('beta2', 0.999), eps=kwargs.get('epsilon', 1e-8))
+            self.optimizer = dy.AdamTrainer(model.pc, alpha=self.current_lr, beta_1=kwargs.get('beta1', 0.9), beta_2=kwargs.get('beta2', 0.999), eps=kwargs.get('epsilon', 1e-8))
         elif optim == 'rmsprop':
             self.optimizer = dy.RMSPropTrainer(model.pc, learning_rate=self.current_lr)
         else:

--- a/python/baseline/dy/seq2seq/decoders.py
+++ b/python/baseline/dy/seq2seq/decoders.py
@@ -114,6 +114,10 @@ layer's hidden size == embedding weight dimensions")
         return self.output(output)
 
     def decode_rnn(self, context, h_i, output_i, dst, src_mask, train):
+        if train:
+            self.decoder_rnn.set_dropout(self.pdrop)
+        else:
+            self.decoder_rnn.disable_dropout()
         embed_out = self.tgt_embeddings.encode(dst, train)
         outputs = []
         attn_fn = self.attn(context)

--- a/python/baseline/dy/seq2seq/train.py
+++ b/python/baseline/dy/seq2seq/train.py
@@ -14,7 +14,6 @@ class Seq2SeqTrainerDynet(Trainer):
         super(Seq2SeqTrainerDynet, self).__init__()
         self.model = model
         self.optimizer = OptimizerManager(model, **kwargs)
-        self.log = logging.getLogger('baseline.timing')
         self.nsteps = kwargs.get('nsteps', 500)
 
     @staticmethod
@@ -24,7 +23,7 @@ class Seq2SeqTrainerDynet(Trainer):
         mask = dy.transpose(mask)
         losses = dy.concatenate_cols(losses)
         masked_loss = dy.cmult(losses, mask)
-        loss = dy.mean_batches(dy.cdiv(dy.sum_elems(masked_loss), dy.sum_elems(mask)))
+        loss = dy.cdiv(dy.sum_batches(dy.sum_elems(masked_loss)), dy.sum_batches(dy.sum_elems(mask)))
         return loss
 
     @staticmethod
@@ -52,7 +51,7 @@ class Seq2SeqTrainerDynet(Trainer):
             loss_val = loss.npvalue().item()
             loss.backward()
             self.optimizer.update()
-            tok_count = self._num_toks(tgt)
+            tok_count = self._num_toks(tgt_lens)
             report_loss = loss_val * tok_count
             epoch_loss += report_loss
             epoch_toks += tok_count

--- a/python/baseline/dy/seq2seq/train.py
+++ b/python/baseline/dy/seq2seq/train.py
@@ -1,20 +1,21 @@
 import time
 import logging
-from baseline.utils import listify, get_model_file
 from baseline.progress import create_progress_bar
+from baseline.utils import listify, get_model_file
 from baseline.train import Trainer, create_trainer, register_trainer, register_training_func
-from baseline.dy.dynety import *
 from baseline.dy.optz import *
+from baseline.dy.dynety import *
 
 
 @register_trainer(task='seq2seq', name='default')
 class Seq2SeqTrainerDynet(Trainer):
+
     def __init__(self, model, **kwargs):
         super(Seq2SeqTrainerDynet, self).__init__()
         self.model = model
         self.optimizer = OptimizerManager(model, **kwargs)
-        self.valid_epochs = 0
         self.log = logging.getLogger('baseline.timing')
+        self.nsteps = kwargs.get('nsteps', 500)
 
     @staticmethod
     def _loss(outputs, labels, tgt_lengths):
@@ -23,49 +24,60 @@ class Seq2SeqTrainerDynet(Trainer):
         mask = dy.transpose(mask)
         losses = dy.concatenate_cols(losses)
         masked_loss = dy.cmult(losses, mask)
-        loss = dy.sum_batches(dy.sum_elems(masked_loss))
+        loss = dy.mean_batches(dy.cdiv(dy.sum_elems(masked_loss), dy.sum_elems(mask)))
         return loss
 
-    def _total(self, tgt):
-        return (tgt != 0).sum()
+    @staticmethod
+    def _num_toks(tgt_lens):
+        return np.sum(tgt_lens)
+
+    def calc_metrics(self, agg, norm):
+        metrics = super(Seq2SeqTrainerDynet, self).calc_metrics(agg, norm)
+        metrics['perplexity'] = np.exp(metrics['avg_loss'])
+        return metrics
 
     def train(self, loader, reporting_fns, **kwargs):
         self.model.train = True
-        metrics = {}
-        total_loss = 0.0
-        total = 0
+        epoch_loss = 0.0
+        epoch_toks = 0
         start = time.time()
+        self.nstep_start = start
         for batch_dict in loader:
             dy.renew_cg()
             inputs = self.model.make_input(batch_dict)
             tgt = inputs.pop('tgt')
+            tgt_lens = batch_dict['tgt_lengths']
             output = self.model.forward(inputs)
-            loss = self._loss(output, tgt, batch_dict['tgt_lengths'])
-            total += self._total(tgt)
+            loss = self._loss(output, tgt, tgt_lens)
             loss_val = loss.npvalue().item()
-            total_loss += loss_val
             loss.backward()
             self.optimizer.update()
+            tok_count = self._num_toks(tgt)
+            report_loss = loss_val * tok_count
+            epoch_loss += report_loss
+            epoch_toks += tok_count
+            self.nstep_agg += report_loss
+            self.nstep_div += tok_count
 
-            if self.optimizer.global_step > 0 and self.optimizer.global_step % 500 == 0:
-                avg_loss = total_loss / total
-                metrics['avg_loss'] = avg_loss
-                metrics['perplexity'] = np.exp(avg_loss)
-                for reporting in reporting_fns:
-                    reporting(metrics, self.optimizer.global_step, 'Train')
+            if (self.optimizer.global_step + 1) % self.nsteps == 0:
+                metrics = self.calc_metrics(self.nstep_agg, self.nstep_div)
+                self.report(
+                    self.optimizer.global_step + 1, metrics, self.nstep_start,
+                    'Train', 'STEP', reporting_fns
+                )
+                self.reset_nstep()
 
-        self.log.debug({'phase': 'Train', 'time': time.time() - start})
-        avg_loss = total_loss / total
-        metrics['avg_loss'] = avg_loss
-        metrics['perplexity'] = np.exp(avg_loss)
-        for reporting in reporting_fns:
-            reporting(metrics, self.optimizer.global_step, 'Train')
+        metrics = self.calc_metrics(epoch_loss, epoch_toks)
+        self.train_epochs += 1
+        self.report(
+            self.train_epochs, metrics, start,
+            'Train', 'EPOCH', reporting_fns
+        )
         return metrics
 
     def test(self, vs, reporting_fns, phase):
         self.model.train = False
-        metrics = {}
-        total_loss = total = 0
+        total_loss = total_toks = 0
         steps = len(vs)
         epochs = 0
         if phase == 'Valid':
@@ -74,24 +86,23 @@ class Seq2SeqTrainerDynet(Trainer):
 
         start = time.time()
         pg = create_progress_bar(steps)
-        for batch_dict in vs:
+        for batch_dict in pg(vs):
             dy.renew_cg()
             inputs = self.model.make_input(batch_dict)
             tgt = inputs.pop('tgt')
+            tgt_lens = batch_dict['tgt_lengths']
             output = self.model.forward(inputs)
-            loss = self._loss(output, tgt, batch_dict['tgt_lengths'])
-            total += self._total(tgt)
+            loss = self._loss(output, tgt, tgt_lens)
+            toks = self._num_toks(tgt_lens)
             loss_val = loss.npvalue().item()
-            total_loss += loss_val
-            pg.update()
-        pg.done()
+            total_loss += loss_val * toks
+            total_toks += toks
 
-        self.log.debug({'phase': phase, 'time': time.time() - start})
-        avg_loss = float(total_loss)/total
-        metrics['avg_loss'] = avg_loss
-        metrics['perplexity'] = np.exp(avg_loss)
-        for reporting in reporting_fns:
-            reporting(metrics, epochs, phase)
+        metrics = self.calc_metrics(total_loss, total_toks)
+        self.report(
+            epochs, metrics, start,
+            phase, 'EPOCH', reporting_fns
+        )
         return metrics
 
 

--- a/python/baseline/pytorch/classify/train.py
+++ b/python/baseline/pytorch/classify/train.py
@@ -1,11 +1,13 @@
-from baseline.utils import listify, get_model_file
-from baseline.progress import create_progress_bar
-from baseline.confusion import ConfusionMatrix
-from baseline.train import EpochReportingTrainer, create_trainer, register_trainer, register_training_func
+import six
+import time
 import torch
 import torch.autograd
 from baseline.utils import verbose_output
+from baseline.confusion import ConfusionMatrix
+from baseline.progress import create_progress_bar
+from baseline.utils import listify, get_model_file
 from baseline.pytorch.optz import OptimizerManager
+from baseline.train import EpochReportingTrainer, create_trainer, register_trainer, register_training_func
 
 
 def _add_to_cm(cm, y, pred):
@@ -25,56 +27,75 @@ class ClassifyTrainerPyTorch(EpochReportingTrainer):
         self.optimizer = OptimizerManager(model, **kwargs)
         self.crit = model.create_loss().cuda()
         self.model = torch.nn.DataParallel(model).cuda()
+        self.nsteps = kwargs.get('nsteps', six.MAXSIZE)
 
     def _make_input(self, batch_dict):
         return self.model.module.make_input(batch_dict)
 
+    @staticmethod
+    def _get_batchsz(batch_dict):
+        return len(batch_dict['y'])
+
     def _test(self, loader, **kwargs):
         self.model.eval()
         total_loss = 0
+        total_norm = 0
         steps = len(loader)
         pg = create_progress_bar(steps)
         cm = ConfusionMatrix(self.labels)
         verbose = kwargs.get("verbose", None)
 
-        for batch_dict in loader:
+        for batch_dict in pg(loader):
             example = self._make_input(batch_dict)
             y = example.pop('y')
             pred = self.model(example)
             loss = self.crit(pred, y)
-            total_loss += loss.item()
+            batchsz = self._get_batchsz(batch_dict)
+            total_loss += loss.item() * batchsz
+            total_norm += batchsz
             _add_to_cm(cm, y, pred)
-            pg.update()
-        pg.done()
 
         metrics = cm.get_all_metrics()
-        metrics['avg_loss'] = total_loss/float(steps)
+        metrics['avg_loss'] = total_loss / float(total_norm)
         verbose_output(verbose, cm)
 
         return metrics
 
-    def _train(self, loader):
+    def _train(self, loader, **kwargs):
         self.model.train()
+        reporting_fns = kwargs.get('reporting_fns', [])
         steps = len(loader)
         pg = create_progress_bar(steps)
         cm = ConfusionMatrix(self.labels)
-        total_loss = 0
-        for batch_dict in loader:
+        epoch_loss = 0
+        epoch_div = 0
+        for batch_dict in pg(loader):
             self.optimizer.zero_grad()
             example = self._make_input(batch_dict)
             y = example.pop('y')
             pred = self.model(example)
             loss = self.crit(pred, y)
-            total_loss += loss.item()
+            batchsz = self._get_batchsz(batch_dict)
+            report_loss = loss.item() * batchsz
+            epoch_loss += report_loss
+            epoch_div += batchsz
+            self.nstep_agg += report_loss
+            self.nstep_div += batchsz
             loss.backward()
             torch.nn.utils.clip_grad_norm_(self.model.parameters(), self.clip)
             _add_to_cm(cm, y, pred)
             self.optimizer.step()
-            pg.update()
-        pg.done()
+
+            if (self.optimizer.global_step + 1) % self.nsteps == 0:
+                metrics = self.calc_metrics(self.nstep_agg, self.nstep_div)
+                self.report(
+                    self.optimizer.global_step + 1, metrics, self.nstep_start,
+                    'Train', 'STEP', reporting_fns
+                )
+                self.reset_nstep()
 
         metrics = cm.get_all_metrics()
-        metrics['avg_loss'] = total_loss/float(steps)
+        metrics['avg_loss'] = epoch_loss / float(epoch_div)
         return metrics
 
 
@@ -87,12 +108,12 @@ def fit(model, ts, vs, es, **kwargs):
     :param vs: A validation data set
     :param es: A test data set, can be None
     :param kwargs: See below
-    
+
     :Keyword Arguments:
         * *do_early_stopping* (``bool``) -- Stop after eval data is not improving. Default to True
         * *epochs* (``int``) -- how many epochs.  Default to 20
         * *outfile* -- Model output file, defaults to classifier-model.pyth
-        * *patience* -- 
+        * *patience* --
            How many epochs where evaluation is no longer improving before we give up
         * *reporting* --
            Callbacks which may be used on reporting updates
@@ -102,7 +123,7 @@ def fit(model, ts, vs, es, **kwargs):
            Learning rate, defaults to 0.01
         * *mom* (``float``) --
            Momentum (SGD only), defaults to 0.9 if optim is `sgd`
-    :return: 
+    :return:
     """
     do_early_stopping = bool(kwargs.get('do_early_stopping', True))
     verbose = kwargs.get('verbose', {'console': kwargs.get('verbose_console', False), 'file': kwargs.get('verbose_file', None)})
@@ -111,7 +132,7 @@ def fit(model, ts, vs, es, **kwargs):
     if do_early_stopping:
         early_stopping_metric = kwargs.get('early_stopping_metric', 'acc')
         patience = kwargs.get('patience', epochs)
-        print('Doing early stopping on [%s] with patience [%d]' % (early_stopping_metric, patience))    
+        print('Doing early stopping on [%s] with patience [%d]' % (early_stopping_metric, patience))
 
     reporting_fns = listify(kwargs.get('reporting', []))
     print('reporting', reporting_fns)
@@ -125,7 +146,7 @@ def fit(model, ts, vs, es, **kwargs):
     for epoch in range(epochs):
         trainer.train(ts, reporting_fns)
         test_metrics = trainer.test(vs, reporting_fns)
-        
+
         if do_early_stopping is False:
             model.save(model_file)
 
@@ -138,7 +159,7 @@ def fit(model, ts, vs, es, **kwargs):
         elif (epoch - last_improved) > patience:
             print('Stopping due to persistent failures to improve')
             break
-        
+
     if do_early_stopping is True:
         print('Best performance on max_metric %.3f at epoch %d' % (max_metric, last_improved))
 

--- a/python/baseline/pytorch/lm/train.py
+++ b/python/baseline/pytorch/lm/train.py
@@ -19,7 +19,6 @@ class LanguageModelTrainerPyTorch(Trainer):
         if self.gpu:
             self.model = self.model.cuda()
             self.crit.cuda()
-        self.log = logging.getLogger('baseline.timing')
         self.nsteps = kwargs.get('nsteps', 500)
 
         self.optimizer = OptimizerManager(self.model, **kwargs)

--- a/python/baseline/pytorch/lm/train.py
+++ b/python/baseline/pytorch/lm/train.py
@@ -11,7 +11,6 @@ class LanguageModelTrainerPyTorch(Trainer):
 
     def __init__(self, model, **kwargs):
         super(LanguageModelTrainerPyTorch, self).__init__()
-        self.valid_epochs = 0
         self.model = model
         self.clip = float(kwargs.get('clip', 5))
         self.gpu = not bool(kwargs.get('nogpu', False))
@@ -21,6 +20,7 @@ class LanguageModelTrainerPyTorch(Trainer):
             self.model = self.model.cuda()
             self.crit.cuda()
         self.log = logging.getLogger('baseline.timing')
+        self.nsteps = kwargs.get('nsteps', 500)
 
         self.optimizer = OptimizerManager(self.model, **kwargs)
 
@@ -31,50 +31,57 @@ class LanguageModelTrainerPyTorch(Trainer):
         else:
             return tuple(self.repackage_hidden(v) for v in h)
 
-    def _get_dims(self, ts):
-        np_array = ts[0]['y']
-        return np_array.shape
+    @staticmethod
+    def _get_dims(batch_dict):
+        return batch_dict['y'].shape
+
+    @staticmethod
+    def _num_toks(batch_dict):
+        return np.prod(LanguageModelTrainerPyTorch._get_dims(batch_dict))
+
+    def calc_metrics(self, agg, norm):
+        metrics = super(LanguageModelTrainerPyTorch, self).calc_metrics(agg, norm)
+        metrics['perplexity'] = np.exp(metrics['avg_loss'])
+        return metrics
 
     def test(self, vs, reporting_fns, phase='Valid'):
-        start_time = time.time()
+        epoch = 0
+        if phase == 'Valid':
+            self.valid_epochs += 1
+            epoch = self.valid_epochs
+        start = time.time()
         self.model.eval()
         total_loss = 0
+        total_toks = 0
         metrics = {}
-        batchsz, nctx = self._get_dims(vs)
+        batchsz, nctx = self._get_dims(vs[0])
 
         hidden = self.model.init_hidden(batchsz)
-        iters = 0
 
         for batch_dict in vs:
             inputs = self.model.make_input(batch_dict)
             y = inputs.pop('y')
             output, hidden = self.model(inputs, hidden)
-            total_loss += self.crit(output, y).data
+            toks = self._num_toks(batch_dict)
+            total_loss += self.crit(output, y).item() * toks
+            total_toks += toks
             if hidden is not None:
                 hidden = self.repackage_hidden(hidden)
-            iters += nctx
-        self.valid_epochs += 1
-
-        avg_loss = float(total_loss) / iters / batchsz
-        metrics['avg_loss'] = avg_loss
-        metrics['perplexity'] = np.exp(avg_loss)
-
-        duration = time.time() - start_time
-        print('%s time (%.3f sec)' % (phase, duration))
-        self.log.debug({'phase': phase, 'time': duration})
-
-        for reporting in reporting_fns:
-            reporting(metrics, self.valid_epochs, phase)
+        metrics = self.calc_metrics(total_loss, total_toks)
+        self.report(
+            epoch, metrics, start,
+            phase, 'EPOCH', reporting_fns
+        )
         return metrics
 
     def train(self, ts, reporting_fns):
-        start_time = time.time()
+        start = time.time()
+        self.nstep_start = start
         self.model.train()
-        total_loss = 0
-        metrics = {}
-        batchsz, nctx = self._get_dims(ts)
+        epoch_loss = 0
+        epoch_toks = 0
+        batchsz, nctx = self._get_dims(ts[0])
         hidden = self.model.init_hidden(batchsz)
-        iters = 0
 
         for batch_dict in ts:
             if hidden is not None:
@@ -85,28 +92,28 @@ class LanguageModelTrainerPyTorch(Trainer):
             output, hidden = self.model(inputs, hidden)
             loss = self.crit(output, y)
             loss.backward()
-            total_loss += loss.data
-            iters += nctx
-            if self.optimizer.global_step > 0 and self.optimizer.global_step % 500 == 0:
-                avg_loss = float(total_loss) / iters / batchsz
-                metrics['avg_loss'] = avg_loss
-                metrics['perplexity'] = np.exp(avg_loss)
-                for reporting in reporting_fns:
-                    reporting(metrics, self.optimizer.global_step, 'Train')
-
             torch.nn.utils.clip_grad_norm_(self.model.parameters(), self.clip)
             self.optimizer.step()
+            toks = self._num_toks(batch_dict)
+            report_loss = loss.item() * toks
+            epoch_loss += report_loss
+            epoch_toks += toks
+            self.nstep_agg += report_loss
+            self.nstep_div += toks
+            if (self.optimizer.global_step + 1) % self.nsteps == 0:
+                metrics = self.calc_metrics(self.nstep_agg, self.nstep_div)
+                self.report(
+                    self.optimizer.global_step + 1, metrics, self.nstep_start,
+                    'Train', 'STEP', reporting_fns
+                )
+                self.reset_nstep()
 
-        avg_loss = float(total_loss) / iters / batchsz
-        metrics['avg_loss'] = avg_loss
-        metrics['perplexity'] = np.exp(avg_loss)
-
-        duration = time.time() - start_time
-        print('Training time (%.3f sec)' % duration)
-        self.log.debug({'phase': 'Train', 'time': duration})
-
-        for reporting in reporting_fns:
-            reporting(metrics, self.optimizer.global_step, 'Train')
+        metrics = self.calc_metrics(epoch_loss, epoch_toks)
+        self.train_epochs += 1
+        self.report(
+            self.train_epochs, metrics, start,
+            'Train', 'EPOCH', reporting_fns
+        )
         return metrics
 
 

--- a/python/baseline/pytorch/optz.py
+++ b/python/baseline/pytorch/optz.py
@@ -152,6 +152,14 @@ class OptimizerManager(object):
         self.lr_function = create_lr_scheduler(**kwargs)
         self._init_optimizer(model, **kwargs)
 
+    @property
+    def global_step(self):
+        return self._global_step
+
+    @global_step.setter
+    def global_step(self, value):
+        self._global_step = value
+
     def _init_optimizer(self, model, **kwargs):
         wd = float(kwargs.get('weight_decay', 0))
         optim = kwargs.get('optim', 'sgd')

--- a/python/baseline/pytorch/seq2seq/decoders.py
+++ b/python/baseline/pytorch/seq2seq/decoders.py
@@ -174,7 +174,7 @@ layer's hidden size == embedding weight dimensions")
         pass
 
     def output(self, x):
-        pred = F.log_softmax(self.preds(x.view(x.size(0)*x.size(1), -1)))
+        pred = F.log_softmax(self.preds(x.view(x.size(0)*x.size(1), -1)), dim=-1)
         pred = pred.view(x.size(0), x.size(1), -1)
         return pred
 

--- a/python/baseline/pytorch/seq2seq/train.py
+++ b/python/baseline/pytorch/seq2seq/train.py
@@ -22,7 +22,6 @@ class Seq2SeqTrainerPyTorch(Trainer):
         if self.gpu:
             self.model = torch.nn.DataParallel(model).cuda()
             self.crit.cuda()
-        self.log = logging.getLogger('baseline.timing')
         self.nsteps = kwargs.get('nsteps', 500)
 
     @staticmethod

--- a/python/baseline/tf/lm/model.py
+++ b/python/baseline/tf/lm/model.py
@@ -204,7 +204,7 @@ class LanguageModelBase(LanguageModel):
             bt_x_v = tf.nn.log_softmax(tf.reshape(self.logits, [-1, vsz]), axis=-1)
             one_hots = tf.one_hot(targets, vsz)
             example_loss = -tf.reduce_sum(one_hots * bt_x_v, axis=-1)
-            loss = tf.reduce_sum(example_loss) / tf.cast(tf.shape(self.y)[0], dtype=tf.float32)
+            loss = tf.reduce_mean(example_loss)
             return loss
 
     def create_loss(self):

--- a/python/baseline/tf/lm/train.py
+++ b/python/baseline/tf/lm/train.py
@@ -17,7 +17,6 @@ class LanguageModelTrainerTf(Trainer):
         self.loss = model.create_loss()
         self.test_loss = model.create_test_loss()
         self.global_step, self.train_op = optimizer(self.loss, **kwargs)
-        self.log = logging.getLogger('baseline.timing')
         self.nsteps = kwargs.get('nsteps', 500)
 
     def checkpoint(self):

--- a/python/baseline/tf/seq2seq/model.py
+++ b/python/baseline/tf/seq2seq/model.py
@@ -11,12 +11,12 @@ import copy
 
 def _temporal_cross_entropy_loss(logits, labels, label_lengths, mx_seq_length):
     """Do cross-entropy loss accounting for sequence lengths
-    
+
     :param logits: a `Tensor` with shape `[timesteps, batch, timesteps, vocab]`
     :param labels: an integer `Tensor` with shape `[batch, timesteps]`
     :param label_lengths: The actual length of the target text.  Assume right-padded
     :param mx_seq_length: The maximum length of the sequence
-    :return: 
+    :return:
     """
 
     # The labels actual length is 100, and starts with <GO>

--- a/python/baseline/tf/seq2seq/train.py
+++ b/python/baseline/tf/seq2seq/train.py
@@ -18,7 +18,6 @@ class Seq2SeqTrainerTf(Trainer):
         self.test_loss = model.create_test_loss()
         self.model = model
         self.global_step, self.train_op = optimizer(self.loss, colocate_gradients_with_ops=True, **kwargs)
-        self.log = logging.getLogger('baseline.timing')
         self.nsteps = kwargs.get('nsteps', 500)
 
     def checkpoint(self):

--- a/python/baseline/tf/tagger/model.py
+++ b/python/baseline/tf/tagger/model.py
@@ -181,7 +181,7 @@ class TaggerModelBase(TaggerModel):
         cross_entropy = tf.one_hot(self.y, nc, axis=-1) * tf.log(tf.nn.softmax(self.probs))
         cross_entropy = -tf.reduce_sum(cross_entropy, reduction_indices=2)
         cross_entropy *= mask
-        cross_entropy = tf.reduce_sum(cross_entropy, reduction_indices=1)
+        cross_entropy = tf.reduce_sum(cross_entropy, axis=1)
         all_loss = tf.reduce_mean(cross_entropy, name="loss")
         return all_loss
 

--- a/python/baseline/tf/tagger/train.py
+++ b/python/baseline/tf/tagger/train.py
@@ -1,11 +1,12 @@
+import six
+import os
 import time
-import tensorflow as tf
 import numpy as np
+import tensorflow as tf
 from baseline.tf.optz import optimizer
 from baseline.progress import create_progress_bar
-from baseline.train import EpochReportingTrainer, create_trainer, register_trainer, register_training_func
-import os
 from baseline.utils import to_spans, f_score, listify, revlut, get_model_file, write_sentence_conll
+from baseline.train import EpochReportingTrainer, create_trainer, register_trainer, register_training_func
 
 
 class TaggerEvaluatorTf(object):
@@ -72,23 +73,22 @@ class TaggerEvaluatorTf(object):
         if conll_output is not None and txts is not None:
             handle = open(conll_output, "w")
 
-        for batch_dict in ts:
-            correct, count, overlaps, golds, guesses = self.process_batch(batch_dict, handle, txts)
-            total_correct += correct
-            total_sum += count
-            total_gold_count += golds
-            total_guess_count += guesses
-            total_overlap_count += overlaps
-            pg.update()
-        pg.done()
+        try:
+            for batch_dict in pg(ts):
+                correct, count, overlaps, golds, guesses = self.process_batch(batch_dict, handle, txts)
+                total_correct += correct
+                total_sum += count
+                total_gold_count += golds
+                total_guess_count += guesses
+                total_overlap_count += overlaps
 
-        total_acc = total_correct / float(total_sum)
-        # Only show the fscore if requested
-        metrics['f1'] = f_score(total_overlap_count, total_gold_count, total_guess_count)
-        metrics['acc'] = total_acc
-
-        if handle is not None:
-            handle.close()
+            total_acc = total_correct / float(total_sum)
+            # Only show the fscore if requested
+            metrics['f1'] = f_score(total_overlap_count, total_gold_count, total_guess_count)
+            metrics['acc'] = total_acc
+        finally:
+            if handle is not None:
+                handle.close()
 
         return metrics
 
@@ -104,6 +104,7 @@ class TaggerTrainerTf(EpochReportingTrainer):
         verbose = kwargs.get('verbose', False)
         self.evaluator = TaggerEvaluatorTf(model, span_type, verbose)
         self.global_step, self.train_op = optimizer(self.loss, **kwargs)
+        self.nsteps = kwargs.get('nsteps', six.MAXSIZE)
 
     def checkpoint(self):
         self.model.saver.save(self.model.sess, "./tf-tagger-%d/tagger" % os.getpid(), global_step=self.global_step)
@@ -113,18 +114,34 @@ class TaggerTrainerTf(EpochReportingTrainer):
         print("Reloading " + latest)
         self.model.saver.restore(self.model.sess, latest)
 
-    def _train(self, ts):
-        total_loss = 0
+    @staticmethod
+    def _get_batchsz(batch_dict):
+        return batch_dict['y'].shape[0]
+
+    def _train(self, ts, **kwargs):
+        reporting_fns = kwargs.get('reporting_fns', [])
+        epoch_loss = 0
+        epoch_norm = 0
         steps = len(ts)
-        metrics = {}
         pg = create_progress_bar(steps)
-        for batch_dict in ts:
+        for batch_dict in pg(ts):
             feed_dict = self.model.make_input(batch_dict, True)
             _, step, lossv = self.model.sess.run([self.train_op, self.global_step, self.loss], feed_dict=feed_dict)
-            total_loss += lossv
-            pg.update()
-        pg.done()
-        metrics['avg_loss'] = float(total_loss)/steps
+            bsz = self._get_batchsz(batch_dict)
+            report_loss = lossv * bsz
+            epoch_loss += report_loss
+            epoch_norm += bsz
+            self.nstep_agg += report_loss
+            self.nstep_div += bsz
+            if (step + 1) % self.nsteps == 0:
+                metrics = self.calc_metrics(self.nstep_agg, self.nstep_div)
+                self.report(
+                    step + 1, metrics, self.nstep_start,
+                    'Train', 'STEP', reporting_fns
+                )
+                self.reset_nstep()
+
+        metrics = self.calc_metrics(epoch_loss, epoch_norm)
         return metrics
 
     def _test(self, ts):

--- a/python/mead/config/conll-iobes-no-crf.json
+++ b/python/mead/config/conll-iobes-no-crf.json
@@ -1,7 +1,7 @@
 {
     "version": 2,
     "task": "tagger",
-    "batchsz": 1,
+    "batchsz": 10,
     "conll_output": "conll-iobes-results.conll",
     "unif": 0.1,
     "preproc": {
@@ -54,11 +54,11 @@
         "epochs": 100,
         "optim": "sgd",
         "eta": 0.015,
-        "autobatchsz": 10,
         "mom": 0.9,
         "patience": 40,
         "early_stopping_metric": "f1",
         "clip": 5.0,
+        "nsteps": 100,
         "span_type": "iobes"
     }
 }

--- a/python/mead/config/logging.json
+++ b/python/mead/config/logging.json
@@ -51,7 +51,7 @@
         "baseline.timing": {
             "level": "DEBUG",
             "handlers": ["timing_file_handler"],
-            "propagate": "no"
+            "propagate": false
         }
     },
 

--- a/python/mead/config/ptb-med.json
+++ b/python/mead/config/ptb-med.json
@@ -1,4 +1,5 @@
-{   "version":2,
+{
+    "version":2,
     "basedir":"ptb-med",
     "task": "lm",
     "basedir": "ptb-med",
@@ -7,31 +8,22 @@
     "nbptt": 35,
     "preproc": {
     },
-    "features": [{
-        "name": "word",
-        "vectorizer": {
-          "type":"token1d",
-          "fields":"text"
-        },
-        "embeddings": {"label":"w2v-gn"}
-   }],
+    "features": [
+        {
+            "name": "word",
+            "vectorizer": {
+                "type":"token1d",
+                "fields":"text"
+            },
+            "embeddings": {"label":"w2v-gn"}
+        }
+    ],
     "backend": "tensorflow",
     "dataset": "ptb",
     "loader": {
         "reader_type": "default",
         "tgt_key": "word"
     },
-    "features": [
-        {
-            "name": "word",
-            "vectorizer": {
-                "type": "token1d",
-                "fields": "text"
-            },
-            "embeddings": {"label": "w2v-gn"}
-        }
-
-    ],
     "model": {
         "model_type": "default",
         "hsz": 650,
@@ -43,13 +35,14 @@
     "train": {
         "epochs": 39,
         "decay_rate": 1.2,
-        "patience": 40000,
+        "patience": 20,
         "optim": "sgd",
         "start_decay_epoch": 6,
         "lr_scheduler_type": "zaremba",
-        "eta": 1.0,
+        "eta": 35.0,
         "mom": 0.0,
+        "nsteps": 500,
         "do_early_stopping": true,
-        "clip": 5.0
+        "clip": 0.25
     }
 }

--- a/python/mead/tasks.py
+++ b/python/mead/tasks.py
@@ -658,7 +658,7 @@ class LanguageModelingTask(Task):
         tgt_key = self.config_params['loader'].get('tgt_key', self.primary_key)
         self.train_data = self.reader.load(self.dataset['train_file'], self.feat2index, self.config_params['batchsz'], tgt_key=tgt_key)
         self.valid_data = self.reader.load(self.dataset['valid_file'], self.feat2index, self.config_params['batchsz'], tgt_key=tgt_key)
-        self.test_data = self.reader.load(self.dataset['test_file'], self.feat2index, self.config_params['batchsz'], tgt_key=tgt_key)
+        self.test_data = self.reader.load(self.dataset['test_file'], self.feat2index, 1, tgt_key=tgt_key)
 
     def _create_model(self):
 

--- a/python/mead/utils.py
+++ b/python/mead/utils.py
@@ -140,14 +140,16 @@ KEYS = {
     ('train', 'verbose'),
     ('train', 'model_base'),
     ('train', 'model_zip'),
-    ('test_batchsz')
+    ('train', 'nsteps'),
+    ('test_batchsz'),
+    ('basedir'),
 }
 
 
 @exporter
 def remove_extra_keys(config, keys=KEYS):
     """Remove config items that don't effect the model.
-    When base most things off of the sha1 hash of the model configs but there
+    We base most things off of the sha1 hash of the model configs but there
     is a problem. Some things in the config file don't effect the model such
     as the name of the `conll_output` file or if you are using `visdom`
     reporting. This strips out these kind of things so that as long as the model
@@ -155,7 +157,7 @@ def remove_extra_keys(config, keys=KEYS):
     :param config: dict, The json data.
     :param keys: Set[Tuple[str]], The keys to remove.
     :returns:
-        dict, The data with certain keys removed.
+        dict, The config with certain keys removed.
     """
     c = deepcopy(config)
     for key in keys:

--- a/python/tests/test_dy_losses.py
+++ b/python/tests/test_dy_losses.py
@@ -1,0 +1,71 @@
+import pytest
+import numpy as np
+dy = pytest.importorskip('dynet')
+from baseline.dy.seq2seq.train import Seq2SeqTrainerDynet
+from baseline.dy.lm.train import LanguageModelTrainerDynet
+
+
+@pytest.fixture
+def shapes():
+    B = np.random.randint(20, 51)
+    S = np.random.randint(30, 61)
+    C = np.random.randint(10, 100)
+    return B, S, C
+
+
+@pytest.fixture
+def logits(shapes):
+    return np.random.rand(*shapes)
+
+
+@pytest.fixture
+def labels(shapes, lengths):
+    B, S, C = shapes
+    labels = np.random.randint(1, C, size=(B, S))
+    for i, l in enumerate(lengths):
+        labels[i, l:] = 0
+    return labels
+
+
+@pytest.fixture
+def lengths(shapes):
+    B, S, _ = shapes
+    lengths = np.random.randint(1, S, size=B)
+    lengths[np.random.choice(np.arange(B), replace=False, size=B//2)] = S
+    return lengths
+
+
+def test_masked_token_level_loss(shapes, logits, labels, lengths):
+    dy.renew_cg()
+    B, S, C = shapes
+    dy_logits = [dy.inputTensor(x, batched=True) for x in logits.transpose(1, 2, 0)]
+    dy_labels = labels.transpose(1, 0)
+    gold = dy.zeros((1,))
+    for b in range(B):
+        for i, (logit, label) in enumerate(zip(dy_logits, dy_labels)):
+            if i >= lengths[b]:
+                continue
+            log = dy.pick_batch_elem(logit, b)
+            lab = label[b]
+            gold += dy.pickneglogsoftmax(log, lab)
+    gold = gold.npvalue() / np.sum(lengths)
+
+    res = Seq2SeqTrainerDynet._loss(dy_logits, dy_labels, lengths)
+    np.testing.assert_allclose(res.npvalue(), gold, rtol=1e-6)
+
+
+def test_token_level_loss(shapes, logits, labels, lengths):
+    dy.renew_cg()
+    B, S, C = shapes
+    dy_logits = [dy.inputTensor(x, batched=True) for x in logits.transpose(1, 2, 0)]
+    dy_labels = labels.transpose(1, 0)
+    gold = dy.zeros((1,))
+    for b in range(B):
+        for logit, label in zip(dy_logits, dy_labels):
+            log = dy.pick_batch_elem(logit, b)
+            lab = label[b]
+            gold += dy.pickneglogsoftmax(log, lab)
+    gold = gold.npvalue() / (B * S)
+
+    res = LanguageModelTrainerDynet._loss(dy_logits, dy_labels)
+    np.testing.assert_allclose(res.npvalue(), gold, rtol=1e-6)

--- a/python/tests/test_reporting_hooks.py
+++ b/python/tests/test_reporting_hooks.py
@@ -6,6 +6,7 @@ pytest.importorskip('tensorboardX')
 import numpy as np
 import baseline.reporting
 from baseline.reporting import TensorBoardReporting
+from baseline.reporting import ReportingHook
 
 
 def random_str(len_=None, min_=5, max_=21):
@@ -59,3 +60,51 @@ def test_absolute_log_dir(patches):
     _ = TensorBoardReporting(log_dir=log_dir, flush_secs=2, base_dir=base_dir)
     gold = os.path.join(log_dir, str(pid))
     w_patch.assert_called_once_with(gold, flush_secs=2)
+
+
+def test_infer_type_train():
+    hook = ReportingHook()
+    gold = 'STEP'
+    phase = 'Train'
+    tt = hook._infer_tick_type(phase, None)
+    assert tt == gold
+
+
+def test_infer_type_test():
+    hook = ReportingHook()
+    gold = 'EPOCH'
+    phase = 'Test'
+    tt = hook._infer_tick_type(phase, None)
+    assert tt == gold
+
+
+def test_infer_type_valid():
+    hook = ReportingHook()
+    gold = 'EPOCH'
+    phase = 'Valid'
+    tt = hook._infer_tick_type(phase, None)
+    assert tt == gold
+
+
+def test_infer_type_override_train():
+    hook = ReportingHook()
+    gold = 'EPOCH'
+    phase = 'Train'
+    tt = hook._infer_tick_type(phase, gold)
+    assert tt == gold
+
+
+def test_infer_type_override_valid():
+    hook = ReportingHook()
+    gold = 'STEP'
+    phase = 'Valid'
+    tt = hook._infer_tick_type(phase, gold)
+    assert tt == gold
+
+
+def test_infer_type_override_test():
+    hook = ReportingHook()
+    gold = 'STEP'
+    phase = 'Test'
+    tt = hook._infer_tick_type(phase, gold)
+    assert tt == gold

--- a/python/tests/test_torchy.py
+++ b/python/tests/test_torchy.py
@@ -1,0 +1,57 @@
+import pytest
+import numpy as np
+torch = pytest.importorskip('torch')
+from baseline.utils import Offsets
+from baseline.pytorch.torchy import SequenceCriterion
+
+C = 10
+B = 50
+S = 20
+
+
+@pytest.fixture
+def lengths():
+    lengths = torch.randint(1, S, size=(B,)).long()
+    return lengths
+
+
+@pytest.fixture
+def logits(lengths):
+    logits = torch.rand(B, S, C)
+    for i, l in enumerate(lengths):
+        logits[i, l:, :] = 0
+    return logits
+
+
+@pytest.fixture
+def labels(lengths):
+    lab = torch.randint(1, C, size=(B, S)).long()
+    for i, l in enumerate(lengths):
+        lab[i, l:] = 0
+    return lab
+
+
+def raw_loss(logits, labels, loss):
+    B, T, H = logits.size()
+    crit = loss(reduce=False, ignore_index=Offsets.PAD)
+    total_size = labels.nelement()
+    res = crit(logits.view(total_size, -1), labels.view(total_size))
+    return res.view(B, T)
+
+
+def test_batch_sequence_loss(logits, labels):
+    loss = torch.nn.CrossEntropyLoss
+    raw = raw_loss(logits, labels, loss)
+    gold = torch.mean(torch.sum(raw, dim=1))
+    crit = SequenceCriterion(LossFn=loss, avg='batch')
+    res = crit(logits, labels)
+    np.testing.assert_allclose(res.numpy(), gold.numpy(), rtol=1e-6)
+
+
+def test_token_sequence_loss(logits, labels, lengths):
+    loss = torch.nn.CrossEntropyLoss
+    raw = raw_loss(logits, labels, loss)
+    gold = torch.sum(raw) / torch.sum(lengths).to(logits.dtype)
+    crit = SequenceCriterion(LossFn=loss, avg='token')
+    res = crit(logits, labels)
+    np.testing.assert_allclose(res.numpy(), gold.numpy(), rtol=1e-6)


### PR DESCRIPTION
This PR adds the ability to have nstep reporting for each task and framework. This is used mostly for tensorboard reporting.

This adds reporting hooks that are step based and and those that are epoch based. They just ignore ones that they aren't set to use.

This also adds a new logging reporter that logs to stdout using the root logger. This allows for long running model (seq2seq and lm) to log to screen without polluting the reporting log. 