### PR TITLE
Add back ability to do zaremba decay

### DIFF
--- a/python/baseline/train.py
+++ b/python/baseline/train.py
@@ -281,6 +281,3 @@ def create_trainer(model, **kwargs):
     trainer_type = kwargs.get('trainer_type', 'default')
     Constructor = BASELINE_TRAINERS[model.task_name][trainer_type]
     return Constructor(model, **kwargs)
-
-
-

--- a/python/mead/config/ptb-med.json
+++ b/python/mead/config/ptb-med.json
@@ -1,5 +1,6 @@
 {
     "task": "lm",
+    "basedir": "ptb-med",
     "batchsz": 20,
     "unif": 0.05,
     "nbptt": 35,
@@ -11,15 +12,24 @@
     "backend": "tensorflow",
     "dataset": "ptb",
     "loader": {
-        "reader_type": "default"
+        "reader_type": "default",
+        "tgt_key": "word"
     },
+    "features": [
+        {
+            "name": "word",
+            "vectorizer": {
+                "type": "token1d",
+                "fields": "text"
+            },
+            "embeddings": {"label": "w2v-gn"}
+        }
+
+    ],
     "model": {
         "model_type": "default",
         "hsz": 650,
-        "layers": 2 
-    },
-    "word_embeddings": {
-        "label": "w2v-gn"
+        "layers": 2
     },
     "train": {
         "epochs": 39,
@@ -27,7 +37,7 @@
         "patience": 40000,
         "optim": "sgd",
         "start_decay_epoch": 6,
-        "decay_type": "zaremba",
+        "lr_scheduler_type": "zaremba",
         "eta": 1.0,
         "mom": 0.0,
         "do_early_stopping": true,


### PR DESCRIPTION
This adds back the logic to do zaremba decay based on a starting epoch. Currently it seems like if we want to do something like piece wise decay the only way to do it is to actually give the bounds in the config file. This seems like a lot of work. We might want to update LR schedulers to allow for something like decay_start and decay_step with the ability to override with explicit bounds in the case you want uneven steps