### PR TITLE
Fixed pytorch types

### DIFF
--- a/python/baseline/pytorch/classify/model.py
+++ b/python/baseline/pytorch/classify/model.py
@@ -66,7 +66,7 @@ class ClassifierModelBase(nn.Module, ClassifierModel):
 
         y = batch_dict.get('y')
         if y is not None:
-            y = torch.from_numpy(y)
+            y = torch.from_numpy(y).to(torch.long)
             if self.gpu is not None:
                 y = y.cuda()
             example_dict['y'] = y

--- a/python/baseline/pytorch/embeddings.py
+++ b/python/baseline/pytorch/embeddings.py
@@ -51,6 +51,7 @@ class LookupTableEmbeddings(nn.Module, PyTorchEmbeddings):
         return self.vsz
 
     def forward(self, x):
+        x = x.to(torch.long)
         return self.embeddings(x)
 
 
@@ -106,6 +107,7 @@ class CharConvEmbeddings(nn.Module, PyTorchEmbeddings):
         # For starters we need to perform embeddings for each character
         # (TxB) x W -> (TxB) x W x D
         _0, _1, W = xch.shape
+        xch = xch.to(torch.long)
         char_embeds = self.embeddings(xch.view(-1, W))
         # (TxB) x D x W
         char_vecs = char_embeds.transpose(1, 2).contiguous()

--- a/python/baseline/pytorch/lm/model.py
+++ b/python/baseline/pytorch/lm/model.py
@@ -34,7 +34,7 @@ class LanguageModelBase(nn.Module, LanguageModel):
 
         y = batch_dict.get('y')
         if y is not None:
-            y = torch.from_numpy(y)
+            y = torch.from_numpy(y).to(torch.long)
             if self.gpu is not None:
                 y = y.cuda()
             example_dict['y'] = y

--- a/python/baseline/pytorch/tagger/model.py
+++ b/python/baseline/pytorch/tagger/model.py
@@ -136,7 +136,7 @@ class TaggerModelBase(nn.Module, TaggerModel):
 
         y = batch_dict.get('y')
         if y is not None:
-            y = torch.from_numpy(y)[perm_idx]
+            y = torch.from_numpy(y)[perm_idx].to(torch.long)
             if self.gpu is not None:
                 y = y.cuda()
             example_dict['y'] = y


### PR DESCRIPTION
Changing the vectorizers to force `np.int32` caused pytorch to have some problems. Pytorch wants LongTensors rather than IntTensors.

This change casts the 'y' target values to LongTensors during `make_input`.

Other inputs are cast to Longs when they are used in the embeddings layer. Casting a `[100 x 100]` tensor on GPU takes `14.4 micro_s +/- 231 ns` This doesn't seem like a huge performance hit but it would faster to do the cast once during `make_input`. However because we don't know which features are indices to embedding tables and which could be continuous pass through features I don't think we can just cast everything in the loop.