### PR TITLE
Feature/default all gpus

### DIFF
--- a/python/baseline/tf/classify/model.py
+++ b/python/baseline/tf/classify/model.py
@@ -383,6 +383,7 @@ class ClassifierModelBase(ClassifierModel):
         gpus = kwargs.get('gpus', 1)
         if gpus == -1:
             gpus = len(os.getenv('CUDA_VISIBLE_DEVICES', os.getenv('NV_GPU', '0')).split(','))
+            kwargs['gpus'] = gpus
         if gpus > 1:
             return ClassifyParallelModel(cls.create, embeddings, labels, **kwargs)
         sess = kwargs.get('sess', tf.Session())

--- a/python/baseline/tf/classify/model.py
+++ b/python/baseline/tf/classify/model.py
@@ -49,12 +49,8 @@ class ClassifyParallelModel(ClassifierModel):
         super(ClassifyParallelModel, self).__init__()
         # We need to remove these because we may be calling back to our caller, and we need
         # the condition of calling to be non-parallel
-        gpus = kwargs.pop('gpus', -1)
-        # If the gpu ID is set to -1, use CUDA_VISIBLE_DEVICES to figure it out
-        if gpus == -1:
-            gpus = len(os.getenv('CUDA_VISIBLE_DEVICES', os.getenv('NV_GPU', '0')).split(','))
+        gpus = kwargs.pop('gpus')
         print('Num GPUs', gpus)
-
         self.labels = labels
         nc = len(labels)
 
@@ -384,9 +380,10 @@ class ClassifierModelBase(ClassifierModel):
         :return: A fully-initialized tensorflow classifier 
         """
 
-        gpus = kwargs.get('gpus')
-        # If we are parallelized, we will use the wrapper object ClassifyParallelModel and this creation function
-        if gpus is not None:
+        gpus = kwargs.get('gpus', 1)
+        if gpus == -1:
+            gpus = len(os.getenv('CUDA_VISIBLE_DEVICES', os.getenv('NV_GPU', '0')).split(','))
+        if gpus > 1:
             return ClassifyParallelModel(cls.create, embeddings, labels, **kwargs)
         sess = kwargs.get('sess', tf.Session())
 

--- a/python/baseline/tf/lm/model.py
+++ b/python/baseline/tf/lm/model.py
@@ -237,6 +237,7 @@ class LanguageModelBase(LanguageModel):
         gpus = kwargs.get('gpus', 1)
         if gpus == -1:
             gpus = len(os.getenv('CUDA_VISIBLE_DEVICES', os.getenv('NV_GPU', '0')).split(','))
+            kwargs['gpus'] = gpus
         if gpus > 1:
             return DataParallelLanguageModel(cls.create, embeddings, **kwargs)
         lm = cls()

--- a/python/baseline/tf/seq2seq/model.py
+++ b/python/baseline/tf/seq2seq/model.py
@@ -269,6 +269,7 @@ class EncoderDecoderModelBase(EncoderDecoderModel):
         gpus = kwargs.get('gpus', 1)
         if gpus == -1:
             gpus = len(os.getenv('CUDA_VISIBLE_DEVICES', os.getenv('NV_GPU', '0')).split(','))
+            kwargs['gpus'] = gpus
         if gpus > 1:
             return DataParallelEncoderDecoderModel(cls.create, src_embeddings, tgt_embedding, **kwargs)
         model = cls()

--- a/python/mead/trainer.py
+++ b/python/mead/trainer.py
@@ -14,7 +14,7 @@ def main():
     parser.add_argument('--embeddings', help='json library of embeddings', default='config/embeddings.json', type=convert_path)
     parser.add_argument('--logging', help='json file for logging', default='config/logging.json', type=convert_path)
     parser.add_argument('--task', help='task to run', choices=['classify', 'tagger', 'seq2seq', 'lm'])
-    parser.add_argument('--gpus', help='Number of GPUs (defaults to 1)', type=int)
+    parser.add_argument('--gpus', help='Number of GPUs (defaults to number available)', type=int, default=-1)
     parser.add_argument('--reporting', help='reporting hooks', nargs='+')
     parser.add_argument('--backend', help='The deep learning backend to use')
     args, reporting_args = parser.parse_known_args()


### PR DESCRIPTION
This changes how TensorFlow utilizes GPUs.  We will now utilize all GPUs provided in the `CUDA_VISIBLE_DEVICES` mask by default.  For TensorFlow it will still be possible to provide a subset using specifying `--gpus X` in the command line or in the mead config