### PR TITLE
constrained decoding

### DIFF
--- a/python/baseline/tf/tfy.py
+++ b/python/baseline/tf/tfy.py
@@ -2,7 +2,8 @@ import os
 import numpy as np
 import tensorflow as tf
 from tensorflow.python.layers import core as layers_core
-from baseline.utils import lookup_sentence, beam_multinomial, crf_mask as crf_m, Offsets
+from baseline.utils import lookup_sentence, beam_multinomial, Offsets
+from baseline.utils import transition_mask as transition_mask_np
 import math
 
 
@@ -83,12 +84,14 @@ def _add_ema(model, decay):
     return ema_op, load, restore_vars
 
 
-def crf_mask(vocab, span_type, s_idx, e_idx, pad_idx=None):
+def transition_mask(vocab, span_type, s_idx, e_idx, pad_idx=None):
     """Create a CRF Mask.
 
     Returns a mask with invalid moves as 0 and valid moves as 1.
     """
-    return tf.constant(crf_m(vocab, span_type, s_idx, e_idx, pad_idx).T)
+    mask = transition_mask_np(vocab, span_type, s_idx, e_idx, pad_idx).T
+    inv_mask = (mask == 0).astype(np.float32)
+    return tf.constant(mask), tf.constant(inv_mask)
 
 
 # TODO deprecated, remove

--- a/python/baseline/utils.py
+++ b/python/baseline/utils.py
@@ -123,10 +123,21 @@ def sequence_mask(lengths, max_len=-1):
 
 
 @exporter
-def crf_mask(vocab, span_type, s_idx, e_idx, pad_idx=None):
+def transition_mask(vocab, span_type, s_idx, e_idx, pad_idx=None):
     """Create a CRF mask.
 
     Returns a mask with invalid moves as 0 and valid as 1.
+
+    :param vocab: dict, Label vocabulary mapping name to index.
+    :param span_type: str, The sequence labeling formalism {IOB, IOB2, BIO, or IOBES}
+    :param s_idx: int, What is the index of the GO symbol?
+    :param e_idx: int, What is the index of the EOS symbol?
+    :param pad_idx: int, What is the index of the PAD symbol?
+
+    Note:
+        In this mask the PAD symbol is between the last symbol and EOS, PADS can
+        only move to pad and the EOS. Any symbol that can move to an EOS can also
+        move to a pad.
     """
     rev_lut = {v: k for k, v in vocab.items()}
     start = rev_lut[s_idx]

--- a/python/mead/config/conll-bio-dy-autobatch.json
+++ b/python/mead/config/conll-bio-dy-autobatch.json
@@ -39,7 +39,7 @@
         "dropout": 0.5,
         "rnntype": "blstm",
         "layers": 1,
-        "crf_mask": true,
+        "constrain_decode": true,
         "crf": true
     },
 

--- a/python/mead/config/conll-bio.json
+++ b/python/mead/config/conll-bio.json
@@ -43,7 +43,7 @@
         "dropout": 0.5,
         "rnntype": "blstm",
         "layers": 1,
-        "crf_mask": true,
+        "constrain_decode": true,
         "crf": 1
     },
     "train": {

--- a/python/mead/config/conll-cnn.yml
+++ b/python/mead/config/conll-cnn.yml
@@ -40,7 +40,7 @@ model:
   rnntype: cnn
   layers: 2
   crf: 1
-  crf_mask: true
+  constrain_decode: true
   activation: relu
 train:
   epochs: 600

--- a/python/mead/config/conll-elmo-bio.yml
+++ b/python/mead/config/conll-elmo-bio.yml
@@ -50,7 +50,7 @@ model:
     dropout: 0.5
     rnntype: blstm
     layers: 2
-    crf_mask: true
+    constrain_decode: true
     crf: 1
 
 

--- a/python/mead/config/conll-iobes-dy-autobatch.json
+++ b/python/mead/config/conll-iobes-dy-autobatch.json
@@ -39,8 +39,8 @@
         "dropout": 0.5,
         "rnntype": "blstm",
         "layers": 1,
-        "crf_mask": true,
-	"crf": true 
+        "constrain_decode": true,
+        "crf": true
     },
     "train": {
         "epochs": 80,

--- a/python/mead/config/conll-iobes-no-crf.json
+++ b/python/mead/config/conll-iobes-no-crf.json
@@ -1,0 +1,65 @@
+{
+    "version": 2,
+    "task": "tagger",
+    "batchsz": 1,
+    "conll_output": "conll-iobes-results.conll",
+    "unif": 0.1,
+    "preproc": {
+    },
+    "features": [
+        {
+            "name": "glove",
+            "vectorizer": {
+                "type": "dict1d",
+                "fields": "text",
+                "transform": "baseline.lowercase"
+            },
+            "embeddings": { "label": "glove-6B-100" }
+        },
+        {
+            "name": "senna",
+            "vectorizer": {
+                "type": "dict1d",
+                "fields": "text",
+                "transform": "baseline.lowercase"
+            },
+            "embeddings": { "label": "senna" }
+        },
+        {
+            "name": "char",
+            "vectorizer": { "type": "dict2d" },
+            "embeddings": { "dsz": 30, "wsz": 30, "type": "char-conv" }
+        }
+    ],
+    "backend": "pytorch",
+    "dataset": "conll-iobes",
+    "loader": {
+        "reader_type": "default",
+	    "named_fields": {
+	        "0": "text",
+	        "-1": "y"
+	}
+    },
+    "model": {
+        "model_type": "default",
+        "hsz": 400,
+        "dropout": 0.5,
+	    "dropin": {"word": 0.1 },
+        "rnntype": "blstm",
+        "layers": 1,
+        "constrain_decode": true,
+        "crf": 0
+    },
+    "train": {
+        "epochs": 100,
+        "optim": "sgd",
+        "eta": 0.015,
+        "autobatchsz": 10,
+        "mom": 0.9,
+        "patience": 40,
+        "early_stopping_metric": "f1",
+        "clip": 5.0,
+        "span_type": "iobes"
+    }
+}
+

--- a/python/mead/config/conll-iobes-tf.json
+++ b/python/mead/config/conll-iobes-tf.json
@@ -37,7 +37,7 @@
 	"dropin": {"word": 0.1 },
         "rnntype": "blstm",
         "layers": 1,
-        "crf_mask": true,
+        "constrain_decode": true,
         "crf": 1
     },
     "train": {

--- a/python/mead/config/conll-iobes.json
+++ b/python/mead/config/conll-iobes.json
@@ -37,7 +37,7 @@
 	"dropin": {"word": 0.1 },
         "rnntype": "blstm",
         "layers": 1,
-        "crf_mask": true,
+        "constrain_decode": true,
         "crf": 1
     },
     "train": {

--- a/python/mead/config/conll-multi-emb-iobes-tf.json
+++ b/python/mead/config/conll-multi-emb-iobes-tf.json
@@ -55,7 +55,7 @@
     "dropin": {"word": 0.1,"senna": 0.1},
     "rnntype": "blstm",
     "layers": 1,
-    "crf_mask": true,
+    "constrain_decode": true,
     "crf": 1
   },
   "train": {

--- a/python/mead/config/conll-multi-emb-iobes.json
+++ b/python/mead/config/conll-multi-emb-iobes.json
@@ -55,7 +55,7 @@
     "dropin": {"word": 0.1,"senna": 0.1},
     "rnntype": "blstm",
     "layers": 1,
-    "crf_mask": true,
+    "constrain_decode": true,
     "crf": 1
   },
   "train": {

--- a/python/mead/config/wnut-elmo.json
+++ b/python/mead/config/wnut-elmo.json
@@ -47,7 +47,7 @@
         "wsz": 10,
         "dropout": 0.5,
         "rnntype": "blstm",
-        "crf_mask": true,
+        "constrain_decode": true,
         "crf": 1
     },
     "train": {

--- a/python/mead/config/wnut-pyt.json
+++ b/python/mead/config/wnut-pyt.json
@@ -27,7 +27,7 @@
 	"dropout": 0.5,
 	"rnntype": "blstm",
 	"layers": 1,
-        "crf_mask": true,
+        "constrain_decode": true,
 	"crf": 1
     },
     "word_embeddings": {"label": "glove-42B"},

--- a/python/mead/config/wnut.json
+++ b/python/mead/config/wnut.json
@@ -45,7 +45,7 @@
 	"dropout": 0.5,
 	"rnntype": "blstm",
 	"layers": 1,
-        "crf_mask":true,
+    "constrain_decode":true,
 	"crf": 1
     },
     "train": {


### PR DESCRIPTION
```
                                               f1                                        
                                         num_exps      mean       std       min       max
sha1                                                                                     
5086e8f1f1df7990a1656ed7f787be511aa59752      5.0  0.914501  0.002673  0.912191  0.919043
```

This PR adds the ability to a viterbi-ish decode on the output of a tagger trained with MLE. Transition probabilities are not learned but just set to hard constraints to remove illegal transitions.

Results above are obtained using the normal tagger hyperparameters but no crf, constrained_decoding, and using both glove and senna embeddings.

This PR also moves the creation of the constraint mask (we have been calling this the crf mask before) outside of the model. This eventually needed to be done to remove the vocab from the model.

With the injection of the transition constraints it no longer makes sense for the CRF to be able to add a `<GO>` and `<EOS>` probability to each emission probability (this wasn't being used by us anyway) so it is also removed.