### PR TITLE
Seq2seq models can optionally share weights

### DIFF
--- a/python/baseline/pytorch/torchy.py
+++ b/python/baseline/pytorch/torchy.py
@@ -191,6 +191,15 @@ def pytorch_linear(in_sz, out_sz, unif=0, initializer=None):
     l.bias.data.zero_()
     return l
 
+def tie_weight(to_layer, from_layer):
+    """Assigns a weight object to the layer weights.
+
+    This method exists to duplicate baseline functionality across packages.
+
+    :param to_layer: the pytorch layer to assign weights to  
+    :param from_layer: pytorch layer to retrieve weights from  
+    """
+    to_layer.weight = from_layer.weight
 
 def pytorch_clone_module(module_, N):
     return nn.ModuleList([copy.deepcopy(module_) for _ in range(N)])

--- a/python/baseline/tf/embeddings.py
+++ b/python/baseline/tf/embeddings.py
@@ -105,6 +105,12 @@ class LookupTableEmbeddings(TensorFlowEmbeddings):
             unif = kwargs.get('unif', 0.1)
             self.weights = np.random.uniform(-unif, unif, (self.vsz, self.dsz))
 
+    def get_dsz(self):
+        return self.dsz
+
+    def get_vsz(self):
+        return self.vsz
+
     def detached_ref(self):
         """This will detach any attached input and reference the same sub-graph otherwise
 

--- a/python/baseline/tf/seq2seq/decoders.py
+++ b/python/baseline/tf/seq2seq/decoders.py
@@ -267,9 +267,13 @@ got {} hsz and {} dsz".format(self.hsz, self.tgt_embedding.get_dsz()))
         Wo = self._get_tgt_weights()
         with tf.variable_scope("dec", reuse=tf.AUTO_REUSE):
             tie_shape = [Wo.get_shape()[-1], Wo.get_shape()[0]]
-            with tf.variable_scope("Share", custom_getter=tie_weight(Wo, tie_shape)):
+            if self.do_weight_tying:
+                with tf.variable_scope("Share", custom_getter=tie_weight(Wo, tie_shape)):
+                    proj = tf.layers.Dense(self.tgt_embedding.vsz, 
+                                        use_bias=False)
+            else:
                 proj = tf.layers.Dense(self.tgt_embedding.vsz, 
-                                       use_bias=False)
+                                        use_bias=False)
 
             self._create_cell(encoder_outputs.output, src_len, pkeep, **kwargs)
             batch_sz = tf.shape(encoder_outputs.output)[0]

--- a/python/baseline/tf/tfy.py
+++ b/python/baseline/tf/tfy.py
@@ -160,6 +160,21 @@ def dense_layer(output_layer_depth):
     return output_layer
 
 
+def tie_weight(weight, tie_shape):
+    """Higher order function to share weights between two layers.
+
+    Tensorflow will take a custom_getter inside of a variable scope.
+    This method creates a getter that looks for a match in shapes. If they match,
+    The weights are transposed and shared.
+
+    """
+    def tie_getter(getter, name, *args, **kwargs):
+        if kwargs['shape'] == tie_shape:
+            return tf.transpose(weight)
+        return getter("{}".format(name), *args, **kwargs)
+    return tie_getter
+
+
 def lstm_cell(hsz, forget_bias=1.0):
     """Produce a single cell with no dropout
 

--- a/python/tests/test_pytorch_weight_sharing.py
+++ b/python/tests/test_pytorch_weight_sharing.py
@@ -1,0 +1,47 @@
+import numpy as np
+import torch
+import torch.nn as nn
+from baseline.pytorch.torchy import pytorch_linear
+
+class TiedWeights(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.tgt_embeddings = nn.Embedding(100, 10) # vsz, dsz
+        self.preds = pytorch_linear(10, 100) # hsz, output_sz
+        self.preds.weight = self.tgt_embeddings.weight # tied weights
+    
+    def forward(self, input_vec):
+        return self.preds(self.tgt_embeddings(input_vec))
+
+
+def test_weight_tying():
+    model = TiedWeights()
+    model.train()
+
+    loss_fn = nn.MSELoss()
+
+    optim = torch.optim.Adam([p for p in model.parameters() if p.requires_grad ])
+    steps = 0
+    epoch_loss, epoch_accuracy = 0, 0
+    for idx in range(100):
+        inputs, targets = random_ints(10), random_floats(10)
+
+        if torch.cuda.is_available():
+            inputs = inputs.cuda()
+            targets = targets.cuda()
+
+        likelihood = model(inputs)
+
+        loss = loss_fn(likelihood, targets)
+
+        loss.backward()
+        optim.step()
+
+    assert torch.equal(model.tgt_embeddings.weight, model.preds.weight)
+
+def random_ints(size):
+    return torch.tensor(np.random.randint(0, 100, size=size))
+
+def random_floats(size):
+    return torch.rand(size, 100)
+    # return torch.tensor(np.random.randint(0, 100, size=size))

--- a/python/tests/test_tf_weight_sharing.py
+++ b/python/tests/test_tf_weight_sharing.py
@@ -1,0 +1,29 @@
+import numpy as np
+import tensorflow as tf
+from baseline.tf.tfy import tie_weight
+
+def test_sharing():
+    input_ = tf.placeholder(tf.int32, shape=[None])
+    weight = tf.get_variable("weight", shape=[100, 200], initializer=tf.random_normal_initializer())
+    embed = tf.nn.embedding_lookup(weight, input_)
+
+
+    tie_shape = [weight.get_shape()[-1], weight.get_shape()[0]]
+    with tf.variable_scope("Share", custom_getter=tie_weight(weight, tie_shape)):
+        layer = tf.layers.Dense(100, use_bias=False, kernel_regularizer=tf.contrib.layers.l2_regularizer(scale=0.1))
+        out = layer(embed)
+
+    loss = tf.reduce_mean(tf.square(out - 0))
+    train_op = tf.train.GradientDescentOptimizer(1).minimize(loss)
+
+    with tf.Session() as sess:
+        sess.run(tf.global_variables_initializer())
+        weights = sess.run([weight, layer.kernel])
+        np.testing.assert_allclose(weights[0], weights[1].T)
+        print("** Weights Start the Same")
+        for _ in range(100):
+            sess.run(train_op, {input_: np.random.randint(0, 100, size=10)})
+
+        weights = sess.run([weight, layer.kernel])
+        np.testing.assert_allclose(weights[0], weights[1].T)
+        print("** Weights Stay the Same")


### PR DESCRIPTION
A user should be able to tie weights within seq2seq decoders.

This PR adds such ability to pytorch, tf, and dynet.