### PR TITLE
Create a class that can run two lr schedulers

### DIFF
--- a/python/baseline/dy/optz.py
+++ b/python/baseline/dy/optz.py
@@ -1,17 +1,17 @@
 import dynet as dy
-from baseline.train import create_lr_scheduler, register_lr_scheduler
-
-from baseline.train import (register_lr_scheduler,
-                            create_lr_scheduler,
-                            ConstantScheduler,
-                            WarmupLinearScheduler,
-                            CyclicLRScheduler,
-                            PiecewiseDecayScheduler,
-                            ZarembaDecayScheduler,
-                            CosineDecayScheduler,
-                            InverseTimeDecayScheduler,
-                            ExponentialDecayScheduler)
-import math
+from baseline.train import (
+    register_lr_scheduler,
+    create_lr_scheduler,
+    ConstantScheduler,
+    WarmupLinearScheduler,
+    CyclicLRScheduler,
+    PiecewiseDecayScheduler,
+    ZarembaDecayScheduler,
+    CosineDecayScheduler,
+    InverseTimeDecayScheduler,
+    ExponentialDecayScheduler,
+    CompositeLRScheduler,
+)
 
 
 @register_lr_scheduler(name='default')
@@ -64,6 +64,11 @@ class InverseTimeDecaySchedulerDyNet(InverseTimeDecayScheduler):
 class ExponentialDecaySchedulerDyNet(ExponentialDecayScheduler):
     def __init__(self, *args, **kwargs):
         super(ExponentialDecaySchedulerDyNet, self).__init__(*args, **kwargs)
+
+
+@register_lr_scheduler(name='composite')
+class CompositeLRSchedulerDyNet(CompositeLRScheduler): pass
+
 
 class OptimizerManager(object):
 

--- a/python/baseline/pytorch/optz.py
+++ b/python/baseline/pytorch/optz.py
@@ -1,16 +1,19 @@
+import math
 import torch
 import torch.autograd
-from baseline.train import (register_lr_scheduler,
-                            create_lr_scheduler,
-                            ConstantScheduler,
-                            WarmupLinearScheduler,
-                            CyclicLRScheduler,
-                            PiecewiseDecayScheduler,
-                            ZarembaDecayScheduler,
-                            CosineDecayScheduler,
-                            InverseTimeDecayScheduler,
-                            ExponentialDecayScheduler)
-import math
+from baseline.train import (
+    register_lr_scheduler,
+    create_lr_scheduler,
+    ConstantScheduler,
+    WarmupLinearScheduler,
+    CyclicLRScheduler,
+    PiecewiseDecayScheduler,
+    ZarembaDecayScheduler,
+    CosineDecayScheduler,
+    InverseTimeDecayScheduler,
+    ExponentialDecayScheduler,
+    CompositeLRScheduler,
+)
 
 
 @register_lr_scheduler(name='default')
@@ -66,6 +69,9 @@ class InverseTimeDecaySchedulerPytorch(InverseTimeDecayScheduler):
 class ExponentialDecaySchedulerPyTorch(ExponentialDecayScheduler):
     def __init__(self, *args, **kwargs):
         super(ExponentialDecaySchedulerPyTorch, self).__init__(*args, **kwargs)
+
+@register_lr_scheduler(name='composite')
+class CompositeLRSchedulerPyTorch(CompositeLRScheduler): pass
 
 
 class AdamW(torch.optim.Optimizer):


### PR DESCRIPTION
This PR added a Class that handles having two learning rate schedulers, The first one is the warmup that controls the learning rate for the first `warmup_steps` number of steps and then the second scheduler handles the rest of the deacy.

This is used by having a list for the `lr_scheduler_type` key in the `train` section of the MEAD config.