### PR TITLE
move parameter negotiation into create method for tf embeddings

### DIFF
--- a/python/baseline/tf/classify/model.py
+++ b/python/baseline/tf/classify/model.py
@@ -313,7 +313,7 @@ class ClassifierModelBase(ClassifierModel):
             embed_args = dict({'vsz': md['vsz'], 'dsz': md['dsz']})
             embed_args[key] = tf.get_default_graph().get_tensor_by_name('{}:0'.format(key))
             Constructor = eval(class_name)
-            model.embeddings[key] = Constructor(key, **embed_args)
+            model.embeddings[key] = Constructor.create(key, **embed_args)
 
         if model.lengths_key is not None:
             model.lengths = tf.get_default_graph().get_tensor_by_name('lengths:0')

--- a/python/baseline/tf/embeddings.py
+++ b/python/baseline/tf/embeddings.py
@@ -190,11 +190,6 @@ class CharConvEmbeddings(TensorFlowEmbeddings):
         self.wsz = wsz
         self.weights = weights
         
-        if self.weights is None:
-            unif = kwargs.get('unif', 0.1)
-            self.weights = np.random.uniform(-unif, unif, (self.vsz, self.dsz))
-        self.params = kwargs
-        self.wsz = None
         self.x = None
         if self.weights is None:
             unif = kwargs.get('unif', 0.1)

--- a/python/baseline/tf/embeddings.py
+++ b/python/baseline/tf/embeddings.py
@@ -80,7 +80,7 @@ class LookupTableEmbeddings(TensorFlowEmbeddings):
     def create_placeholder(cls, name):
         return tf.placeholder(tf.int32, [None, None], name=name)
 
-    def __init__(self, name, **kwargs):
+    def __init__(self, name, vsz, dsz, scope, finetune=True, weights=None):
         """Create a lookup-table based embedding.
 
         :param name: The name of the feature/placeholder, and a key for the scope
@@ -95,12 +95,13 @@ class LookupTableEmbeddings(TensorFlowEmbeddings):
         * *unif* -- (``float``) (defaults to `0.1`) If the weights should be created, what is the random initialization range
         """
         super(LookupTableEmbeddings, self).__init__()
-        self.vsz = kwargs.get('vsz')
-        self.dsz = kwargs.get('dsz')
-        self.finetune = kwargs.get('finetune', True)
         self.name = name
-        self.scope = kwargs.get('scope', '{}/LUT'.format(self.name))
-        self.weights = kwargs.get('weights')
+        self.vsz = vsz
+        self.dsz = dsz
+        self.scope = scope
+        self.finetune = finetune
+        self.weights = weights
+
         if self.weights is None:
             unif = kwargs.get('unif', 0.1)
             self.weights = np.random.uniform(-unif, unif, (self.vsz, self.dsz))
@@ -121,9 +122,19 @@ class LookupTableEmbeddings(TensorFlowEmbeddings):
         return LookupTableEmbeddings(self.name,
                                      vsz=self.vsz,
                                      dsz=self.dsz,
-                                     finetune=self.finetune,
                                      scope=self.scope,
+                                     finetune=self.finetune,
                                      weights=self.weights)
+
+    @classmethod
+    def create(cls, model, name, **kwargs):
+        vsz = model.vsz
+        dsz = model.dsz
+        weights = model.weights
+        finetune = kwargs.get('finetune', True)
+        scope = kwargs.get('scope', '{}/LUT'.format(name))
+
+        return cls(name, vsz, dsz, scope, finetune, weights)
 
     def encode(self, x=None):
         """Build a simple Lookup Table and set as input `x` if it exists, or `self.x` otherwise.
@@ -160,14 +171,25 @@ class CharConvEmbeddings(TensorFlowEmbeddings):
     def create_placeholder(cls, name):
         return tf.placeholder(tf.int32, [None, None, None], name=name)
 
-    def __init__(self, name, **kwargs):
+    def __init__(self, name, vsz, dsz, scope, finetune=True, nfeat_factor=None,
+                 cfiltsz=[3], max_feat=30, gating='skip', num_gates=1, 
+                 activation='tanh', wsz=30, weights=None):
         super(CharConvEmbeddings, self).__init__()
-        self.vsz = kwargs.get('vsz')
-        self.dsz = kwargs.get('dsz')
-        self.finetune = kwargs.get('finetune', True)
+
         self.name = name
-        self.scope = kwargs.get('scope', '{}/CharLUT'.format(self.name))
-        self.weights = kwargs.get('weights')
+        self.vsz = vsz
+        self.dsz = dsz
+        self.scope = scope
+        self.finetune = finetune
+        self.nfeat_factor = nfeat_factor
+        self.cfiltsz = cfiltsz
+        self.max_feat = max_feat
+        self.gating = gating
+        self.num_gates = num_gates
+        self.activation = activation
+        self.wsz = wsz
+        self.weights = weights
+        
         if self.weights is None:
             unif = kwargs.get('unif', 0.1)
             self.weights = np.random.uniform(-unif, unif, (self.vsz, self.dsz))
@@ -185,13 +207,11 @@ class CharConvEmbeddings(TensorFlowEmbeddings):
         """
         if self.weights is None:
             raise Exception('You must initialize `weights` in order to use this method')
-        return CharConvEmbeddings(self.name,
-                                  vsz=self.vsz,
-                                  dsz=self.dsz,
-                                  finetune=self.finetune,
-                                  scope=self.scope,
-                                  weights=self.weights,
-                                  **self.params)
+        return CharConvEmbeddings(self.name, self.vsz, self.dsz, self.scope, 
+                                  self.finetune, self.nfeat_factor,
+                                  self.cfiltsz, self.max_feat, self.gating, 
+                                  self.num_gates, self.activation, self.wsz, 
+                                  self.weights)
 
     def save_md(self, target):
         write_json({'vsz': self.get_vsz(), 'dsz': self.get_dsz()}, target)
@@ -205,7 +225,9 @@ class CharConvEmbeddings(TensorFlowEmbeddings):
                                   initializer=tf.constant_initializer(self.weights, dtype=tf.float32, verify_shape=True),
                                   shape=[self.vsz, self.dsz], trainable=True)
             ech0 = tf.scatter_update(Wch, tf.constant(0, dtype=tf.int32, shape=[1]), tf.zeros(shape=[1, self.dsz]))
-            char_comp, self.wsz = pool_chars(x, Wch, ech0, self.dsz, **self.params)
+            char_comp, self.wsz = pool_chars(x, Wch, ech0, self.dsz, self.nfeat_factor,
+                                  self.cfiltsz, self.max_feat, self.gating, 
+                                  self.num_gates, self.activation, self.wsz)
             return char_comp
 
     def get_vsz(self):
@@ -214,6 +236,24 @@ class CharConvEmbeddings(TensorFlowEmbeddings):
     # Warning this function is only initialized AFTER encode
     def get_dsz(self):
         return self.wsz
+
+    @classmethod
+    def create(cls, model, name, **kwargs):
+        vsz = model.vsz
+        dsz = model.dsz
+        weights = model.weights
+        finetune = kwargs.get('finetune', True)
+        scope = kwargs.get('scope', '{}/CharLUT'.format(name))
+        nfeat_factor = kwargs.get('nfeat_factor')
+        cfiltsz = kwargs.get('cfiltsz', [3])
+        max_feat = kwargs.get('max_feat', 200)
+        gating = kwargs.get('gating', 'skip')
+        num_gates = kwargs.get('num_gates', 1)
+        activation = kwargs.get('activation', 'tanh')
+        wsz = kwargs.get('kwargs', 30)
+
+        return cls(name, vsz, dsz, scope, finetune, nfeat_factor,
+                   cfiltsz, max_feat, gating, num_gates, activation, wsz, weights)
 
 
 def get_timing_signal_1d(length,
@@ -262,7 +302,7 @@ def get_timing_signal_1d(length,
 @register_embeddings(name='positional')
 class PositionalLookupTableEmbeddings(LookupTableEmbeddings):
 
-    def __init__(self, name, **kwargs):
+    def __init__(self, name, vsz, dsz, scope, finetune=True, weights=None, unif=0.1):
         """Create a lookup-table based embedding.
 
         :param name: The name of the feature/placeholder, and a key for the scope
@@ -299,3 +339,14 @@ class PositionalLookupTableEmbeddings(LookupTableEmbeddings):
         B, T, C = get_shape_as_list(x)
         signal = get_timing_signal_1d(T, C, min_timescale=1.0, max_timescale=self.max_timescale, start_index=0)
         return x + signal
+
+    @classmethod
+    def create(cls, model, name, **kwargs):
+        vsz = model.vsz
+        dsz = model.dsz
+        weights = model.weights
+        finetune = kwargs.get('finetune', True)
+        scope = kwargs.get('scope', '{}/LUT'.format(name))
+        unif = kwargs.get('unif', 0.1)
+
+        return cls(name, vsz, dsz, scope, finetune, weights, unif)

--- a/python/baseline/tf/lm/model.py
+++ b/python/baseline/tf/lm/model.py
@@ -304,7 +304,7 @@ class LanguageModelBase(LanguageModel):
             md = read_json('{}-{}-md.json'.format(basename, key))
             embed_args = dict({'vsz': md['vsz'], 'dsz': md['dsz']})
             Constructor = eval(class_name)
-            embeddings[key] = Constructor(key, **embed_args)
+            embeddings[key] = Constructor.create(key, **embed_args)
 
         model = cls.create(embeddings, **state)
         for prop in ls_props(model):

--- a/python/baseline/tf/seq2seq/model.py
+++ b/python/baseline/tf/seq2seq/model.py
@@ -225,13 +225,13 @@ class EncoderDecoderModelBase(EncoderDecoderModel):
             md = read_json('{}-{}-md.json'.format(basename, key))
             embed_args = dict({'vsz': md['vsz'], 'dsz': md['dsz']})
             Constructor = eval(class_name)
-            src_embeddings[key] = Constructor(key, **embed_args)
+            src_embeddings[key] = Constructor.create(key, **embed_args)
 
         tgt_class_name = state.pop('tgt_embedding')
         md = read_json('{}-tgt-md.json'.format(basename))
         embed_args = dict({'vsz': md['vsz'], 'dsz': md['dsz']})
         Constructor = eval(tgt_class_name)
-        tgt_embedding = Constructor('tgt', **embed_args)
+        tgt_embedding = Constructor.create('tgt', **embed_args)
         model = cls.create(src_embeddings, tgt_embedding, **state)
         for prop in ls_props(model):
             if prop in state:

--- a/python/baseline/tf/tagger/model.py
+++ b/python/baseline/tf/tagger/model.py
@@ -145,7 +145,7 @@ class TaggerModelBase(TaggerModel):
             embed_args = dict({'vsz': md['vsz'], 'dsz': md['dsz']})
             embed_args[key] = tf.get_default_graph().get_tensor_by_name('{}:0'.format(key))
             Constructor = eval(class_name)
-            model.embeddings[key] = Constructor(key, **embed_args)
+            model.embeddings[key] = Constructor.create(key, **embed_args)
 
         model.crf = bool(state.get('crf', False))
         model.proj = bool(state.get('proj', False))

--- a/python/baseline/tf/tfy.py
+++ b/python/baseline/tf/tfy.py
@@ -516,7 +516,9 @@ def char_word_conv_embeddings(char_vec, filtsz, char_dsz, nfeats, activation_fn=
     return joined, wsz_all
 
 
-def pool_chars(x_char, Wch, ce0, char_dsz, **kwargs):
+def pool_chars(x_char, Wch, ce0, char_dsz, nfeat_factor=None, 
+               cfiltsz=[3], max_feat=200, gating='skip',
+               num_gates=1, activation='tanh', wsz=30):
     """Take in a tensor of characters (B x maxs x maxw) and do character convolution
 
     :param x_char: TF tensor for input characters, (B x maxs x maxw)
@@ -535,18 +537,16 @@ def pool_chars(x_char, Wch, ce0, char_dsz, **kwargs):
     :return: The character compositional embedding and the number of hidden units as a tuple
 
     """
-    filtsz = kwargs.get('cfiltsz', [3])
-    if 'nfeat_factor' in kwargs:
-        max_feat = kwargs.get('max_feat', 200)
-        nfeats = [min(kwargs['nfeat_factor'] * fsz, max_feat) for fsz in filtsz]
+    filtsz = cfiltsz
+    if nfeat_factor:
+        max_feat = max_feat
+        nfeats = [min(nfeat_factor * fsz, max_feat) for fsz in filtsz]
     else:
-        nfeats = kwargs.get('wsz', 30)
+        nfeats = wsz
     mxlen = tf.shape(x_char)[1]
-    gating = kwargs.get('gating', "skip")
+
     gating_fn = highway_conns if gating.startswith('highway') else skip_conns
-    num_gates = int(kwargs.get('num_gates', 1))
-    # print(gating_fn, num_gates)
-    activation_type = kwargs.get('activation', 'tanh')
+
     with tf.variable_scope("Chars2Word"):
         with tf.control_dependencies([ce0]):
             mxwlen = tf.shape(x_char)[-1]

--- a/python/baseline/tf/tfy.py
+++ b/python/baseline/tf/tfy.py
@@ -553,7 +553,7 @@ def pool_chars(x_char, Wch, ce0, char_dsz, nfeat_factor=None,
             char_bt_x_w = tf.reshape(x_char, [-1, mxwlen])
             cembed = tf.nn.embedding_lookup(Wch, char_bt_x_w, name="embeddings")
             cmot, num_filts = char_word_conv_embeddings(cembed, filtsz, char_dsz, nfeats,
-                                                        activation_fn=tf_activation(activation_type),
+                                                        activation_fn=tf_activation(activation),
                                                         gating=gating_fn,
                                                         num_gates=num_gates)
             word_char = tf.reshape(cmot, [-1, mxlen, num_filts])


### PR DESCRIPTION
keyword argument negotiation allows for class extensibility, but can make it difficult to know what arguments a class will support.

This PR moves this negotiation to the existing classmethod create() while the init method has an explicit definition. Additionally, tfy.pool_chars() is modified to no longer read kwargs.