### PR TITLE
fixed vectorizer

### DIFF
--- a/python/baseline/vectorizers.py
+++ b/python/baseline/vectorizers.py
@@ -198,17 +198,28 @@ class Char2DVectorizer(AbstractCharVectorizer):
         vec2d = np.zeros((self.mxlen, self.mxwlen), dtype=int)
         i = 0
         j = 0
+        over = False
         for atom in self._next_element(tokens, vocab):
+            if over:
+                # If if we have gone over mxwlen burn tokens until we hit end of word
+                if atom == EOW:
+                    over = False
+                continue
             if i == self.mxlen:
-                i -= 1
                 break
-            if atom == EOW or j == self.mxwlen:
+            if atom == EOW:
                 i += 1
                 j = 0
+                continue
+            elif j == self.mxwlen:
+                over = True
+                i += 1
+                j = 0
+                continue
             else:
                 vec2d[i, j] = atom
                 j += 1
-        valid_length = i + 1
+        valid_length = i
         return vec2d, valid_length
 
     def get_dims(self):

--- a/python/tests/test_vectorizers.py
+++ b/python/tests/test_vectorizers.py
@@ -1,0 +1,71 @@
+import string
+import pytest
+import numpy as np
+from baseline.utils import Offsets
+from baseline.vectorizers import Char2DVectorizer
+
+
+@pytest.fixture
+def vocab():
+    vocab = {k: i for i, k in enumerate(Offsets.VALUES)}
+    for i, k in enumerate(string.ascii_lowercase, len(vocab)): vocab[k] = i
+    return vocab
+
+
+def test_char_2d_shapes(vocab):
+    mxlen, mxwlen = np.random.randint(1, 100, size=2)
+    gold_shape = (mxlen, mxwlen)
+    vect = Char2DVectorizer(mxlen=mxlen, mxwlen=mxwlen)
+    res, _ = vect.run([''], vocab)
+    assert res.shape == gold_shape
+
+
+def test_char_2d_cuts_off_mxlen(vocab):
+    mxlen = 2; mxwlen = 4
+    input_ = ['a', 'b', 'c']
+    vect = Char2DVectorizer(mxlen=mxlen, mxwlen=mxwlen)
+    res, _ = vect.run(input_, vocab)
+    assert res.shape[0] == mxlen
+    for i, char in enumerate(input_[:mxlen]):
+        assert res[i, 0] == vocab[char]
+    values = set(res.flatten().tolist())
+    for char in input_[mxlen:]:
+        assert vocab[char] not in values
+
+
+def test_char_2d_cuts_off_mxwlen(vocab):
+    mxlen = 2; mxwlen = 4
+    input_ = ['aaaabbbb', 'cccc']
+    gold = np.array([[vocab['a']] * mxwlen, [vocab['c']] * mxwlen], dtype=int)
+    vect = Char2DVectorizer(mxlen=mxlen, mxwlen=mxwlen)
+    res, _ = vect.run(input_, vocab)
+    np.testing.assert_equal(res, gold)
+
+
+def test_char_2d_valid_length(vocab):
+    mxlen, mxwlen = np.random.randint(3, 15, size=2)
+    my_len = np.random.randint(1, mxlen)
+    input_ = ['a'] * my_len
+    vect = Char2DVectorizer(mxlen=mxlen, mxwlen=mxwlen)
+    _, lens = vect.run(input_, vocab)
+    assert lens == my_len
+
+
+def test_char_2d_valid_length_cutoff(vocab):
+    mxlen, mxwlen = np.random.randint(3, 15, size=2)
+    my_len = mxlen + np.random.randint(5, 10)
+    input_ = ['a'] * my_len
+    vect = Char2DVectorizer(mxlen=mxlen, mxwlen=mxwlen)
+    _, lens = vect.run(input_, vocab)
+    assert my_len > mxlen
+    assert lens == mxlen
+
+
+def test_char_2d_run_values(vocab):
+    mxlen, mxwlen = np.random.randint(3, 15, size=2)
+    input_ = [chr(i + 97) * mxwlen for i in range(mxlen)]
+    vect = Char2DVectorizer(mxlen=mxlen, mxwlen=mxwlen)
+    res, _ = vect.run(input_, vocab)
+    for i, word in enumerate(input_):
+        for j, char in enumerate(word):
+            assert res[i, j] == vocab[char]


### PR DESCRIPTION
This PR fixes two problems in the char2d vectorizer.

#### One

  Words longer then mxwlen would wrap into the next line, for example if `vocab['a'] = 5 and `vocab['t'] = 12`

```
>>> vect.run(['aatt', 'aa'], vocab)
(array([[ 5,  5],
       [12, 12],
       [ 5,  5],
       [ 0,  0]]), 4)
```

#### Two

The valid length was too long for examples that didn't hit mxlen. (see above)


This PR fixes these issues and adds some tests for expected behavior of `Char2DVectorizer.run`

Note: The way the current vectorizer works (a single for loop that yields a single character at a time), is nice in that the iteration code is shared between the Char2D and Char1D vectorizers, however not having the loop over characters in `Char2DVectorizer.run` makes this fix a little strange looking. (If there was an explict for loop in this function we should just break when we hit `j == self.mxwlen`