### PR TITLE
ability to name specific runs

### DIFF
--- a/python/baseline/reporting.py
+++ b/python/baseline/reporting.py
@@ -124,11 +124,16 @@ class TensorBoardReporting(ReportingHook):
     def __init__(self, **kwargs):
         super(TensorBoardReporting, self).__init__(**kwargs)
         from tensorboardX import SummaryWriter
+        # Base dir is often the dir created to save the model into
         base_dir = kwargs.get('base_dir', '.')
         log_dir = os.path.expanduser(kwargs.get('log_dir', 'runs'))
         if not os.path.isabs(log_dir):
             log_dir = os.path.join(base_dir, log_dir)
-        log_dir = os.path.join(log_dir, str(os.getpid()))
+        # Run dir is the name of an individual run
+        run_dir = kwargs.get('run_dir')
+        pid = str(os.getpid())
+        run_dir = '{}-{}'.format(run_dir, pid) if run_dir is not None else pid
+        log_dir = os.path.join(log_dir, run_dir)
         flush_secs = int(kwargs.get('flush_secs', 2))
         self._log = SummaryWriter(log_dir, flush_secs=flush_secs)
 

--- a/python/tests/test_reporting_hooks.py
+++ b/python/tests/test_reporting_hooks.py
@@ -62,6 +62,21 @@ def test_absolute_log_dir(patches):
     w_patch.assert_called_once_with(gold, flush_secs=2)
 
 
+def test_no_run_dir(patches):
+    p_patch, pid, w_patch = patches
+    _ = TensorBoardReporting(flush_secs=2)
+    gold = os.path.join('.', 'runs', str(pid))
+    w_patch.assert_called_once_with(gold, flush_secs=2)
+
+
+def test_run_dir(patches):
+    p_patch, pid, w_patch = patches
+    run_dir = random_str()
+    _ = TensorBoardReporting(flush_secs=2, run_dir=run_dir)
+    gold = os.path.join('.', 'runs', '{}-{}'.format(run_dir, pid))
+    w_patch.assert_called_once_with(gold, flush_secs=2)
+
+
 def test_infer_type_train():
     hook = ReportingHook()
     gold = 'STEP'


### PR DESCRIPTION
This PR updates the way names of the dirs that hold the tensorboard logs for a single run are names. A new kwargs `run_dir` is added. If this kwarg is provided the run is named `{run_dir}-{pid}` otherwise it is just named `{pid}` like before.

The point of this pr is to be able to run multiple groups of jobs and compare runs using the regex filter tensorboard provides.