### PR TITLE
char1D fix

### DIFF
--- a/python/baseline/vectorizers.py
+++ b/python/baseline/vectorizers.py
@@ -272,6 +272,7 @@ class Char1DVectorizer(AbstractCharVectorizer):
         for i, atom in enumerate(self._next_element(tokens, vocab)):
             if i == self.mxlen:
                 i -= 1
+                break
             vec1d[i] = atom
         if self.time_reverse:
             vec1d = vec1d[::-1]

--- a/python/baseline/vectorizers.py
+++ b/python/baseline/vectorizers.py
@@ -156,7 +156,7 @@ class AbstractCharVectorizer(AbstractVectorizer):
 
     def _next_element(self, tokens, vocab):
         OOV = vocab['<UNK>']
-        EOW = vocab.get('<EOW>', vocab.get(' '))
+        EOW = vocab.get('<EOW>', vocab.get(' ', Offsets.PAD))
         for token in self.iterable(tokens):
             for ch in token:
                 yield vocab.get(ch, OOV)
@@ -193,7 +193,7 @@ class Char2DVectorizer(AbstractCharVectorizer):
         if self.mxwlen < 0:
             self.mxwlen = self.max_seen_char
 
-        EOW = vocab.get('<EOW>', vocab.get(' '))
+        EOW = vocab.get('<EOW>', vocab.get(' ', Offsets.PAD))
 
         vec2d = np.zeros((self.mxlen, self.mxwlen), dtype=int)
         i = 0

--- a/python/tests/test_vectorizers.py
+++ b/python/tests/test_vectorizers.py
@@ -2,12 +2,13 @@ import string
 import pytest
 import numpy as np
 from baseline.utils import Offsets
-from baseline.vectorizers import Char2DVectorizer
+from baseline.vectorizers import Char2DVectorizer, Char1DVectorizer
 
 
 @pytest.fixture
 def vocab():
     vocab = {k: i for i, k in enumerate(Offsets.VALUES)}
+    vocab['<EOW>'] = len(vocab)
     for i, k in enumerate(string.ascii_lowercase, len(vocab)): vocab[k] = i
     return vocab
 
@@ -69,3 +70,22 @@ def test_char_2d_run_values(vocab):
     for i, word in enumerate(input_):
         for j, char in enumerate(word):
             assert res[i, j] == vocab[char]
+
+
+def test_char_1d_shape(vocab):
+    mxlen = np.random.randint(3, 15)
+    input_ = ['a']
+    vect = Char1DVectorizer(mxlen=mxlen)
+    res, _ = vect.run(input_, vocab)
+    assert res.shape == (mxlen,)
+
+
+def test_char_1d_cut_off_mxlen(vocab):
+    mxlen = np.random.randint(3, 15)
+    extra = np.random.randint(5, 10)
+    input_ = ['a' * mxlen + 'b' * extra]
+    vect = Char1DVectorizer(mxlen=mxlen)
+    res, _ = vect.run(input_, vocab)
+    assert res.shape == (mxlen,)
+    assert all(res == vocab['a'])
+    assert vocab['b'] not in res

--- a/python/tests/test_vectorizers.py
+++ b/python/tests/test_vectorizers.py
@@ -89,3 +89,13 @@ def test_char_1d_cut_off_mxlen(vocab):
     assert res.shape == (mxlen,)
     assert all(res == vocab['a'])
     assert vocab['b'] not in res
+
+
+def test_char_1d_no_eow(vocab):
+    del vocab['<EOW>']
+    mxlen = np.random.randint(3, 15)
+    input_ = ['a']
+    vect = Char1DVectorizer(mxlen=mxlen)
+    res, _ = vect.run(input_, vocab)
+    assert res[0] == vocab['a']
+    assert res[1] == Offsets.PAD


### PR DESCRIPTION
This PR fixes a bug in the Char1D vectorizer where it crashes is the input to run is longer when the mxlen rather than cutting it off at mxlen.

**Question before merge:** If we look [here](https://github.com/dpressel/baseline/blob/837ba7299d962f08554e09df6a415115306beb54/python/baseline/vectorizers.py#L159) we see that if `<EOW>` and `' '` are not in the vocab then the value for `EOW` is `None`. This will actually crash the vectorizer. Is there some sort of default value we should use?