### PR TITLE
fix the embeddings to support model loading again

### DIFF
--- a/python/baseline/tf/classify/model.py
+++ b/python/baseline/tf/classify/model.py
@@ -313,7 +313,7 @@ class ClassifierModelBase(ClassifierModel):
             embed_args = dict({'vsz': md['vsz'], 'dsz': md['dsz']})
             embed_args[key] = tf.get_default_graph().get_tensor_by_name('{}:0'.format(key))
             Constructor = eval(class_name)
-            model.embeddings[key] = Constructor.create(key, **embed_args)
+            model.embeddings[key] = Constructor(key, **embed_args)
 
         if model.lengths_key is not None:
             model.lengths = tf.get_default_graph().get_tensor_by_name('lengths:0')

--- a/python/baseline/tf/embeddings.py
+++ b/python/baseline/tf/embeddings.py
@@ -169,15 +169,10 @@ class CharConvEmbeddings(TensorFlowEmbeddings):
     def __init__(self, name, **kwargs):
         super(CharConvEmbeddings, self).__init__()
 
-        self.scope = kwargs.get('scope', '{}/CharLUT'.format(self.name))
-
         self.name = name
-
+        self.scope = kwargs.get('scope', '{}/CharLUT'.format(self.name))
         self.vsz = kwargs.get('vsz')
         self.dsz = kwargs.get('dsz')
-        self.finetune = kwargs.get('finetune', True)
-        self.name = name
-        self.scope = kwargs.get('scope', '{}/LUT'.format(self.name))
         self.weights = kwargs.get('weights')
         self.finetune = kwargs.get('finetune', True)
         self.nfeat_factor = kwargs.get('nfeat_factor', None)

--- a/python/baseline/tf/embeddings.py
+++ b/python/baseline/tf/embeddings.py
@@ -80,7 +80,7 @@ class LookupTableEmbeddings(TensorFlowEmbeddings):
     def create_placeholder(cls, name):
         return tf.placeholder(tf.int32, [None, None], name=name)
 
-    def __init__(self, name, vsz, dsz, scope, finetune=True, weights=None):
+    def __init__(self, name, **kwargs):
         """Create a lookup-table based embedding.
 
         :param name: The name of the feature/placeholder, and a key for the scope
@@ -95,12 +95,13 @@ class LookupTableEmbeddings(TensorFlowEmbeddings):
         * *unif* -- (``float``) (defaults to `0.1`) If the weights should be created, what is the random initialization range
         """
         super(LookupTableEmbeddings, self).__init__()
+
+        self.vsz = kwargs.get('vsz')
+        self.dsz = kwargs.get('dsz')
+        self.finetune = kwargs.get('finetune', True)
         self.name = name
-        self.vsz = vsz
-        self.dsz = dsz
-        self.scope = scope
-        self.finetune = finetune
-        self.weights = weights
+        self.scope = kwargs.get('scope', '{}/LUT'.format(self.name))
+        self.weights = kwargs.get('weights')
 
         if self.weights is None:
             unif = kwargs.get('unif', 0.1)
@@ -128,13 +129,7 @@ class LookupTableEmbeddings(TensorFlowEmbeddings):
 
     @classmethod
     def create(cls, model, name, **kwargs):
-        vsz = model.vsz
-        dsz = model.dsz
-        weights = model.weights
-        finetune = kwargs.get('finetune', True)
-        scope = kwargs.get('scope', '{}/LUT'.format(name))
-
-        return cls(name, vsz, dsz, scope, finetune, weights)
+        return cls(name, vsz=model.vsz, dsz=model.dsz, weights=model.weights, **kwargs)
 
     def encode(self, x=None):
         """Build a simple Lookup Table and set as input `x` if it exists, or `self.x` otherwise.
@@ -171,24 +166,28 @@ class CharConvEmbeddings(TensorFlowEmbeddings):
     def create_placeholder(cls, name):
         return tf.placeholder(tf.int32, [None, None, None], name=name)
 
-    def __init__(self, name, vsz, dsz, scope, finetune=True, nfeat_factor=None,
-                 cfiltsz=[3], max_feat=30, gating='skip', num_gates=1, 
-                 activation='tanh', wsz=30, weights=None):
+    def __init__(self, name, **kwargs):
         super(CharConvEmbeddings, self).__init__()
 
+        self.scope = kwargs.get('scope', '{}/CharLUT'.format(self.name))
+
         self.name = name
-        self.vsz = vsz
-        self.dsz = dsz
-        self.scope = scope
-        self.finetune = finetune
-        self.nfeat_factor = nfeat_factor
-        self.cfiltsz = cfiltsz
-        self.max_feat = max_feat
-        self.gating = gating
-        self.num_gates = num_gates
-        self.activation = activation
-        self.wsz = wsz
-        self.weights = weights
+
+        self.vsz = kwargs.get('vsz')
+        self.dsz = kwargs.get('dsz')
+        self.finetune = kwargs.get('finetune', True)
+        self.name = name
+        self.scope = kwargs.get('scope', '{}/LUT'.format(self.name))
+        self.weights = kwargs.get('weights')
+        self.finetune = kwargs.get('finetune', True)
+        self.nfeat_factor = kwargs.get('nfeat_factor', None)
+        self.cfiltsz = kwargs.get('cfiltsz', [3])
+        self.max_feat = kwargs.get('max_feat', 30)
+        self.gating = kwargs.get('gating', 'skip')
+        self.num_gates = kwargs.get('num_gates', 1)
+        self.activation = kwargs.get('activation', 'tanh')
+        self.wsz = kwargs.get('wsz', 30)
+        self.weights = kwargs.get('weights', None)
         
         self.x = None
         if self.weights is None:
@@ -202,11 +201,11 @@ class CharConvEmbeddings(TensorFlowEmbeddings):
         """
         if self.weights is None:
             raise Exception('You must initialize `weights` in order to use this method')
-        return CharConvEmbeddings(self.name, self.vsz, self.dsz, self.scope, 
-                                  self.finetune, self.nfeat_factor,
-                                  self.cfiltsz, self.max_feat, self.gating, 
-                                  self.num_gates, self.activation, self.wsz, 
-                                  self.weights)
+        return CharConvEmbeddings(name=self.name, vsz=self.vsz, dsz=self.dsz, scope=self.scope,
+                                  finetune=self.finetune, nfeat_factor=self.nfeat_factor,
+                                  cfiltsz=self.cfiltsz, max_feat=self.max_feat, gating=self.gating,
+                                  num_gates=self.num_gates, activation=self.activation, wsz=self.wsz,
+                                  weights=self.weights)
 
     def save_md(self, target):
         write_json({'vsz': self.get_vsz(), 'dsz': self.get_dsz()}, target)
@@ -234,21 +233,7 @@ class CharConvEmbeddings(TensorFlowEmbeddings):
 
     @classmethod
     def create(cls, model, name, **kwargs):
-        vsz = model.vsz
-        dsz = model.dsz
-        weights = model.weights
-        finetune = kwargs.get('finetune', True)
-        scope = kwargs.get('scope', '{}/CharLUT'.format(name))
-        nfeat_factor = kwargs.get('nfeat_factor')
-        cfiltsz = kwargs.get('cfiltsz', [3])
-        max_feat = kwargs.get('max_feat', 200)
-        gating = kwargs.get('gating', 'skip')
-        num_gates = kwargs.get('num_gates', 1)
-        activation = kwargs.get('activation', 'tanh')
-        wsz = kwargs.get('kwargs', 30)
-
-        return cls(name, vsz, dsz, scope, finetune, nfeat_factor,
-                   cfiltsz, max_feat, gating, num_gates, activation, wsz, weights)
+        return cls(name=name, vsz=model.vsz, dsz=model.dsz, weights=model.weights, **kwargs)
 
 
 def get_timing_signal_1d(length,
@@ -297,7 +282,7 @@ def get_timing_signal_1d(length,
 @register_embeddings(name='positional')
 class PositionalLookupTableEmbeddings(LookupTableEmbeddings):
 
-    def __init__(self, name, vsz, dsz, scope, finetune=True, weights=None, unif=0.1):
+    def __init__(self, name, **kwargs):
         """Create a lookup-table based embedding.
 
         :param name: The name of the feature/placeholder, and a key for the scope
@@ -337,11 +322,4 @@ class PositionalLookupTableEmbeddings(LookupTableEmbeddings):
 
     @classmethod
     def create(cls, model, name, **kwargs):
-        vsz = model.vsz
-        dsz = model.dsz
-        weights = model.weights
-        finetune = kwargs.get('finetune', True)
-        scope = kwargs.get('scope', '{}/LUT'.format(name))
-        unif = kwargs.get('unif', 0.1)
-
-        return cls(name, vsz, dsz, scope, finetune, weights, unif)
+        return cls(name, vsz=model.vsz, dsz=model.dsz, weights=model.weights, **kwargs)

--- a/python/baseline/tf/lm/model.py
+++ b/python/baseline/tf/lm/model.py
@@ -294,7 +294,7 @@ class LanguageModelBase(LanguageModel):
             md = read_json('{}-{}-md.json'.format(basename, key))
             embed_args = dict({'vsz': md['vsz'], 'dsz': md['dsz']})
             Constructor = eval(class_name)
-            embeddings[key] = Constructor.create(key, **embed_args)
+            embeddings[key] = Constructor(key, **embed_args)
 
         model = cls.create(embeddings, **state)
         for prop in ls_props(model):

--- a/python/baseline/tf/seq2seq/model.py
+++ b/python/baseline/tf/seq2seq/model.py
@@ -225,13 +225,13 @@ class EncoderDecoderModelBase(EncoderDecoderModel):
             md = read_json('{}-{}-md.json'.format(basename, key))
             embed_args = dict({'vsz': md['vsz'], 'dsz': md['dsz']})
             Constructor = eval(class_name)
-            src_embeddings[key] = Constructor.create(key, **embed_args)
+            src_embeddings[key] = Constructor(key, **embed_args)
 
         tgt_class_name = state.pop('tgt_embedding')
         md = read_json('{}-tgt-md.json'.format(basename))
         embed_args = dict({'vsz': md['vsz'], 'dsz': md['dsz']})
         Constructor = eval(tgt_class_name)
-        tgt_embedding = Constructor.create('tgt', **embed_args)
+        tgt_embedding = Constructor('tgt', **embed_args)
         model = cls.create(src_embeddings, tgt_embedding, **state)
         for prop in ls_props(model):
             if prop in state:

--- a/python/baseline/tf/tagger/model.py
+++ b/python/baseline/tf/tagger/model.py
@@ -135,7 +135,7 @@ class TaggerModelBase(TaggerModel):
             embed_args = dict({'vsz': md['vsz'], 'dsz': md['dsz']})
             embed_args[key] = tf.get_default_graph().get_tensor_by_name('{}:0'.format(key))
             Constructor = eval(class_name)
-            model.embeddings[key] = Constructor.create(key, **embed_args)
+            model.embeddings[key] = Constructor(key, **embed_args)
 
         model.crf = bool(state.get('crf', False))
         model.proj = bool(state.get('proj', False))

--- a/python/baseline/tf/tfy.py
+++ b/python/baseline/tf/tfy.py
@@ -321,11 +321,11 @@ def multi_rnn_cell_w_dropout(hsz, pdrop, rnntype, num_layers, variational=False,
     """
     if variational:
         return tf.contrib.rnn.MultiRNNCell(
-            [rnn_cell_w_dropout(hsz, pdrop, rnntype, variational, training) for _ in range(num_layers)],
+            [rnn_cell_w_dropout(hsz, pdrop, rnntype, variational=variational, training=training) for _ in range(num_layers)],
             state_is_tuple=True
         )
     return tf.contrib.rnn.MultiRNNCell(
-        [rnn_cell_w_dropout(hsz, pdrop, rnntype, training) if i < num_layers - 1 else rnn_cell_w_dropout(hsz, 1.0, rnntype) for i in range(num_layers)],
+        [rnn_cell_w_dropout(hsz, pdrop, rnntype, training=training) if i < num_layers - 1 else rnn_cell_w_dropout(hsz, 1.0, rnntype) for i in range(num_layers)],
         state_is_tuple=True
     )
 


### PR DESCRIPTION
This fixes a bug introduced by a refactoring of the embeddings to not take kwargs in the constructor, and tot attempt to force the models to load from `.create()`.  This was not the intent of the `.create()` method, which expects to be loaded from pre-trained VSM embeddings.

Change reverts the `.load()` behavior on the model, and re-establishes the kwargs in the constructors