### PR TITLE
unpackable offsets

### DIFF
--- a/python/baseline/utils.py
+++ b/python/baseline/utils.py
@@ -8,6 +8,7 @@ import logging
 import zipfile
 import platform
 import importlib
+from collections import Mapping
 from contextlib import contextmanager
 from functools import partial, update_wrapper, wraps
 import numpy as np
@@ -47,8 +48,23 @@ def export(obj, all_list=None):
 exporter = export(__all__)
 
 
+class UnpackableOffsets(type):
+    def __iter__(self):
+        for x in self.VALUES:
+            yield x
+
+    def __getitem__(self, item):
+        item = item[1:-1]
+        return getattr(self, item)
+
+    def __len__(self):
+        return len(self.VALUES)
+
+# Multi-inheritance from multiple metaclasses requires a explicit metaclass
+class UnpackableOffsetsMapping(UnpackableOffsets, Mapping): pass
+
 @exporter
-class Offsets:
+class Offsets(six.with_metaclass(UnpackableOffsetsMapping)):
     """Support pre 3.4"""
     PAD, GO, EOS, UNK, OFFSET = range(0, 5)
     VALUES = ["<PAD>", "<GO>", "<EOS>", "<UNK>"]

--- a/python/tests/test_utils.py
+++ b/python/tests/test_utils.py
@@ -1,7 +1,8 @@
 import os
+from copy import deepcopy
 from functools import partial
 import pytest
-from baseline.utils import get_env_gpus
+from baseline.utils import get_env_gpus, Offsets
 
 
 @pytest.fixture
@@ -46,3 +47,26 @@ def test_none(remove_envs):
     gold = ['0']
     gpus = get_env_gpus()
     assert gpus == gold
+
+
+def test_offsets_double_star():
+    gold = {k: i for i, k in enumerate(Offsets.VALUES)}
+    assert dict(**Offsets) == gold
+
+
+def test_offsets_single_star():
+    gold = deepcopy(Offsets.VALUES)
+    def collect(*args):
+        return list(args)
+    assert collect(*Offsets) == gold
+
+
+def test_offsets_lengths():
+    gold = len(Offsets.VALUES)
+    assert len(Offsets) == gold
+
+
+def test_offsets_get_item():
+    for i, item in enumerate(Offsets.VALUES):
+        res = Offsets[item]
+        assert res == i


### PR DESCRIPTION
This makes offsets `**` and `*` unpackable as well as allowing `len()` to work on it. 