### PR TITLE
Add Lample LSTM character embeddings

### DIFF
--- a/python/baseline/dy/tagger/model.py
+++ b/python/baseline/dy/tagger/model.py
@@ -29,6 +29,7 @@ class TaggerModelBase(DynetModel, TaggerModel):
         self.activation_type = kwargs.get('activation', 'tanh')
         self.init_encoder(dsz, **kwargs)
         self.output = self.init_output(self.hsz, nc)
+        self.train = True
 
     def init_encoder(self, input_sz, **kwargs):
         pass
@@ -52,7 +53,7 @@ class TaggerModelBase(DynetModel, TaggerModel):
     def embed(self, batch_dict):
         all_embeddings_lists = []
         for k, embedding in self.embeddings.items():
-            all_embeddings_lists.append(embedding.encode(batch_dict[k]))
+            all_embeddings_lists.append(embedding.encode(batch_dict[k], self.train))
 
         embedded = dy.concatenate(all_embeddings_lists, d=1)
         embed_list = [self.dropout(e) for e in embedded]

--- a/python/baseline/tf/embeddings.py
+++ b/python/baseline/tf/embeddings.py
@@ -1,9 +1,9 @@
-import tensorflow as tf
-from baseline.tf.tfy import embed, pool_chars, get_shape_as_list
-from baseline.utils import write_json
-from baseline.embeddings import register_embeddings
-import numpy as np
 import math
+import numpy as np
+import tensorflow as tf
+from baseline.utils import write_json, Offsets
+from baseline.embeddings import register_embeddings
+from baseline.tf.tfy import embed, pool_chars, get_shape_as_list, stacked_lstm
 
 
 class TensorFlowEmbeddings(object):
@@ -183,7 +183,7 @@ class CharConvEmbeddings(TensorFlowEmbeddings):
         self.activation = kwargs.get('activation', 'tanh')
         self.wsz = kwargs.get('wsz', 30)
         self.weights = kwargs.get('weights', None)
-        
+
         self.x = None
         if self.weights is None:
             unif = kwargs.get('unif', 0.1)
@@ -318,3 +318,73 @@ class PositionalLookupTableEmbeddings(LookupTableEmbeddings):
     @classmethod
     def create(cls, model, name, **kwargs):
         return cls(name, vsz=model.vsz, dsz=model.dsz, weights=model.weights, **kwargs)
+
+@register_embeddings(name='char-lstm')
+class CharLSTMEmbeddings(TensorFlowEmbeddings):
+    @classmethod
+    def create_placeholder(cls, name):
+        return tf.placeholder(tf.int32, [None, None, None], name=name)
+
+    def __init__(self, name, **kwargs):
+        super(CharLSTMEmbeddings, self).__init__()
+        self.name = name
+        self.scope = kwargs.get('scope', '{}/CharLUT'.format(self.name))
+        self.vsz = kwargs.get('vsz')
+        self.dsz = kwargs.get('dsz')
+        self.finetune = kwargs.get('finetune', True)
+        self.weights = kwargs.get('weights')
+        self.lstmsz = kwargs.get('lstmsz', 50)
+        self.layers = kwargs.get('layers', 1)
+        self.pdrop = kwargs.get('pdrop', 0.5)
+        self.rnn_type = kwargs.get('rnn_type', 'blstm')
+        self.x = None
+        if self.weights is None:
+            unif = kwargs.get('unif', 0.1)
+            self.weights = np.random.uniform(-unif, unif, (self.vsz, self.dsz))
+
+    def detach_ref(self):
+        if self.weights is None:
+            raise Exception('You must initialize `weights` in order to use this method.')
+        return LampleLSTMEmbeddings(
+            name=self.name, vsz=self.vsz, dsz=self.dsz, scope=self.scope,
+            finetune=self.finetune, lstmsz=self.lstmsz, layers=self.layers,
+            dprop=self.pdrop, rnn_type=self.rnn_type, weights=self.weights,
+        )
+
+    def encode(self, x=None):
+        if x is None:
+            x = LampleLSTMEmbeddings.create_placeholder(self.name)
+        self.x = x
+        with tf.variable_scope(self.scope):
+            Wch = tf.get_variable(
+                "Wch",
+                initializer=tf.constant_initializer(self.weights, dtype=tf.float32, verify_shape=True),
+                shape=[self.vsz, self.dsz],
+                trainable=True
+            )
+            ech0 = tf.scatter_update(Wch, tf.constant(Offsets.PAD, dtype=tf.int32, shape=[1]), tf.zeros(shape=[1, self.dsz]))
+
+            shape = tf.shape(x)
+            B = shape[0]
+            T = shape[1]
+            W = shape[2]
+            flat_chars = tf.reshape(x, [-1, W])
+            word_lengths = tf.reduce_sum(tf.cast(tf.equal(flat_chars, Offsets.PAD), tf.int32), axis=1)
+            with tf.control_dependencies([ech0]):
+                embed_chars =  tf.nn.embedding_lookup(Wch, flat_chars)
+
+            fwd_lstm = stacked_lstm(self.lstmsz // 2, self.pdrop, self.layers)
+            bwd_lstm = stacked_lstm(self.lstmsz // 2, self.pdrop, self.layers)
+            _, rnn_state = tf.nn.bidirectional_dynamic_rnn(fwd_lstm, bwd_lstm, embed_chars, sequence_length=word_lengths, dtype=tf.float32)
+
+            result = tf.concat([rnn_state[0][-1].h, rnn_state[1][-1].h], axis=1)
+            return tf.reshape(result, [B, T, self.lstmsz])
+
+    def get_dsz(self):
+        return self.lstmsz
+
+    def get_vsz(self):
+        return self.vsz
+
+    def save_md(self, target):
+        write_json({'vsz': self.vsz, 'dsz': self.dsz, 'lstmsz': self.lstmsz}, target)

--- a/python/mead/config/mp-settings.json
+++ b/python/mead/config/mp-settings.json
@@ -1,17 +1,15 @@
 {
     "datacache": "~/.bl-data",
     "reporting_hooks":{
-        "visdom": {
-            "name": "ZZZZZZZZZZZZ"
-        },
         "xpctl": {
-            "cred": "~/xpctlcred.json"
+            "cred": "~/xpctlcred.json.remote",
+            "module": "reporting_xpctl"
         }
     },
     "hpctl": {
         "backend": {
             "type": "mp",
-            "real_gpus": [0, 1, 2, 3, 4, 5, 6]
+            "real_gpus": [0]
         },
         "logging": {
             "host": "localhost",


### PR DESCRIPTION
This PR adds Lample style lstm based character embeddings for all frameworks.

`7c683d15ffaf0d2070169ac72224bbc9ae6463d1     10.0  0.914731  0.002580  0.911343  0.917888`

These results (similar HPs to the Ma and Hovy paper with the lstm size matching the lample paper) are from a LSTM-LSTM-CRF model with Glove and Senna. Results seem consistent with Reimers and Gurevych where this model has a higher mean than MaHovy but a lower max.

This also updates the Dynet tagger so that dropout can be applied to the conv-char embeddings which brings performance (on a few test runs) closer to the TF and Pyt performance.