### PR TITLE
Mead export.py separates output for server and client.

### DIFF
--- a/python/baseline/remote.py
+++ b/python/baseline/remote.py
@@ -50,7 +50,10 @@ class RemoteModelTensorFlowREST(object):
         url = '{}/v1/models/{}{}:predict'.format(self.remote, self.name, v_str)
         request = self.create_request(examples)
         outcomes_list = requests.post(url, json=request)
-        outcomes_list = outcomes_list.json()['outputs']
+        outcomes_list = outcomes_list.json()
+        if "error" in outcomes_list:
+            raise ValueError("remote server returns error: {0}".format(outcomes_list["error"]))
+        outcomes_list = outcomes_list["outputs"]
         outcomes_list = self.deserialize_response(examples, outcomes_list)
         return outcomes_list
 

--- a/python/mead/export.py
+++ b/python/mead/export.py
@@ -18,6 +18,7 @@ def main():
     parser.add_argument('--model_version', help='model_version', default=1)
     parser.add_argument('--output_dir', help='output dir', default='./models')
     parser.add_argument('--beam', help='beam_width', default=30, type=int)
+    parser.add_argument('--is_remote', help='if True, separate items for remote server and client. If False bundle everything together', default=True, type=lambda x: (str(x).lower() == 'true'))
 
     args = parser.parse_args()
 
@@ -31,7 +32,7 @@ def main():
     task = mead.Task.get_task_specific(task_name, args.logging, args.settings)
     task.read_config(config_params, args.datasets)
     exporter = create_exporter(task, args.exporter_type)
-    exporter.run(args.model, args.output_dir, args.model_version)
+    exporter.run(args.model, args.output_dir, args.model_version, remote=args.is_remote)
 
 if __name__ == "__main__":
     main()

--- a/python/mead/tf/exporters.py
+++ b/python/mead/tf/exporters.py
@@ -49,16 +49,23 @@ class TensorFlowExporter(mead.exporters.Exporter):
                 sig_input, sig_output, sig_name, assets = self._create_rpc_call(sess, basename)
                 # output_path = os.path.join(tf.compat.as_bytes(output_dir), tf.compat.as_bytes(str(model_version)))
                 output_path = os.path.join(output_dir, str(model_version))
-                print('Exporting trained model to %s' % output_path)
-
+                print('Exporting Trained model to %s' % output_path)
+                for_remote = kwargs.get('remote', True)
+                client_output = server_output = output_path
+                if for_remote:
+                    client_output = os.path.join(output_dir, 'client/', os.path.basename(output_dir), str(model_version))
+                    server_output = os.path.join(output_dir, 'server/', os.path.basename(output_dir), str(model_version))
+                    os.makedirs(client_output)
                 try:
-                    builder = self._create_saved_model_builder(sess, output_path, sig_input, sig_output, sig_name)
-                    create_bundle(builder, output_path, basename, assets)
+                    builder = self._create_saved_model_builder(sess, server_output, sig_input, sig_output, sig_name)
+                    create_bundle(builder, client_output, basename, assets)
                     print('Successfully exported model to %s' % output_dir)
                 except AssertionError as e:
                     # model already exists
                     raise e
                 except Exception as e:
+                    import traceback
+                    traceback.print_exc()
                     # export process broke.
                     # TODO(MB): we should remove the directory, if one has been saved already.
                     raise e


### PR DESCRIPTION

`export.py` has the option to export to a remote serving or local serving.
1. Exporting to remote serving, it will create 2 output directories, `client` and `server`. Each contains necessary files for the server/client to consume. Eg:
```
>python export.py  ... --output_dir AOS1 --is_remote=true
>tree AOS1
AOS1/
├── client
│   └── AOS1
│       └── 1
│           ├── classify-model-tf-3751.labels
│           ├── model.assets
│           ├── vectorizers-3751.pkl
│           └── vocabs-word-3751.json
└── server
    └── AOS1
        └── 1
            ├── saved_model.pb
            └── variables
                ├── variables.data-00000-of-00001
                └── variables.index

```
The server would then consume `AOS1/server` and the client would consume `AOS1/client`. Eg:

For server: `tensorflow_model_server ... --model_base_path="AOS1/server/AOS1" --model_name="AOS1"`

For client: `remote_classifer = baseline.services.ClassifierService.load("AOS1/client/AOS1/1" name="AOS1", remote=<server>)`
2. Exporting to local serving, it will create a single output directory as before:
```
>python export.py  ... --output_dir AOS1_local --is_remote=false
>tree AOS1_local
AOS1_local/
└── 1
    ├── classify-model-tf-3751.labels
    ├── model.assets
    ├── saved_model.pb
    ├── variables
    │   ├── variables.data-00000-of-00001
    │   └── variables.index
    ├── vectorizers-3751.pkl
    └── vocabs-word-3751.json

```