### PR TITLE
Don't crash when there is an empty vocab.

### DIFF
--- a/python/baseline/w2v.py
+++ b/python/baseline/w2v.py
@@ -104,8 +104,8 @@ class PretrainedEmbeddingsModel(WordEmbeddingsModel):
     def __init__(self, filename, known_vocab=None, unif_weight=None, keep_unused=False, normalize=False, **kwargs):
         super(PretrainedEmbeddingsModel, self).__init__()
 
-        if known_vocab is None and keep_unused is False:
-            print('Warning: known_vocab=None, keep_unused=False. Setting keep_unused=True, all vocab will be preserved')
+        if (known_vocab is None or not known_vocab) and keep_unused is False:
+            print('Warning: known_vocab=None or is Empty, keep_unused=False. Setting keep_unused=True, all vocab will be preserved')
             keep_unused = True
         uw = 0.0 if unif_weight is None else unif_weight
         self.vocab = {}


### PR DESCRIPTION
This PR makes the pretrained vector reader class use the full pretrained vocab when an empty vocab is given as well as when the `known_vocab` is `None`. Otherwise you get an esoteric error about `vec` not being defined when reading the vectors (for glove files at least).

This came about when I had the dataset index pointing at a wrong file, the vocab from the reader was empty which caused errors in `w2v.py`. Do we want to add some sort of warning in MEAD that no vocab could be generated from the datasets when this happens?