### PR TITLE
remove EOW from token1d vectorizers

### DIFF
--- a/python/baseline/vectorizers.py
+++ b/python/baseline/vectorizers.py
@@ -75,7 +75,6 @@ class Token1DVectorizer(AbstractVectorizer):
         for tok in self.iterable(tokens):
             counter[tok] += 1
             seen += 1
-            counter['<EOW>'] += 1
         self.max_seen = max(self.max_seen, seen)
         return counter
 


### PR DESCRIPTION
This isn't used for token vectorizers so it doesn't need to be there, especially given that it appears in the output space for the taggers.