### PR TITLE
add fastText text file parsing

### DIFF
--- a/python/baseline/mime_type.py
+++ b/python/baseline/mime_type.py
@@ -2,6 +2,8 @@ import re
 from binascii import hexlify
 from functools import partial
 from baseline.utils import export
+import sys
+PY3 = sys.version_info[0] == 3
 
 __all__ = []
 exporter = export(__all__)
@@ -17,6 +19,36 @@ def check_mn(b, mn=None, start=0):
         return True
     return False
 
+# A function that takes an integer in the 8-bit range and returns
+# a single-character byte object in py3 / a single-character string
+# in py2.
+#
+int2byte = (lambda x: bytes((x,))) if PY3 else chr
+
+_text_characters = (
+        b''.join(int2byte(i) for i in range(32, 127)) +
+        b'\n\r\t\f\b')
+
+# Borrowed from: https://eli.thegreenplace.net/2011/10/19/perls-guess-if-file-is-text-or-binary-implemented-in-python
+def is_text_file(block):
+    """ Uses heuristics to guess whether the given file is text or binary,
+        by reading a single block of bytes from the file.
+        If more than 30% of the chars in the block are non-text, or there
+        are NUL ('\x00') bytes in the block, assume this is a binary file.
+    """
+    if b'\x00' in block:
+        # Files with null bytes are binary
+        return False
+    elif not block:
+        # An empty file is considered a valid text file
+        return True
+
+    # Use translate's 'deletechars' argument to efficiently remove all
+    # occurrences of _text_characters from the block
+    nontext = block.translate(None, _text_characters)
+    return float(len(nontext)) / len(block) <= 0.30
+
+
 check_gzip = partial(check_mn, mn=MN.GZIP)
 check_tar = partial(check_mn, mn=MN.TAR, start=MN.TAR_START)
 check_zip = partial(check_mn, mn=MN.ZIP)
@@ -29,7 +61,7 @@ def check_re(b, regex=None):
     return True if regex.match(b) else False
 
 check_html = partial(check_re, regex=RE.HTML)
-check_bin = partial(check_re, regex=RE.BIN)
+
 
 @exporter
 def mime_type(file_name):
@@ -42,6 +74,6 @@ def mime_type(file_name):
         return "application/zip"
     if check_html(b):
         return "text/html"
-    if check_bin(b):
-        return "application/w2v"
-    return "text/plain"
+    if is_text_file(b):
+        return "text/plain"
+    return "application/w2v"


### PR DESCRIPTION
This change makes it possible to load fastText text files, which contain the same header as word2vec, but with a text body like GloVe.  The text file reader just ignores the first line, but I also had to change how we detect binary (the previous check caused ambiguity)