### PR TITLE
Update embeddings

### DIFF
--- a/python/baseline/embeddings.py
+++ b/python/baseline/embeddings.py
@@ -68,7 +68,7 @@ def load_embeddings(name, **kwargs):
 
     elif hasattr(embeddings_cls, 'create'):
         unif = kwargs.pop('unif', 0.1)
-        known_vocab = kwargs.pop('known_vocab')
+        known_vocab = kwargs.pop('known_vocab', None)
         keep_unused = kwargs.pop('keep_unused', False)
         normalize = kwargs.pop('normalized', False)
         # if there is no filename, use random-init model

--- a/python/baseline/tf/embeddings.py
+++ b/python/baseline/tf/embeddings.py
@@ -102,7 +102,6 @@ class LookupTableEmbeddings(TensorFlowEmbeddings):
         return tf.placeholder(tf.int32, [None, None], name=name)
 
     def __init__(self, name, **kwargs):
-        super(LookupTableEmbeddings, self).__init__(kwargs.get('finetune', True), name)
         """Create a lookup-table based embedding.
 
         :param name: The name of the feature/placeholder, and a key for the scope
@@ -116,13 +115,12 @@ class LookupTableEmbeddings(TensorFlowEmbeddings):
         * *scope* -- (``str``) An optional variable scope, by default it will be `{name}/LUT`
         * *unif* -- (``float``) (defaults to `0.1`) If the weights should be created, what is the random initialization range
         """
-        super(LookupTableEmbeddings, self).__init__()
+        super(LookupTableEmbeddings, self).__init__(kwargs.get('finetune', True), name)
 
         self.vsz = kwargs.get('vsz')
         self.dsz = kwargs.get('dsz')
         self.finetune = kwargs.get('finetune', True)
-        self._name = name
-        self.scope = kwargs.get('scope', '{}/LUT'.format(self._name))
+        self.scope = kwargs.get('scope', '{}/LUT'.format(self.name))
 
         self.weights = kwargs.get('weights')
 
@@ -148,7 +146,7 @@ class LookupTableEmbeddings(TensorFlowEmbeddings):
         """
         if self.weights is None:
             raise Exception('You must initialize `weights` in order to use this method')
-        return LookupTableEmbeddings(self._name,
+        return LookupTableEmbeddings(self.name,
                                      vsz=self.vsz,
                                      dsz=self.dsz,
                                      scope=self.scope,
@@ -162,7 +160,7 @@ class LookupTableEmbeddings(TensorFlowEmbeddings):
         :return: The sub-graph output
         """
         if x is None:
-            x = LookupTableEmbeddings.create_placeholder(self._name)
+            x = LookupTableEmbeddings.create_placeholder(self.name)
         self.x = x
 
         e0 = tf.scatter_update(self.W, tf.constant(0, dtype=tf.int32, shape=[1]), tf.zeros(shape=[1, self.dsz]))
@@ -188,8 +186,7 @@ class CharConvEmbeddings(TensorFlowEmbeddings):
         return tf.placeholder(tf.int32, [None, None, None], name=name)
 
     def __init__(self, name, **kwargs):
-        super(CharConvEmbeddings, self).__init__()
-        self._name = name
+        super(CharConvEmbeddings, self).__init__(name=name)
         self.scope = kwargs.get('scope', '{}/CharLUT'.format(self.name))
         self.vsz = kwargs.get('vsz')
         self.dsz = kwargs.get('dsz')
@@ -222,7 +219,7 @@ class CharConvEmbeddings(TensorFlowEmbeddings):
         """
         if self.weights is None:
             raise Exception('You must initialize `weights` in order to use this method')
-        return CharConvEmbeddings(name=self._name, vsz=self.vsz, dsz=self.dsz, scope=self.scope,
+        return CharConvEmbeddings(name=self.name, vsz=self.vsz, dsz=self.dsz, scope=self.scope,
                                   finetune=self.finetune, nfeat_factor=self.nfeat_factor,
                                   cfiltsz=self.cfiltsz, max_feat=self.max_feat, gating=self.gating,
                                   num_gates=self.num_gates, activation=self.activation, wsz=self.wsz,
@@ -234,7 +231,7 @@ class CharConvEmbeddings(TensorFlowEmbeddings):
         self.x = x
 
         ech0 = tf.scatter_update(self.Wch, tf.constant(0, dtype=tf.int32, shape=[1]), tf.zeros(shape=[1, self.dsz]))
-        char_comp, self.wsz = pool_chars(x, self.Wch, ech0, self.dsz, self.nfeat_factor,
+        char_comp, self.wsz = pool_chars(self.x, self.Wch, ech0, self.dsz, self.nfeat_factor,
                                          self.cfiltsz, self.max_feat, self.gating,
                                          self.num_gates, self.activation, self.wsz)
         return char_comp

--- a/python/mead/config/sst2-bert-hub-maxmean.json
+++ b/python/mead/config/sst2-bert-hub-maxmean.json
@@ -1,0 +1,53 @@
+{
+  "version": 2,
+  "task": "classify",
+  "basedir": "./sst2",
+  "batchsz": 50,
+  "modules": [
+    "embed_bert"
+  ],
+  "features": [
+    {
+      "name": "bert",
+      "vectorizer": {
+        "type": "wordpiece1d",
+        "vocab_file": "/home/dpressel/dev/work/bert/uncased_L-12_H-768_A-12/vocab.txt"
+      },
+      "embeddings": {
+        "type": "bert-embed",
+        "embed_file": "https://tfhub.dev/google/bert_uncased_L-12_H-768_A-12/1",
+        "dsz": 768
+      }
+    }
+  ],
+  "preproc": {
+    "mxlen": 100
+  },
+  "backend": "tensorflow",
+  "dataset": "SST2",
+  "loader": {
+    "reader_type": "default"
+  },
+  "unif": 0.25,
+  "model": {
+    "model_type": "composite",
+    "sub": [
+      "NBowModel",
+      "NBowMaxModel"
+    ],
+    "hsz": 100,
+    "dropout": 0.5,
+    "finetune": true
+  },
+  "train": {
+    "epochs": 5,
+    "optim": "adamw",
+    "eta": 0.00025,
+    "weight_decay": 1.0e-5,
+    "early_stopping_metric": "acc",
+    "verbose": {
+      "console": true,
+      "file": "sst2-cm.csv"
+    }
+  }
+}

--- a/python/mead/config/sst2-bert-hub.json
+++ b/python/mead/config/sst2-bert-hub.json
@@ -1,0 +1,54 @@
+{
+  "version": 2,
+  "task": "classify",
+  "basedir": "./sst2",
+  "batchsz": 50,
+  "modules": [
+    "embed_bert"
+  ],
+  "features": [
+    {
+      "name": "bert",
+      "vectorizer": {
+        "type": "wordpiece1d",
+        "vocab_file": "/home/dpressel/dev/work/bert/uncased_L-12_H-768_A-12/vocab.txt"
+      },
+      "embeddings": {
+        "type": "bert-embed",
+        "embed_file": "https://tfhub.dev/google/bert_uncased_L-12_H-768_A-12/1",
+        "dsz": 768
+      }
+    }
+  ],
+  "preproc": {
+    "mxlen": 100
+  },
+  "backend": "tensorflow",
+  "dataset": "SST2",
+  "loader": {
+    "reader_type": "default"
+  },
+  "unif": 0.25,
+  "model": {
+    "model_type": "default",
+    "filtsz": [
+      3,
+      4,
+      5
+    ],
+    "cmotsz": 100,
+    "dropout": 0.5,
+    "finetune": true
+  },
+  "train": {
+    "epochs": 5,
+    "optim": "adamw",
+    "eta": 0.00025,
+    "weight_decay": 1.0e-5,
+    "early_stopping_metric": "acc",
+    "verbose": {
+      "console": true,
+      "file": "sst2-cm.csv"
+    }
+  }
+}

--- a/python/mead/config/sst2-bert-mean.json
+++ b/python/mead/config/sst2-bert-mean.json
@@ -1,0 +1,53 @@
+{
+    "version": 2,
+    "task": "classify",
+    "basedir": "./sst2",
+    "batchsz": 50,
+    "modules": ["embed_bert"],
+    "features": 
+    [
+	{
+	    "name": "bert",
+	    "vectorizer": {
+		"type": "wordpiece1d",
+		"vocab_file": "/home/dpressel/dev/work/bert/uncased_L-12_H-768_A-12/vocab.txt"
+	    },
+	    "embeddings": {
+		"type": "bert",
+		"dsz": 768,
+		"vocab_file": "/home/dpressel/dev/work/bert/uncased_L-12_H-768_A-12/vocab.txt",
+		"bert_config": "/home/dpressel/dev/work/bert/uncased_L-12_H-768_A-12/bert_config.json",
+		"embed_file": "/home/dpressel/dev/work/bert/uncased_L-12_H-768_A-12/bert_model.ckpt",
+                "operator": "mean",
+                "layers": [-1,-2, -3, -4]
+	    }
+	}
+    ],
+    "preproc": {
+	"mxlen": 100
+    },
+    "backend": "tensorflow",
+    "dataset": "SST2",
+    "loader": {
+	"reader_type": "default"
+    },
+    "unif": 0.25,
+    "model": {
+	"model_type": "default",
+	"filtsz": [3,4,5],
+	"cmotsz": 100,
+	"dropout": 0.5,
+	"finetune": true
+    },
+    "train": {
+	"epochs": 5,
+	"optim": "adamw",
+	"eta": 0.00025,
+        "weight_decay": 1.0e-5,
+	"early_stopping_metric": "acc",
+	"verbose": {
+	    "console": true,
+	    "file": "sst2-cm.csv"
+	}
+    }
+}


### PR DESCRIPTION
* This is a small refactoring that makes the tf embeddings inherit from a keras layer
  - Adds a few optional parameters
  - Moves the config generation under `get_config`
  - it allows `known_vocab` to not exist in `load_embeddings` which makes it easier to use as an API instead of from MEAD
  - it renames `.weights` to `._weights` so as not to collide with Keras
* Also, adds a new tfhub based bert embeddings object
  - support sentence level features on last layer and direct use of final hidden state (the existing model supports sentence level features on any combination of layers on a reduce operation and that remains)
  - module now supports direct model loading (as before) as well as tfhub loading by URL
  - there is caching for the BERT vocab so that its only loaded on the first run

I did not refactor to use the tfhub `vocab_file` yet, that will come later