### PR TITLE
Make preproc config param optional

### DIFF
--- a/python/baseline/services.py
+++ b/python/baseline/services.py
@@ -249,11 +249,11 @@ class TaggerService(Service):
                             mxwlen = max(mxwlen, len(t))
             # If its a dict, we just wrap it up
             elif isinstance(tokens[0], dict):
-                mxlen = max(len(tokens))
+                mxlen = len(tokens)
                 for t in tokens:
                     mxwlen = max(mxwlen, len(t))
                 tokens_seq = [tokens]
-            else:
+             else:
                 raise Exception('Unknown input format')
 
         if len(tokens_seq) == 0:

--- a/python/baseline/services.py
+++ b/python/baseline/services.py
@@ -253,7 +253,7 @@ class TaggerService(Service):
                 for t in tokens:
                     mxwlen = max(mxwlen, len(t))
                 tokens_seq = [tokens]
-             else:
+            else:
                 raise Exception('Unknown input format')
 
         if len(tokens_seq) == 0:

--- a/python/mead/tasks.py
+++ b/python/mead/tasks.py
@@ -103,8 +103,8 @@ class Task(object):
             if feature.get('primary', False) is True:
                 self.primary_key = key
             vectorizer_section = feature.get('vectorizer', {'type': 'token1d'})
-            vectorizer_section['mxlen'] = vectorizer_section.get('mxlen', self.config_params.get('preproc', dict()).get('mxlen', -1))
-            vectorizer_section['mxwlen'] = vectorizer_section.get('mxwlen', self.config_params.get('preproc', dict()).get('mxwlen', -1))
+            vectorizer_section['mxlen'] = vectorizer_section.get('mxlen', self.config_params.get('preproc', {}).get('mxlen', -1))
+            vectorizer_section['mxwlen'] = vectorizer_section.get('mxwlen', self.config_params.get('preproc', {}).get('mxwlen', -1))
             if 'transform' in vectorizer_section:
                 vectorizer_section['transform_fn'] = eval(vectorizer_section['transform'])
             vectorizer = baseline.create_vectorizer(**vectorizer_section)
@@ -181,7 +181,7 @@ class Task(object):
     def _create_task_specific_reader(self):
         self._create_vectorizers()
         reader_params = self.config_params['loader']
-        reader_params['clean_fn'] = reader_params.get('clean_fn', self.config_params.get('preproc', dict()).get('clean_fn'))
+        reader_params['clean_fn'] = reader_params.get('clean_fn', self.config_params.get('preproc', {}).get('clean_fn'))
         reader_params['mxlen'] = self.vectorizers[self.primary_key].mxlen
         if self.config_params['model'].get('gpus', 1) > 1:
             reader_params['truncate'] = True
@@ -189,7 +189,7 @@ class Task(object):
 
     @staticmethod
     def _get_min_f(config):
-        backoff = config['loader'].get('min_f', config.get('preproc', dict()).get('min_f', -1))
+        backoff = config['loader'].get('min_f', config.get('preproc', {}).get('min_f', -1))
         return {f['name']: f.get('min_f', backoff) for f in config['features']}
 
     def _setup_task(self, **kwargs):
@@ -289,7 +289,7 @@ class Task(object):
         unif = self.config_params.get('unif', 0.1)
         keep_unused = self.config_params.get('keep_unused', False)
 
-        embeddings_map = dict()
+        embeddings_map = {}
         out_vocabs = {}
         for feature in features:
             embeddings_section = feature['embeddings']
@@ -370,11 +370,11 @@ class ClassifierTask(Task):
 
     def _setup_task(self, **kwargs):
         super(ClassifierTask, self)._setup_task(**kwargs)
-        if self.config_params.get('preproc', dict()).get('clean', False) is True:
-            self.config_params.get('preproc', dict())['clean_fn'] = baseline.TSVSeqLabelReader.do_clean
+        if self.config_params.get('preproc', {}).get('clean', False) is True:
+            self.config_params.get('preproc', {})['clean_fn'] = baseline.TSVSeqLabelReader.do_clean
             print('Clean')
         else:
-            self.config_params['preproc'] = dict()
+            self.config_params['preproc'] = {}
             self.config_params['preproc']['clean_fn'] = None
 
     def initialize(self, embeddings):
@@ -427,7 +427,7 @@ class TaggerTask(Task):
     def _create_backend(self, **kwargs):
         backend = Backend(self.config_params.get('backend', 'tf'))
         if 'preproc' not in self.config_params:
-            self.config_params['preproc'] = dict()
+            self.config_params['preproc'] = {}
         if backend.name == 'pytorch':
             self.config_params['preproc']['trim'] = True
         elif backend.name == 'dy':
@@ -529,7 +529,7 @@ class EncoderDecoderTask(Task):
     def _create_backend(self, **kwargs):
         backend = Backend(self.config_params.get('backend', 'tf'))
         if 'preproc' not in self.config_params:
-            self.config_params['preproc'] = dict()
+            self.config_params['preproc'] = {}
         self.config_params['preproc']['show_ex'] = show_examples
         if backend.name == 'pytorch':
             self.config_params['preproc']['trim'] = True
@@ -623,7 +623,7 @@ class EncoderDecoderTask(Task):
         rlut2 = baseline.revlut(self.feat2tgt)
         if num_ex > 0:
             print('Showing examples')
-            preproc = self.config_params.get('preproc', dict())
+            preproc = self.config_params.get('preproc', {})
             show_ex_fn = preproc['show_ex']
             self.config_params['train']['after_train_fn'] = lambda model: show_ex_fn(model,
                                                                                      self.valid_data, rlut1, rlut2,
@@ -650,7 +650,7 @@ class LanguageModelingTask(Task):
 
         reader_params = self.config_params['loader']
         reader_params['nctx'] = reader_params.get('nctx', self.config_params.get('nctx', self.config_params.get('nbptt', 35)))
-        reader_params['clean_fn'] = reader_params.get('clean_fn', self.config_params.get('preproc', dict()).get('clean_fn'))
+        reader_params['clean_fn'] = reader_params.get('clean_fn', self.config_params.get('preproc', {}).get('clean_fn'))
         reader_params['mxlen'] = self.vectorizers[self.primary_key].mxlen
         if self.config_params['model'].get('gpus', 1) > 1:
             reader_params['truncate'] = True
@@ -660,10 +660,10 @@ class LanguageModelingTask(Task):
         backend = Backend(self.config_params.get('backend', 'tf'))
 
         if backend.name == 'pytorch':
-            self.config_params.get('preproc', dict())['trim'] = True
+            self.config_params.get('preproc', {})['trim'] = True
 
         elif backend.name == 'dy':
-            self.config_params.get('preproc', dict())['trim'] = True
+            self.config_params.get('preproc', {})['trim'] = True
             import _dynet
             dy_params = _dynet.DynetParams()
             dy_params.from_args()

--- a/python/mead/tasks.py
+++ b/python/mead/tasks.py
@@ -650,7 +650,7 @@ class LanguageModelingTask(Task):
 
         reader_params = self.config_params['loader']
         reader_params['nctx'] = reader_params.get('nctx', self.config_params.get('nctx', self.config_params.get('nbptt', 35)))
-        reader_params['clean_fn'] = reader_params.get('clean_fn', self.config_params.get('preproc', {}).get('clean_fn'))
+        reader_params['clean_fn'] = reader_params.get('clean_fn', self.config_params.get('preproc', dict()).get('clean_fn'))
         reader_params['mxlen'] = self.vectorizers[self.primary_key].mxlen
         if self.config_params['model'].get('gpus', 1) > 1:
             reader_params['truncate'] = True


### PR DESCRIPTION
in `v1`, the configs should not have a `preproc` section, but there were places in the code where we were assuming that section existed. this PR fixes that.

tested with one config. but do not merge it now, ~i will change all configs by removing the `preproc` section~. i will update the PR. 

As we decided to keep `preproc` i think the PR should be ok to merge, i am not changing the other configs to remove the preproc section. I have tested with one classification and one tagger config. worked for both.

There's another change: needed for tagger models to work when tokens are in the format `List[{'feature1': <>, 'feature2': <>}]` 