### PR TITLE
add optional support to reload from a checkpoint

### DIFF
--- a/python/baseline/tf/classify/model.py
+++ b/python/baseline/tf/classify/model.py
@@ -412,6 +412,7 @@ class ClassifierModelBase(ClassifierModel):
                 model.probs = tf.nn.softmax(model.logits, name="probs")
         model.sess = sess
         # writer = tf.summary.FileWriter('blah', sess.graph)
+
         return model
 
     def embed(self, **kwargs):

--- a/python/baseline/tf/classify/train.py
+++ b/python/baseline/tf/classify/train.py
@@ -149,6 +149,12 @@ def fit(model, ts, vs, es=None, **kwargs):
     model.sess.run(tables)
     model.sess.run(tf.global_variables_initializer())
     model.set_saver(tf.train.Saver())
+    checkpoint = kwargs.get('checkpoint')
+    if checkpoint is not None:
+        latest = tf.train.latest_checkpoint(checkpoint)
+        print('Reloading ' + latest)
+        model.saver.restore(model.sess, latest)
+
 
     last_improved = 0
 

--- a/python/baseline/tf/lm/train.py
+++ b/python/baseline/tf/lm/train.py
@@ -148,6 +148,11 @@ def fit(model, ts, vs, es=None, **kwargs):
     model.sess.run(init)
     saver = tf.train.Saver()
     model.set_saver(saver)
+    checkpoint = kwargs.get('checkpoint')
+    if checkpoint is not None:
+        latest = tf.train.latest_checkpoint(checkpoint)
+        print('Reloading ' + latest)
+        model.saver.restore(model.sess, latest)
 
     do_early_stopping = bool(kwargs.get('do_early_stopping', True))
 

--- a/python/baseline/tf/seq2seq/train.py
+++ b/python/baseline/tf/seq2seq/train.py
@@ -153,6 +153,12 @@ def fit(model, ts, vs, es=None, **kwargs):
     saver = tf.train.Saver()
     trainer.prepare(saver)
 
+    checkpoint = kwargs.get('checkpoint')
+    if checkpoint is not None:
+        latest = tf.train.latest_checkpoint(checkpoint)
+        print('Reloading ' + latest)
+        model.saver.restore(model.sess, latest)
+
     do_early_stopping = bool(kwargs.get('do_early_stopping', True))
 
     best_metric = 0

--- a/python/baseline/tf/tagger/train.py
+++ b/python/baseline/tf/tagger/train.py
@@ -164,6 +164,12 @@ def fit(model, ts, vs, es, **kwargs):
     model.sess.run(init)
     saver = tf.train.Saver()
     model.save_using(saver)
+    checkpoint = kwargs.get('checkpoint')
+    if checkpoint is not None:
+        latest = tf.train.latest_checkpoint(checkpoint)
+        print('Reloading ' + latest)
+        model.saver.restore(model.sess, latest)
+
     do_early_stopping = bool(kwargs.get('do_early_stopping', True))
     verbose = bool(kwargs.get('verbose', False))
 

--- a/python/mead/trainer.py
+++ b/python/mead/trainer.py
@@ -17,6 +17,7 @@ def main():
     parser.add_argument('--gpus', help='Number of GPUs (defaults to number available)', type=int, default=-1)
     parser.add_argument('--reporting', help='reporting hooks', nargs='+')
     parser.add_argument('--backend', help='The deep learning backend to use')
+    parser.add_argument('--checkpoint', help='Restart training from this checkpoint')
     args, reporting_args = parser.parse_known_args()
 
     config_params = read_config_stream(args.config)
@@ -45,7 +46,7 @@ def main():
     task = mead.Task.get_task_specific(task_name, args.logging, args.settings)
     task.read_config(config_params, args.datasets, reporting_args=reporting_args, config_file=deepcopy(config_params))
     task.initialize(args.embeddings)
-    task.train()
+    task.train(args.checkpoint)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
this adds an argument to `task.fit()` and the underlying trainer `fit()` methods that allows a `checkpoint` param to be passed in which is restored (for tensorflow).  This updates `mead-train` to support this optional argument as well.  It doesnt track the status of training and restart from there, it just restores the model