### PR TITLE
fix vocab bug that casuses non compact numbering

### DIFF
--- a/python/baseline/w2v.py
+++ b/python/baseline/w2v.py
@@ -162,6 +162,7 @@ class PretrainedEmbeddingsModel(WordEmbeddingsModel):
             for i in range(vsz):
                 word = self._readtospc(f)
                 raw = f.read(width)
+                if word in self.vocab: continue
                 if keep_unused is False and word not in known_vocab:
                     continue
                 if known_vocab and word in known_vocab:
@@ -193,6 +194,7 @@ class PretrainedEmbeddingsModel(WordEmbeddingsModel):
                 current = header_end + 1
                 for i in range(vsz):
                     word, vec, current = self._read_word2vec_line_mmap(m, width, current)
+                    if word in self.vocab: continue
                     if keep_unused is False and word not in known_vocab:
                         continue
                     if known_vocab and word in known_vocab:


### PR DESCRIPTION
If a w2v file had a duplicate word then the word would take on the index the second/later time it was found leaving a gap in the vocab. This lead to `len(vocab) < max(vocab.values())`. This causes bug later for example in preproc exporter when it tries to turn the vocab into a list by iterating through `for v, i in vocab.items()` and assigning to a list of size `len(vocab)`