### PR TITLE
Feature/load backport

### DIFF
--- a/api-examples/classify-text.py
+++ b/api-examples/classify-text.py
@@ -9,8 +9,7 @@ parser.add_argument('--backend', help='backend', default='tf')
 parser.add_argument('--remote', help='(optional) remote endpoint', type=str) # localhost:8500
 parser.add_argument('--name', help='(optional) service name', type=str)
 parser.add_argument('--preproc', help='(optional) where to perform preprocessing', choices={'client', 'server'}, default='client')
-
-args = parser.parse_known_args()[0]
+args = parser.parse_args()
 
 if os.path.exists(args.text) and os.path.isfile(args.text):
     texts = []

--- a/api-examples/tag-text.py
+++ b/api-examples/tag-text.py
@@ -10,6 +10,8 @@ parser.add_argument('--remote', help='(optional) remote endpoint', type=str) # l
 parser.add_argument('--name', help='(optional) signature name', type=str)
 parser.add_argument('--preproc', help='(optional) where to perform preprocessing', choices={'client', 'server'}, default='client')
 
+bl.import_user_module("vec_text")
+
 args = parser.parse_known_args()[0]
 
 if os.path.exists(args.text) and os.path.isfile(args.text):

--- a/api-examples/tag-text.py
+++ b/api-examples/tag-text.py
@@ -9,10 +9,7 @@ parser.add_argument('--backend', help='backend', default='tf')
 parser.add_argument('--remote', help='(optional) remote endpoint', type=str) # localhost:8500
 parser.add_argument('--name', help='(optional) signature name', type=str)
 parser.add_argument('--preproc', help='(optional) where to perform preprocessing', choices={'client', 'server'}, default='client')
-
-bl.import_user_module("vec_text")
-
-args = parser.parse_known_args()[0]
+args = parser.parse_args()
 
 if os.path.exists(args.text) and os.path.isfile(args.text):
     texts = []

--- a/python/addons/embed_elmo.py
+++ b/python/addons/embed_elmo.py
@@ -1057,6 +1057,3 @@ class ELMoHubEmbeddings(TensorFlowEmbeddings):
         return ELMoHubEmbeddings(
             self.name, dsz=self.dsz, vsz=self.vsz, finetune=self.finetune, cache_dir=self.cache_dir
         )
-
-    def save_md(self, target):
-        write_json({'vsz': self.vsz, 'dsz': self.dsz}, target)

--- a/python/addons/residual_conv.py
+++ b/python/addons/residual_conv.py
@@ -1,0 +1,41 @@
+import tensorflow as tf
+from baseline.model import register_model
+from baseline.tf.classify import ClassifierModelBase
+
+
+@register_model(task='classify', name='res-conv')
+class ResidualConvClassifier(ClassifierModelBase):
+    """A Conv Net classifier that sums the parallel filters rather than concat."""
+    def pool(self, embed, dsz, init, **kwargs):
+        filtsz = kwargs['filtsz']
+        motsz = kwargs['cmotsz']
+        DUMMY_AXIS = 1
+        TIME_AXIS = 2
+        FEATURE_AXIS = 3
+        expanded = tf.expand_dims(embed, DUMMY_AXIS)
+        output = tf.zeros((tf.shape(expanded)[0], 1, tf.shape(expanded)[TIME_AXIS], motsz))
+        for fsz in filtsz:
+            with tf.variable_scope('cmot-%s' % fsz):
+                kernel_shape = [1, fsz, dsz, motsz]
+                W = tf.get_variable('W', kernel_shape)
+                b = tf.get_variable(
+                    'b', [motsz],
+                    initializer=tf.constant_initializer(0.0)
+                )
+                conv = tf.nn.conv2d(
+                    expanded, W,
+                    strides=[1, 1, 1, 1],
+                    padding="SAME", name="CONV"
+                )
+                activation = tf.nn.relu(tf.nn.bias_add(conv, b), 'activation')
+                output += activation
+        combine = tf.reshape(tf.reduce_max(output, axis=TIME_AXIS), (-1, motsz))
+        return combine
+
+    @classmethod
+    def create(cls, embeddings, labels, **kwargs):
+        from baseline.utils import color, Colors
+        print(color("="*80, Colors.RED))
+        print(color("THIS IS TO SHOW THAT THIS SUBCLASS CREATE IS CALLED WHEN LOADING!", Colors.RED))
+        print(color("="*80, Colors.RED))
+        return super(ResidualConvClassifier, cls).create(embeddings, labels, **kwargs)

--- a/python/baseline/remote.py
+++ b/python/baseline/remote.py
@@ -34,7 +34,7 @@ class RemoteModelTensorFlowREST(object):
         """
         return self.labels
 
-    def predict(self, examples):
+    def predict(self, examples, **kwargs):
         """Run prediction over HTTP/REST.
 
         :param examples: The input examples
@@ -146,7 +146,7 @@ class RemoteModelTensorFlowGRPC(object):
         """
         return self.labels
 
-    def predict(self, examples):
+    def predict(self, examples, **kwargs):
         """Run prediction over gRPC
 
         :param examples: The input examples

--- a/python/baseline/remote.py
+++ b/python/baseline/remote.py
@@ -91,7 +91,7 @@ class RemoteModelTensorFlowREST(object):
             for i in range(num_ex):
                 score_i = scores[i]
                 classes_i = classes[i]
-                d = [(c, s) for c, s in zip(classes_i, score_i)]
+                d = [(c, np.float32(s)) for c, s in zip(classes_i, score_i)]
                 result.append(d)
             return result
 

--- a/python/baseline/tf/classify/model.py
+++ b/python/baseline/tf/classify/model.py
@@ -187,8 +187,6 @@ class ClassifierModelBase(ClassifierModel):
         write_json(self.labels, '{}.labels'.format(basename))
         for key, embedding in self.embeddings.items():
             embedding.save_md('{}-{}-md.json'.format(basename, key))
-        with open('{}.saver'.format(basename), 'w') as f:
-            f.write(str(self.saver.as_saver_def()))
 
     def _record_state(self, **kwargs):
         embeddings_info = {}

--- a/python/baseline/tf/classify/model.py
+++ b/python/baseline/tf/classify/model.py
@@ -1,19 +1,28 @@
-import logging
-import tensorflow as tf
-import numpy as np
-from google.protobuf import text_format
-from tensorflow.python.platform import gfile
-from baseline.utils import fill_y, listify, write_json, ls_props, read_json
-from baseline.model import ClassifierModel, register_model
-from baseline.tf.tfy import (stacked_lstm,
-                             parallel_conv,
-                             TRAIN_FLAG,
-                             new_placeholder_dict)
-from baseline.tf.embeddings import *
-from baseline.version import __version__
-from tensorflow.contrib.layers import fully_connected
 import os
 import copy
+import logging
+from itertools import chain
+import numpy as np
+import tensorflow as tf
+from tensorflow.contrib.layers import fully_connected
+from baseline.tf.embeddings import *
+from baseline.version import __version__
+from baseline.utils import (
+    fill_y,
+    listify,
+    ls_props,
+    read_json,
+    write_json,
+    MAGIC_VARS,
+)
+from baseline.model import ClassifierModel, register_model
+from baseline.tf.tfy import (
+    TRAIN_FLAG,
+    stacked_lstm,
+    parallel_conv,
+    reload_embeddings,
+    new_placeholder_dict,
+)
 
 
 logger = logging.getLogger('baseline')
@@ -83,7 +92,7 @@ class ClassifyParallelModel(ClassifierModel):
         losses = []
         self.labels = labels
 
-        sess = tf.Session(config=tf.ConfigProto(allow_soft_placement=True, log_device_placement=False)) 
+        sess = tf.Session(config=tf.ConfigProto(allow_soft_placement=True, log_device_placement=False))
         with tf.device(tf.DeviceSpec(device_type="CPU")):
             # This change is required since we attach our .x onto the object in v1
             self.inference = create_fn(embeddings, labels, sess=sess, **kwargs)
@@ -138,22 +147,23 @@ class ClassifyParallelModel(ClassifierModel):
 
 class ClassifierModelBase(ClassifierModel):
     """Base for all baseline implementations of token-based classifiers
-    
+
     This class provides a loose skeleton around which the baseline models
     are built.  This essentially consists of dividing up the network into a logical separation between "embedding",
     or composition of lookup tables to build a vector representation of a temporal input, "pooling",
     or the conversion of temporal data to a fixed representation, and "stacking" layers, which are (optional)
     fully-connected layers below, followed by a projection to output space and a softmax
-    
+
     For instance, the baseline convolutional and LSTM models implement pooling as CMOT, and LSTM last time
     respectively, whereas, neural bag-of-words (NBoW) do simple max or mean pooling followed by multiple fully-
     connected layers.
-    
+
     """
     def __init__(self):
         """Base
         """
         super(ClassifierModelBase, self).__init__()
+        self._unserializable = []
 
     def set_saver(self, saver):
         self.saver = saver
@@ -173,29 +183,24 @@ class ClassifierModelBase(ClassifierModel):
         :param basename:
         :return:
         """
-        path = basename.split('/')
-        base = path[-1]
-        outdir = '/'.join(path[:-1])
+        write_json(self._state, '{}.state'.format(basename))
+        write_json(self.labels, '{}.labels'.format(basename))
+        for key, embedding in self.embeddings.items():
+            embedding.save_md('{}-{}-md.json'.format(basename, key))
+        with open('{}.saver'.format(basename), 'w') as f:
+            f.write(str(self.saver.as_saver_def()))
 
-        # For each embedding, save a record of the keys
-
+    def _record_state(self, **kwargs):
         embeddings_info = {}
         for k, v in self.embeddings.items():
             embeddings_info[k] = v.__class__.__name__
-        state = {
-            "version": __version__,
-            "embeddings": embeddings_info
-        }
-        for prop in ls_props(self):
-            state[prop] = getattr(self, prop)
 
-        write_json(state, basename + '.state')
-        write_json(self.labels, basename + ".labels")
-        for key, embedding in self.embeddings.items():
-            embedding.save_md(basename + '-{}-md.json'.format(key))
-        tf.train.write_graph(self.sess.graph_def, outdir, base + '.graph', as_text=False)
-        with open(basename + '.saver', 'w') as f:
-            f.write(str(self.saver.as_saver_def()))
+        blacklist = set(chain(self._unserializable, MAGIC_VARS, self.embeddings.keys()))
+        self._state = {k: v for k, v in kwargs.items() if k not in blacklist}
+        self._state.update({
+            'version': __version__,
+            'embeddings': embeddings_info,
+        })
 
     def save(self, basename, **kwargs):
         """Save meta-data and actual data for a model
@@ -216,8 +221,8 @@ class ClassifierModelBase(ClassifierModel):
     def create_loss(self):
         """The loss function is currently provided here, although this is not a great place for it
         as it provides a coupling between the model and its loss function.  Just here for convenience at the moment.
-        
-        :return: 
+
+        :return:
         """
         with tf.name_scope("loss"):
             loss = tf.nn.softmax_cross_entropy_with_logits(logits=self.logits, labels=tf.cast(self.y, "float"))
@@ -229,7 +234,7 @@ class ClassifierModelBase(ClassifierModel):
         It runs the `x` tensor in (`BxT`), and turns dropout off, running the network all the way to a softmax
         output. You can use this method directly if you have vector input, or you can use the `ClassifierService`
         which can convert directly from text durign its `transform`.  That method calls this one underneath.
-        
+
         :param batch_dict: (``dict``) Contains any inputs to embeddings for this model
         :return: Each outcome as a ``list`` of tuples `(label, probability)`
         """
@@ -266,7 +271,7 @@ class ClassifierModelBase(ClassifierModel):
 
     def get_labels(self):
         """Get the string labels back
-        
+
         :return: labels
         """
         return self.labels
@@ -274,66 +279,32 @@ class ClassifierModelBase(ClassifierModel):
     @classmethod
     def load(cls, basename, **kwargs):
         """Reload the model from a graph file and a checkpoint
-        
+
         The model that is loaded is independent of the pooling and stacking layers, making this class reusable
         by sub-classes.
-        
+
         :param basename: The base directory to load from
         :param kwargs: See below
-        
+
         :Keyword Arguments:
         * *sess* -- An optional tensorflow session.  If not passed, a new session is
             created
-        
+
         :return: A restored model
         """
-        sess = kwargs.get('session', kwargs.get('sess', tf.Session()))
-        model = cls()
-        with open(basename + '.saver') as fsv:
-            saver_def = tf.train.SaverDef()
-            text_format.Merge(fsv.read(), saver_def)
-
-        checkpoint_name = kwargs.get('checkpoint_name', basename)
-        checkpoint_name = checkpoint_name or basename
-
-        state = read_json(basename + '.state')
-
-        for prop in ls_props(model):
-            if prop in state:
-                setattr(model, prop, state[prop])
-
-        with gfile.FastGFile(basename + '.graph', 'rb') as f:
-            gd = tf.GraphDef()
-            gd.ParseFromString(f.read())
-            sess.graph.as_default()
-            tf.import_graph_def(gd, name='')
-            try:
-                sess.run(saver_def.restore_op_name, {saver_def.filename_tensor_name: checkpoint_name})
-            except:
-                # Backwards compat
-                sess.run(saver_def.restore_op_name, {saver_def.filename_tensor_name: checkpoint_name + ".model"})
-
-        model.embeddings = dict()
-        for key, class_name in state['embeddings'].items():
-            md = read_json('{}-{}-md.json'.format(basename, key))
-            embed_args = dict({'vsz': md['vsz'], 'dsz': md['dsz']})
-            embed_args[key] = tf.get_default_graph().get_tensor_by_name('{}:0'.format(key))
-            Constructor = eval(class_name)
-            model.embeddings[key] = Constructor(key, **embed_args)
-
-        if model.lengths_key is not None:
-            model.lengths = tf.get_default_graph().get_tensor_by_name('lengths:0')
-
-        else:
-            model.lengths = None
-        model.probs = tf.get_default_graph().get_tensor_by_name('output/probs:0')
-
-
-        model.best = tf.get_default_graph().get_tensor_by_name('output/best:0')
-        model.logits = tf.get_default_graph().get_tensor_by_name('output/logits:0')
-
-        model.labels = read_json(basename + '.labels')
-        model.sess = sess
+        _state = read_json("{}.state".format(basename))
+        if __version__ != _state['version']:
+            logger.warning("Loaded model is from baseline version %s, running version is %s", _state['version'], __version__)
+        _state['sess'] = kwargs.pop('sess', tf.Session())
+        embeddings_info = _state.pop('embeddings')
+        embeddings = reload_embeddings(embeddings_info, basename)
+        labels = read_json("{}.labels".format(basename))
+        model = cls.create(embeddings, labels, **_state)
+        model._state = _state
+        if kwargs.get('init', True):
+            model.sess.run(tf.global_variables_initializer())
+        model.saver = tf.train.Saver()
+        model.saver.restore(model.sess, basename)
         return model
 
     @property
@@ -347,16 +318,16 @@ class ClassifierModelBase(ClassifierModel):
     @classmethod
     def create(cls, embeddings, labels, **kwargs):
         """The main method for creating all :class:`WordBasedModel` types.
-        
+
         This method instantiates a model with pooling and optional stacking layers.
         Many of the arguments provided are reused by each implementation, but some sub-classes need more
         information in order to properly initialize.  For this reason, the full list of keyword args are passed
         to the :method:`pool` and :method:`stacked` methods.
-        
+
         :param embeddings: This is a dictionary of embeddings, mapped to their numerical indices in the lookup table
         :param labels: This is a list of the `str` labels
         :param kwargs: There are sub-graph specific Keyword Args allowed for e.g. embeddings. See below for known args:
-        
+
         :Keyword Arguments:
         * *gpus* -- (``int``) How many GPUs to split training across.  If called this function delegates to
             another class `ClassifyParallelModel` which creates a parent graph and splits its inputs across each
@@ -371,8 +342,8 @@ class ClassifierModelBase(ClassifierModel):
         * *dropout* -- This indicates how much dropout should be applied to the model when training.
         * *filtsz* -- This is actually a top-level param due to an unfortunate coupling between the pooling layer
             and the input, which, for convolution, requires input padding.
-        
-        :return: A fully-initialized tensorflow classifier 
+
+        :return: A fully-initialized tensorflow classifier
         """
         TRAIN_FLAG()
         gpus = kwargs.get('gpus', 1)
@@ -385,6 +356,7 @@ class ClassifierModelBase(ClassifierModel):
 
         model = cls()
         model.embeddings = embeddings
+        model._record_state(**kwargs)
         model.lengths_key = kwargs.get('lengths_key')
         if model.lengths_key is not None:
             model.lengths = kwargs.get('lengths', tf.placeholder(tf.int32, [None], name="lengths"))
@@ -437,7 +409,7 @@ class ClassifierModelBase(ClassifierModel):
 
     def pool(self, word_embeddings, dsz, init, **kwargs):
         """This method performs a transformation between a temporal signal and a fixed representation
-        
+
         :param word_embeddings: The output of the embedded lookup, which is the starting point for this operation
         :param dsz: The depth of the embeddings
         :param init: The tensorflow initializer to use for these methods
@@ -473,29 +445,28 @@ class ClassifierModelBase(ClassifierModel):
 @register_model(task='classify', name='default')
 class ConvModel(ClassifierModelBase):
     """Current default model for `baseline` classification.  Parallel convolutions of varying receptive field width
-    
+
     """
 
     def __init__(self):
-        """Constructor 
+        """Constructor
         """
         super(ConvModel, self).__init__()
 
     def pool(self, word_embeddings, dsz, init, **kwargs):
         """Do parallel convolutional filtering with varied receptive field widths, followed by max-over-time pooling
-        
+
         :param word_embeddings: The word embeddings, which are inputs here
         :param dsz: The depth of the word embeddings
         :param init: The tensorflow initializer
         :param kwargs: See below
-        
+
         :Keyword Arguments:
         * *cmotsz* -- (``int``) The number of convolutional feature maps for each filter
             These are MOT-filtered, leaving this # of units per parallel filter
         * *filtsz* -- (``list``) This is a list of filter widths to use
-        
-        
-        :return: 
+
+        :return:
         """
         cmotsz = kwargs['cmotsz']
         filtsz = kwargs['filtsz']
@@ -510,7 +481,7 @@ class ConvModel(ClassifierModelBase):
 @register_model(task='classify', name='lstm')
 class LSTMModel(ClassifierModelBase):
     """A simple single-directional single-layer LSTM. No layer-stacking.
-    
+
     """
 
     def __init__(self):
@@ -527,18 +498,18 @@ class LSTMModel(ClassifierModelBase):
 
     def pool(self, word_embeddings, dsz, init, **kwargs):
         """LSTM with dropout yielding a final-state as output
-        
+
         :param word_embeddings: The input word embeddings
         :param dsz: The input word embedding depth
         :param init: The tensorflow initializer to use (currently ignored)
         :param kwargs: See below
-        
+
         :Keyword Arguments:
         * *rnnsz* -- (``int``) The number of hidden units (defaults to `hsz`)
         * *hsz* -- (``int``) backoff for `rnnsz`, typically a result of stacking params.  This keeps things simple so
           its easy to do things like residual connections between LSTM and post-LSTM stacking layers
-        
-        :return: 
+
+        :return:
         """
         hsz = kwargs.get('rnnsz', kwargs.get('hsz', 100))
         vdrop = bool(kwargs.get('variational_dropout', False))
@@ -597,7 +568,7 @@ class NBowModel(NBowBase):
 
     def pool(self, word_embeddings, dsz, init, **kwargs):
         """Do average pooling on input embeddings, yielding a `dsz` output layer
-        
+
         :param word_embeddings: The word embedding input
         :param dsz: The word embedding depth
         :param init: The tensorflow initializer
@@ -617,7 +588,7 @@ class NBowMaxModel(NBowBase):
 
     def pool(self, word_embeddings, dsz, init, **kwargs):
         """Do max pooling on input embeddings, yielding a `dsz` output layer
-        
+
         :param word_embeddings: The word embedding input
         :param dsz: The word embedding depth
         :param init: The tensorflow initializer

--- a/python/baseline/tf/classify/model.py
+++ b/python/baseline/tf/classify/model.py
@@ -298,6 +298,9 @@ class ClassifierModelBase(ClassifierModel):
         _state['sess'] = kwargs.pop('sess', tf.Session())
         embeddings_info = _state.pop('embeddings')
         embeddings = reload_embeddings(embeddings_info, basename)
+        for k in embeddings_info:
+            if k in kwargs:
+                _state[k] = kwargs[k]
         labels = read_json("{}.labels".format(basename))
         model = cls.create(embeddings, labels, **_state)
         model._state = _state

--- a/python/baseline/tf/embeddings.py
+++ b/python/baseline/tf/embeddings.py
@@ -94,6 +94,7 @@ class TensorFlowEmbeddings(object):
         config['dsz'] = self.get_dsz()
         config['vsz'] = self.get_vsz()
         config['module'] = self.__class__.__module__
+        config['class'] = self.__class__.__name__
         config.update(self._state)
         return config
 

--- a/python/baseline/tf/embeddings.py
+++ b/python/baseline/tf/embeddings.py
@@ -1,4 +1,5 @@
 import math
+import copy
 import numpy as np
 import tensorflow as tf
 from baseline.utils import write_json, Offsets
@@ -9,13 +10,14 @@ class TensorFlowEmbeddings(object):
     """This provides a base for TensorFlow embeddings sub-graphs
 
     """
-    def __init__(self, trainable=True, name=None, dtype=tf.float32):
+    def __init__(self, trainable=True, name=None, dtype=tf.float32, **kwargs):
         """Constructor
         """
         super(TensorFlowEmbeddings, self).__init__()
         self.name = name
         self.trainable = trainable
         self.dtype = dtype
+        self._record_state(**kwargs)
 
     def detached_ref(self):
         """This will detach any attached input and reference the same sub-graph otherwise
@@ -75,6 +77,9 @@ class TensorFlowEmbeddings(object):
         """
         return cls(name, vsz=model.vsz, dsz=model.dsz, weights=model.weights, **kwargs)
 
+    def _record_state(self, **kwargs):
+        self._state = copy.deepcopy(kwargs)
+
     def save_md(self, target):
         """Save the metadata associated with this embedding as a JSON file
 
@@ -88,6 +93,8 @@ class TensorFlowEmbeddings(object):
         config = {}
         config['dsz'] = self.get_dsz()
         config['vsz'] = self.get_vsz()
+        config['module'] = self.__class__.__module__
+        config.update(self._state)
         return config
 
 

--- a/python/baseline/tf/embeddings.py
+++ b/python/baseline/tf/embeddings.py
@@ -78,6 +78,7 @@ class TensorFlowEmbeddings(object):
         return cls(name, vsz=model.vsz, dsz=model.dsz, weights=model.weights, **kwargs)
 
     def _record_state(self, **kwargs):
+        w = kwargs.pop('weights', None)
         self._state = copy.deepcopy(kwargs)
 
     def save_md(self, target):
@@ -91,8 +92,6 @@ class TensorFlowEmbeddings(object):
     def get_config(self):
         #config = super(TensorFlowEmbeddings, self).get_config()
         config = {}
-        config['dsz'] = self.get_dsz()
-        config['vsz'] = self.get_vsz()
         config['module'] = self.__class__.__module__
         config['class'] = self.__class__.__name__
         config.update(self._state)
@@ -123,7 +122,7 @@ class LookupTableEmbeddings(TensorFlowEmbeddings):
         * *scope* -- (``str``) An optional variable scope, by default it will be `{name}/LUT`
         * *unif* -- (``float``) (defaults to `0.1`) If the weights should be created, what is the random initialization range
         """
-        super(LookupTableEmbeddings, self).__init__(kwargs.get('finetune', True), name)
+        super(LookupTableEmbeddings, self).__init__(kwargs.get('finetune', True), name, **kwargs)
 
         self.vsz = kwargs.get('vsz')
         self.dsz = kwargs.get('dsz')
@@ -191,7 +190,7 @@ class CharConvEmbeddings(TensorFlowEmbeddings):
         return tf.placeholder(tf.int32, [None, None, None], name=name)
 
     def __init__(self, name, **kwargs):
-        super(CharConvEmbeddings, self).__init__(name=name)
+        super(CharConvEmbeddings, self).__init__(name=name, **kwargs)
         self.scope = kwargs.get('scope', '{}/CharLUT'.format(self.name))
         self.vsz = kwargs.get('vsz')
         self.dsz = kwargs.get('dsz')
@@ -387,7 +386,7 @@ class CharLSTMEmbeddings(TensorFlowEmbeddings):
         return tf.placeholder(tf.int32, [None, None, None], name=name)
 
     def __init__(self, name, **kwargs):
-        super(CharLSTMEmbeddings, self).__init__()
+        super(CharLSTMEmbeddings, self).__init__(name=name, **kwargs)
         self.name = name
         self.scope = kwargs.get('scope', '{}/CharLUT'.format(self.name))
         self.vsz = kwargs.get('vsz')
@@ -446,7 +445,3 @@ class CharLSTMEmbeddings(TensorFlowEmbeddings):
 
     def get_vsz(self):
         return self.vsz
-
-    def get_config(self):
-        config = super(CharLSTMEmbeddings, self).get_config()
-        config['lstmsz'] = self.lstmsz

--- a/python/baseline/tf/lm/model.py
+++ b/python/baseline/tf/lm/model.py
@@ -282,6 +282,9 @@ class LanguageModelBase(LanguageModel):
 
         embeddings_info = _state.pop('embeddings')
         embeddings = reload_embeddings(embeddings_info, basename)
+        for k in embeddings_info:
+            if k in kwargs:
+                _state[k] = kwargs[k]
         model = cls.create(embeddings, **_state)
         if kwargs.get('init', True):
             model.sess.run(tf.global_variables_initializer())

--- a/python/baseline/tf/lm/model.py
+++ b/python/baseline/tf/lm/model.py
@@ -181,6 +181,8 @@ class LanguageModelBase(LanguageModel):
         self._state = {k: v for k, v in kwargs.items() if k not in blacklist}
         self._state.update({
             'version': __version__,
+            'module': self.__class__.__module__,
+            'class': self.__class__.__name__,
             'embeddings': embeddings_info,
         })
 

--- a/python/baseline/tf/lm/model.py
+++ b/python/baseline/tf/lm/model.py
@@ -169,8 +169,6 @@ class LanguageModelBase(LanguageModel):
         write_json(self._state, '{}.state'.format(basename))
         for key, embedding in self.embeddings.items():
             embedding.save_md('{}-{}-md.json'.format(basename, key))
-        with open('{}.saver'.format(basename), 'w') as f:
-            f.write(str(self.saver.as_saver_def()))
 
     def _record_state(self, **kwargs):
         embeddings_info = {}

--- a/python/baseline/tf/seq2seq/model.py
+++ b/python/baseline/tf/seq2seq/model.py
@@ -266,6 +266,8 @@ class EncoderDecoderModelBase(EncoderDecoderModel):
         self._state = {k: v for k, v in kwargs.items() if k not in blacklist}
         self._state.update({
             'version': __version__,
+            'module': self.__class__.__module__,
+            'class': self.__class__.__name__,
             'src_embeddings': src_embeddings_info,
             'tgt_embedding': {'tgt': self.tgt_embedding.__class__.__name__}
         })

--- a/python/baseline/tf/seq2seq/model.py
+++ b/python/baseline/tf/seq2seq/model.py
@@ -221,6 +221,9 @@ class EncoderDecoderModelBase(EncoderDecoderModel):
 
         src_embeddings_info = _state.pop('src_embeddings')
         src_embeddings = reload_embeddings(src_embeddings_info, basename)
+        for k in src_embeddings_info:
+            if k in kwargs:
+                _state[k] = kwargs[k]
         tgt_embedding_info = _state.pop('tgt_embedding')
         tgt_embedding = reload_embeddings(tgt_embedding_info, basename)['tgt']
 

--- a/python/baseline/tf/seq2seq/model.py
+++ b/python/baseline/tf/seq2seq/model.py
@@ -254,8 +254,6 @@ class EncoderDecoderModelBase(EncoderDecoderModel):
         for key, embedding in self.src_embeddings.items():
             embedding.save_md('{}-{}-md.json'.format(basename, key))
         self.tgt_embedding.save_md('{}-{}-md.json'.format(basename, 'tgt'))
-        with open('{}.saver'.format(basename), 'w') as f:
-            f.write(str(self.saver.as_saver_def()))
 
     def _record_state(self, **kwargs):
         src_embeddings_info = {}

--- a/python/baseline/tf/seq2seq/model.py
+++ b/python/baseline/tf/seq2seq/model.py
@@ -1,15 +1,17 @@
 import logging
+from itertools import chain
 from baseline.tf.seq2seq.encoders import *
 from baseline.tf.seq2seq.decoders import *
 from google.protobuf import text_format
 from baseline.tf.tfy import *
 from baseline.model import EncoderDecoderModel, register_model, create_seq2seq_decoder, create_seq2seq_encoder, create_seq2seq_arc_policy
-from baseline.utils import ls_props, read_json
+from baseline.utils import ls_props, read_json, MAGIC_VARS
 from baseline.tf.embeddings import *
 from baseline.version import __version__
 import copy
 
 logger = logging.getLogger('baseline')
+
 
 def _temporal_cross_entropy_loss(logits, labels, label_lengths, mx_seq_length):
     """Do cross-entropy loss accounting for sequence lengths
@@ -204,45 +206,28 @@ class EncoderDecoderModelBase(EncoderDecoderModel):
     def __init__(self):
         super(EncoderDecoderModelBase, self).__init__()
         self.saver = None
+        self._unserializable = ['tgt']
 
     @classmethod
     def load(cls, basename, **kwargs):
-        state = read_json(basename + '.state')
+        _state = read_json('{}.state'.format(basename))
+        if __version__ != _state['version']:
+            logger.warning("Loaded model is from baseline version %s, running version is %s", _state['version'], __version__)
         if 'predict' in kwargs:
-            state['predict'] = kwargs['predict']
-
+            _state['predict'] = kwargs['predict']
         if 'beam' in kwargs:
-            state['beam'] = kwargs['beam']
+            _state['beam'] = kwargs['beam']
+        _state['sess'] = kwargs.get('sess', tf.Session())
 
-        state['sess'] = kwargs.get('sess', tf.Session())
-        state['model_type'] = kwargs.get('model_type', 'default')
+        src_embeddings_info = _state.pop('src_embeddings')
+        src_embeddings = reload_embeddings(src_embeddings_info, basename)
+        tgt_embedding_info = _state.pop('tgt_embedding')
+        tgt_embedding = reload_embeddings(tgt_embedding_info, basename)['tgt']
 
-        with open(basename + '.saver') as fsv:
-            saver_def = tf.train.SaverDef()
-            text_format.Merge(fsv.read(), saver_def)
-
-        src_embeddings = dict()
-        src_embeddings_dict = state.pop('src_embeddings')
-        for key, class_name in src_embeddings_dict.items():
-            md = read_json('{}-{}-md.json'.format(basename, key))
-            embed_args = dict({'vsz': md['vsz'], 'dsz': md['dsz']})
-            Constructor = eval(class_name)
-            src_embeddings[key] = Constructor(key, **embed_args)
-
-        tgt_class_name = state.pop('tgt_embedding')
-        md = read_json('{}-tgt-md.json'.format(basename))
-        embed_args = dict({'vsz': md['vsz'], 'dsz': md['dsz']})
-        Constructor = eval(tgt_class_name)
-        tgt_embedding = Constructor('tgt', **embed_args)
-        model = cls.create(src_embeddings, tgt_embedding, **state)
-        for prop in ls_props(model):
-            if prop in state:
-                setattr(model, prop, state[prop])
-        do_init = kwargs.get('init', True)
-        if do_init:
-            init = tf.global_variables_initializer()
-            model.sess.run(init)
-
+        model = cls.create(src_embeddings, tgt_embedding, **_state)
+        model._state = _state
+        if kwargs.get('init', True):
+            model.sess.run(tf.global_variables_initializer())
         model.saver = tf.train.Saver()
         model.saver.restore(model.sess, basename)
         return model
@@ -261,6 +246,26 @@ class EncoderDecoderModelBase(EncoderDecoderModel):
         word_embeddings = tf.concat(values=all_embeddings_src, axis=-1)
         return word_embeddings
 
+    def save_md(self, basename):
+        write_json(self._state, '{}.state'.format(basename))
+        for key, embedding in self.src_embeddings.items():
+            embedding.save_md('{}-{}-md.json'.format(basename, key))
+        self.tgt_embedding.save_md('{}-{}-md.json'.format(basename, 'tgt'))
+        with open('{}.saver'.format(basename), 'w') as f:
+            f.write(str(self.saver.as_saver_def()))
+
+    def _record_state(self, **kwargs):
+        src_embeddings_info = {}
+        for k, v in self.src_embeddings.items():
+            src_embeddings_info[k] = v.__class__.__name__
+
+        blacklist = set(chain(self._unserializable, MAGIC_VARS, self.src_embeddings.keys()))
+        self._state = {k: v for k, v in kwargs.items() if k not in blacklist}
+        self._state.update({
+            'version': __version__,
+            'src_embeddings': src_embeddings_info,
+            'tgt_embedding': {'tgt': self.tgt_embedding.__class__.__name__}
+        })
 
     @classmethod
     def create(cls, src_embeddings, tgt_embedding, **kwargs):
@@ -273,6 +278,7 @@ class EncoderDecoderModelBase(EncoderDecoderModel):
         model = cls()
         model.src_embeddings = src_embeddings
         model.tgt_embedding = tgt_embedding
+        model._record_state(**kwargs)
         model.src_len = kwargs.pop('src_len', tf.placeholder(tf.int32, [None], name="src_len"))
         model.tgt_len = kwargs.pop('tgt_len', tf.placeholder(tf.int32, [None], name="tgt_len"))
         model.mx_tgt_len = kwargs.pop('mx_tgt_len', tf.placeholder(tf.int32, name="mx_tgt_len"))
@@ -326,30 +332,6 @@ class EncoderDecoderModelBase(EncoderDecoderModel):
         for prop in ls_props(obj):
             state[prop] = getattr(obj, prop)
 
-    def save_md(self, basename):
-
-        path = basename.split('/')
-        src_embeddings_info = {}
-        for k, v in self.src_embeddings.items():
-            src_embeddings_info[k] = v.__class__.__name__
-        state = {
-            "version": __version__,
-            "src_embeddings": src_embeddings_info,
-            "tgt_embedding": self.tgt_embedding.__class__.__name__,
-            "hsz": self.hsz,
-            "layers": self.layers
-        }
-        self._write_props_to_state(self, state)
-        self._write_props_to_state(self.encoder, state)
-        self._write_props_to_state(self.decoder, state)
-
-        write_json(state, basename + '.state')
-        for key, embedding in self.src_embeddings.items():
-            embedding.save_md('{}-{}-md.json'.format(basename, key))
-
-        self.tgt_embedding.save_md('{}-tgt-md.json'.format(basename))
-        with open(basename + '.saver', 'w') as f:
-            f.write(str(self.saver.as_saver_def()))
 
     def save(self, model_base):
         self.save_md(model_base)

--- a/python/baseline/tf/tagger/model.py
+++ b/python/baseline/tf/tagger/model.py
@@ -41,8 +41,6 @@ class TaggerModelBase(TaggerModel):
         write_json(self.labels, '{}.labels'.format(basename))
         for key, embedding in self.embeddings.items():
             embedding.save_md('{}-{}-md.json'.format(basename, key))
-        with open('{}.saver'.format(basename), 'w') as f:
-            f.write(str(self.saver.as_saver_def()))
 
     def _record_state(self, **kwargs):
         """

--- a/python/baseline/tf/tagger/model.py
+++ b/python/baseline/tf/tagger/model.py
@@ -15,6 +15,7 @@ from baseline.utils import listify, Offsets
 
 logger = logging.getLogger('baseline')
 
+
 class TaggerModelBase(TaggerModel):
 
     @property
@@ -36,11 +37,11 @@ class TaggerModelBase(TaggerModel):
         :param basename:
         :return:
         """
-        write_json(self._state, basename + '.state')
-        write_json(self.labels, basename + '.labels')
+        write_json(self._state, '{}.state'.format(basename))
+        write_json(self.labels, '{}.labels'.format(basename))
         for key, embedding in self.embeddings.items():
             embedding.save_md('{}-{}-md.json'.format(basename, key))
-        with open("{}.saver".format(basename), 'w') as f:
+        with open('{}.saver'.format(basename), 'w') as f:
             f.write(str(self.saver.as_saver_def()))
 
     def _record_state(self, **kwargs):
@@ -58,8 +59,8 @@ class TaggerModelBase(TaggerModel):
         blacklist = set(chain(self._unserializable, MAGIC_VARS, self.embeddings.keys()))
         self._state = {k: v for k, v in kwargs.items() if k not in blacklist}
         self._state.update({
-            "version": __version__,
-            "embeddings": embeddings_info,
+            'version': __version__,
+            'embeddings': embeddings_info,
         })
         if 'constraint' in kwargs:
             self._state['constraint'] = True
@@ -114,8 +115,9 @@ class TaggerModelBase(TaggerModel):
         :return: A restored model
         """
         _state = read_json("{}.state".format(basename))
+        if __version__ != _state['version']:
+            logger.warning("Loaded model is from baseline version %s, running version is %s", _state['version'], __version__)
         _state['sess'] = kwargs.pop('sess', tf.Session())
-        _state['model_type'] = kwargs.get('model_type', 'default')
         embeddings_info = _state.pop("embeddings")
         embeddings = reload_embeddings(embeddings_info, basename)
         labels = read_json("{}.labels".format(basename))

--- a/python/baseline/tf/tagger/model.py
+++ b/python/baseline/tf/tagger/model.py
@@ -1,12 +1,13 @@
 import os
 import json
 import logging
+from itertools import chain
 from google.protobuf import text_format
 from tensorflow.python.platform import gfile
 from tensorflow.contrib.layers import fully_connected, xavier_initializer
 from baseline.model import TaggerModel, create_tagger_model, load_tagger_model
 from baseline.tf.tfy import *
-from baseline.utils import ls_props, read_json, write_json
+from baseline.utils import ls_props, read_json, write_json, MAGIC_VARS
 from baseline.tf.embeddings import *
 from baseline.version import __version__
 from baseline.model import register_model
@@ -28,33 +29,40 @@ class TaggerModelBase(TaggerModel):
         self.saver.save(self.sess, basename)
 
     def save_md(self, basename):
+        """
+        This method saves out a `.state` file containing meta-data from these classes and any info
+        registered by a user-defined derived class as a `property`. Also write the `graph` and `saver` and `labels`
 
-        path = basename.split('/')
-        base = path[-1]
-        outdir = '/'.join(path[:-1])
+        :param basename:
+        :return:
+        """
+        write_json(self._state, basename + '.state')
+        write_json(self.labels, basename + '.labels')
+        for key, embedding in self.embeddings.items():
+            embedding.save_md('{}-{}-md.json'.format(basename, key))
+        with open("{}.saver".format(basename), 'w') as f:
+            f.write(str(self.saver.as_saver_def()))
 
-        # For each embedding, save a record of the keys
+    def _record_state(self, **kwargs):
+        """
+        First, write out the embedding names, so we can recover those.  Then do a deepcopy on the model init params
+        so that it can be recreated later.  Anything that is a placeholder directly on this model needs to be removed
 
+        :param kwargs:
+        :return:
+        """
         embeddings_info = {}
         for k, v in self.embeddings.items():
             embeddings_info[k] = v.__class__.__name__
-        state = {
-            'version': __version__,
-            'embeddings': embeddings_info,
-            'crf': self.crf,
-            'proj': self.proj,
-            'constrain_decode': True if self.constraint is not None else False
-        }
-        for prop in ls_props(self):
-            state[prop] = getattr(self, prop)
 
-        write_json(state, basename + '.state')
-        write_json(self.labels, basename + ".labels")
-        for key, embedding in self.embeddings.items():
-            embedding.save_md(basename + '-{}-md.json'.format(key))
-        tf.train.write_graph(self.sess.graph_def, outdir, base + '.graph', as_text=False)
-        with open(basename + '.saver', 'w') as f:
-            f.write(str(self.saver.as_saver_def()))
+        blacklist = set(chain(self._unserializable, MAGIC_VARS, self.embeddings.keys()))
+        self._state = {k: v for k, v in kwargs.items() if k not in blacklist}
+        self._state.update({
+            "version": __version__,
+            "embeddings": embeddings_info,
+        })
+        if 'constraint' in kwargs:
+            self._state['constraint'] = True
 
     @property
     def dropin_value(self):
@@ -93,7 +101,6 @@ class TaggerModelBase(TaggerModel):
     @classmethod
     def load(cls, basename, **kwargs):
         """Reload the model from a graph file and a checkpoint
-
         The model that is loaded is independent of the pooling and stacking layers, making this class reusable
         by sub-classes.
 
@@ -101,67 +108,27 @@ class TaggerModelBase(TaggerModel):
         :param kwargs: See below
 
         :Keyword Arguments:
-        * *session* -- An optional tensorflow session.  If not passed, a new session is
+        * *sess* -- An optional tensorflow session.  If not passed, a new session is
             created
 
         :return: A restored model
         """
-        sess = kwargs.get('session', kwargs.get('sess', tf.Session()))
-        model = cls()
-        with open(basename + '.saver') as fsv:
-            saver_def = tf.train.SaverDef()
-            text_format.Merge(fsv.read(), saver_def)
-
-        checkpoint_name = kwargs.get('checkpoint_name', basename)
-        checkpoint_name = checkpoint_name or basename
-
-        state = read_json(basename + '.state')
-        for prop in ls_props(model):
-            if prop in state:
-                setattr(model, prop, state[prop])
-
-        with gfile.FastGFile(basename + '.graph', 'rb') as f:
-            gd = tf.GraphDef()
-            gd.ParseFromString(f.read())
-            sess.graph.as_default()
-            tf.import_graph_def(gd, name='')
-            try:
-                sess.run(saver_def.restore_op_name, {saver_def.filename_tensor_name: checkpoint_name})
-            except:
-                # Backwards compat
-                sess.run(saver_def.restore_op_name, {saver_def.filename_tensor_name: checkpoint_name + ".model"})
-
-        model.embeddings = dict()
-        for key, class_name in state['embeddings'].items():
-            md = read_json('{}-{}-md.json'.format(basename, key))
-            embed_args = dict({'vsz': md['vsz'], 'dsz': md['dsz']})
-            embed_args[key] = tf.get_default_graph().get_tensor_by_name('{}:0'.format(key))
-            Constructor = eval(class_name)
-            model.embeddings[key] = Constructor(key, **embed_args)
-
-        model.crf = bool(state.get('crf', False))
-        model.proj = bool(state.get('proj', False))
-        model.lengths = tf.get_default_graph().get_tensor_by_name('lengths:0')
-
-        model.y = tf.get_default_graph().get_tensor_by_name('y:0')
-        model.probs = tf.get_default_graph().get_tensor_by_name('output/probs:0')
-        model.best = tf.get_default_graph().get_tensor_by_name('output/best:0')
-
-        try:
-            model.A = tf.get_default_graph().get_tensor_by_name('Loss/transitions:0')
-            if not model.crf:
-                logger.warning('Warning: meta-data says no CRF but model contains transition matrix!')
-                model.crf = True
-        except:
-            if model.crf is True:
-                logger.warning('Warning: meta-data says there is a CRF but not transition matrix found!')
-            model.A = None
-            model.crf = False
-
-        model.labels = read_json(basename + '.labels')
-        model.sess = sess
-        model.saver = tf.train.Saver(saver_def=saver_def)
-        return model
+        _state = read_json("{}.state".format(basename))
+        _state['sess'] = kwargs.pop('sess', tf.Session())
+        _state['model_type'] = kwargs.get('model_type', 'default')
+        embeddings_info = _state.pop("embeddings")
+        embeddings = reload_embeddings(embeddings_info, basename)
+        labels = read_json("{}.labels".format(basename))
+        if _state.get('constraint') is not None:
+            # Dummy constraint values that will be filled in by the check pointing
+            _state['constraint'] = [tf.zeros((len(labels), len(labels))) for _ in range(2)]
+        model = cls.create(embeddings, labels, **_state)
+        model._state = _state
+        model.create_loss()
+        if kwargs.get('init', True):
+            model.sess.run(tf.global_variables_initializer())
+        model.saver = tf.train.Saver()
+        model.saver.restore(model.sess, basename)
 
     def save_using(self, saver):
         self.saver = saver
@@ -194,6 +161,7 @@ class TaggerModelBase(TaggerModel):
             ll, self.A = tf.contrib.crf.crf_log_likelihood(self.probs, self.y, self.lengths, self.A)
         else:
             ll, self.A = tf.contrib.crf.crf_log_likelihood(self.probs, self.y, self.lengths)
+
         return tf.reduce_mean(-ll)
 
     def _create_sentence_level_decode(self, trans, norm=False):
@@ -234,11 +202,11 @@ class TaggerModelBase(TaggerModel):
                         self._create_sentence_level_decode(self.constraint, norm=True)
                     else:
                         self._create_word_level_decode()
-
         return all_loss
 
     def __init__(self):
         super(TaggerModelBase, self).__init__()
+        self._unserializable = ['constraint']
 
     def get_labels(self):
         return self.labels
@@ -271,6 +239,7 @@ class TaggerModelBase(TaggerModel):
 
         model = cls()
         model.embeddings = embeddings
+        model._record_state(**kwargs)
         model.lengths_key = kwargs.get('lengths_key')
         model.lengths = kwargs.get('lengths', tf.placeholder(tf.int32, [None], name="lengths"))
         model.labels = labels
@@ -289,6 +258,14 @@ class TaggerModelBase(TaggerModel):
         model.feed_input = bool(kwargs.get('feed_input', False))
         model.activation_type = kwargs.get('activation', 'tanh')
         model.constraint = kwargs.get('constraint')
+        # Wrap the constraint in a non-trainable variable so that it is saved
+        # into the checkpoint. This means we won't need to recreate the actual
+        # values of it when we reload the model
+        if model.constraint is not None:
+            constraint = []
+            for i, c in enumerate(model.constraint):
+                constraint.append(tf.get_variable("constraint_{}".format(i), initializer=c, trainable=False))
+            model.constraint = constraint
 
         embedseq = model.embed(**kwargs)
         seed = np.random.randint(10e8)

--- a/python/baseline/tf/tagger/model.py
+++ b/python/baseline/tf/tagger/model.py
@@ -120,6 +120,9 @@ class TaggerModelBase(TaggerModel):
         _state['sess'] = kwargs.pop('sess', tf.Session())
         embeddings_info = _state.pop("embeddings")
         embeddings = reload_embeddings(embeddings_info, basename)
+        for k in embeddings_info:
+            if k in kwargs:
+                _state[k] = kwargs[k]
         labels = read_json("{}.labels".format(basename))
         if _state.get('constraint') is not None:
             # Dummy constraint values that will be filled in by the check pointing

--- a/python/baseline/tf/tagger/model.py
+++ b/python/baseline/tf/tagger/model.py
@@ -60,6 +60,8 @@ class TaggerModelBase(TaggerModel):
         self._state = {k: v for k, v in kwargs.items() if k not in blacklist}
         self._state.update({
             'version': __version__,
+            'module': self.__class__.__module__,
+            'class': self.__class__.__name__,
             'embeddings': embeddings_info,
         })
         if 'constraint' in kwargs:

--- a/python/baseline/utils.py
+++ b/python/baseline/utils.py
@@ -20,7 +20,7 @@ import collections
 __all__ = []
 logger = logging.getLogger('baseline')
 # These are inputs to models that shouldn't be saved out
-MAGIC_VARS = ['sess', 'tgt', 'y', 'lengths']
+MAGIC_VARS = ['sess', 'tgt', 'y', 'lengths', 'gpus']
 
 
 def optional_params(func):

--- a/python/baseline/utils.py
+++ b/python/baseline/utils.py
@@ -18,6 +18,7 @@ import collections
 
 __all__ = []
 logger = logging.getLogger('baseline')
+MAGIC_VARS = ['sess', 'tgt', 'y', 'lengths']  # These are inputs to models that shouldn't be saved out
 
 
 def optional_params(func):

--- a/python/mead/config/sst2-residual-conv.json
+++ b/python/mead/config/sst2-residual-conv.json
@@ -1,0 +1,51 @@
+{
+  "version": 2,
+  "task": "classify",
+  "basedir": "./sst2",
+  "modules": ["residual_conv"],
+  "batchsz": 50,
+  "features": [
+    {
+      "name": "word",
+      "vectorizer": {
+        "type": "token1d",
+	"transform": "baseline.lowercase"
+      },
+      "embeddings": {
+        "label": "w2v-gn"
+      }
+    }
+  ],
+  "preproc": {
+    "rev": false,
+    "clean": true
+  },
+  "backend": "tensorflow",
+  "dataset": "SST2",
+  "loader": {
+    "reader_type": "default"
+  },
+  "unif": 0.25,
+  "model": {
+    "model_type": "res-conv",
+    "filtsz": [
+      3,
+      4,
+      5
+    ],
+    "cmotsz": 300,
+    "dropout": 0.5,
+    "finetune": true
+  },
+  "train": {
+    "epochs": 2,
+    "optim": "adadelta",
+    "eta": 1.0,
+    "model_zip": true,
+    "early_stopping_metric": "acc",
+    "verbose": {
+      "console": true,
+      "file": "sst2-cm.csv"
+    }
+  }
+}

--- a/python/mead/export.py
+++ b/python/mead/export.py
@@ -22,7 +22,6 @@ def main():
     parser.add_argument('--is_remote', help='if True, separate items for remote server and client. If False bundle everything together',
                         default=True, type=str2bool)
 
-
     args = parser.parse_args()
     configure_logger(args.logging)
 

--- a/python/mead/tasks.py
+++ b/python/mead/tasks.py
@@ -475,6 +475,8 @@ class TaggerTask(Task):
         labels = self.reader.label2index
         span_type = self.config_params['train'].get('span_type')
         constrain = bool(self.config_params['model'].get('constrain_decode', False))
+        if span_type is None and constrain:
+            logger.warning("Constrained Decoding was set but no span type could be found.")
         self.config_params['model']['span_type'] = span_type
         if span_type is not None and constrain:
             self.config_params['model']['constraint'] = self.backend.transition_mask(

--- a/python/mead/tasks.py
+++ b/python/mead/tasks.py
@@ -476,7 +476,7 @@ class TaggerTask(Task):
         span_type = self.config_params['train'].get('span_type')
         constrain = bool(self.config_params['model'].get('constrain_decode', False))
         if span_type is None and constrain:
-            logger.warning("Constrained Decoding was set but no span type could be found.")
+            logger.warning("Constrained Decoding was set but no span type could be found so no Constraints will be applied.")
         self.config_params['model']['span_type'] = span_type
         if span_type is not None and constrain:
             self.config_params['model']['constraint'] = self.backend.transition_mask(

--- a/python/mead/tf/preproc_exporters.py
+++ b/python/mead/tf/preproc_exporters.py
@@ -113,10 +113,11 @@ class ClassifyTensorFlowPreProcExporter(ClassifyTensorFlowExporter):
         pid = model_file.split("-")[-1]
         pc = PreProcessorController(model_base_dir, pid, self.task.config_params['features'])
         tf_example, preprocessed = pc.run()
+        # Create a dict of embedding names to sub-graph outputs to wire in as embedding inputs
         embedding_inputs = {}
         for feature in preprocessed:
             embedding_inputs[feature] = preprocessed[feature]
-        model, classes, values = self._create_model(sess, model_file, embedding_inputs)
+        model, classes, values = self._create_model(sess, model_file, **embedding_inputs)
         sig_input = {
             'tokens': tf.saved_model.utils.build_tensor_info(tf_example[pc.FIELD_NAME]),
         }
@@ -140,10 +141,11 @@ class TaggerTensorFlowPreProcExporter(TaggerTensorFlowExporter):
         pid = model_file.split("-")[-1]
         pc = PreProcessorController(model_base_dir, pid, self.task.config_params['features'])
         tf_example, preprocessed = pc.run()
+        # Create a dict of embedding names to sub-graph outputs to wire in as embedding inputs
         embedding_inputs = {}
         for feature in preprocessed:
             embedding_inputs[feature] = preprocessed[feature]
-        model, classes, values = self._create_model(sess, model_file, embedding_inputs)
+        model, classes, values = self._create_model(sess, model_file, **embedding_inputs)
         sig_input = {
             'tokens': tf.saved_model.utils.build_tensor_info(tf_example[pc.FIELD_NAME]),
              model.lengths_key: tf.saved_model.utils.build_tensor_info(model.lengths)

--- a/python/mead/tf/preproc_exporters.py
+++ b/python/mead/tf/preproc_exporters.py
@@ -1,8 +1,10 @@
 import os
+import baseline
 from mead.exporters import register_exporter
 from mead.preprocessors import create_preprocessors
 from baseline.tf.embeddings import *
-from baseline.utils import export
+from baseline.tf.tfy import *
+from baseline.utils import export, read_json, ls_props
 from collections import namedtuple
 from mead.tf.exporters import ClassifyTensorFlowExporter, TaggerTensorFlowExporter, create_assets
 import json
@@ -110,11 +112,11 @@ class ClassifyTensorFlowPreProcExporter(ClassifyTensorFlowExporter):
         model_base_dir = os.path.split(model_file)[0]
         pid = model_file.split("-")[-1]
         pc = PreProcessorController(model_base_dir, pid, self.task.config_params['features'])
-        model_params = self.task.config_params['model']
         tf_example, preprocessed = pc.run()
+        embedding_inputs = {}
         for feature in preprocessed:
-            model_params[feature] = preprocessed[feature]
-        model, classes, values = self._create_model(sess, model_file)
+            embedding_inputs[feature] = preprocessed[feature]
+        model, classes, values = self._create_model(sess, model_file, embedding_inputs)
         sig_input = {
             'tokens': tf.saved_model.utils.build_tensor_info(tf_example[pc.FIELD_NAME]),
         }
@@ -137,11 +139,11 @@ class TaggerTensorFlowPreProcExporter(TaggerTensorFlowExporter):
         model_base_dir = os.path.split(model_file)[0]
         pid = model_file.split("-")[-1]
         pc = PreProcessorController(model_base_dir, pid, self.task.config_params['features'])
-        model_params = self.task.config_params['model']
         tf_example, preprocessed = pc.run()
+        embedding_inputs = {}
         for feature in preprocessed:
-            model_params[feature] = preprocessed[feature]
-        model, classes, values = self._create_model(sess, model_file)
+            embedding_inputs[feature] = preprocessed[feature]
+        model, classes, values = self._create_model(sess, model_file, embedding_inputs)
         sig_input = {
             'tokens': tf.saved_model.utils.build_tensor_info(tf_example[pc.FIELD_NAME]),
              model.lengths_key: tf.saved_model.utils.build_tensor_info(model.lengths)


### PR DESCRIPTION
This PR creates a consistent and easier to use way to save model metadata and facilitate reloading for tensorflow.

The main way this happens is that when the create function is called a `_record_state` function saves the kwargs that the model was created with to a dict. This is when saved to disk when the model is saved.

Reloading reads back these kwargs and calls create with them which results in the same model.

This also adds a few things to the saved state. These include the class name and module for most things. This allows for the reloading code to import the needed modules without the user specifying them. It also generates a new vectorizer metadata file that has the modules that need to be imported.

This also fixes the situation where is a subclass had a special create function (that is called when mead uses the `create_model` call) it wouldn't be used when reloading (only the default models load was called) There is a addon model that was created specifically to test this, we can ditch it if we want to.

There was also a bug where the dsz saved out by embeddings was the output dsz rather then the input dsz. This broke embeddings like the `char-conv` when the output size (`wsz`) didn't match the input size (`dsz`)

This also updates the exporters to use the new loads which greatly simplifies the exporting.

Tested by training, reloading, and exporting classifiers, taggers, lms, and seq2seq as well as a tagger with elmo embeddings. This work with both normal exporters and preproc exporters