### PR TITLE
return model rather than none

### DIFF
--- a/python/baseline/tf/tagger/model.py
+++ b/python/baseline/tf/tagger/model.py
@@ -134,6 +134,7 @@ class TaggerModelBase(TaggerModel):
             model.sess.run(tf.global_variables_initializer())
         model.saver = tf.train.Saver()
         model.saver.restore(model.sess, basename)
+        return model
 
     def save_using(self, saver):
         self.saver = saver


### PR DESCRIPTION
I deleted to much when I was fixing a merge conflict for the load-backport branch and the tagger model wasn't getting returned when loaded. This fixes that.