### PR TITLE
Parallel readers, Snips data, and more robust cache checking

### DIFF
--- a/docs/tagging.md
+++ b/docs/tagging.md
@@ -77,12 +77,20 @@ Out default CRF model can be run with the following:
 python trainer.py --config config/ontonotes.json
 ```
 
+### SNIPS NLU slot filling
+
+SNIPS NLU is data created by SNIPS for benchmarking chatbots systems. It includes intent detection and slot filling, This is the slot filling model and can be trained with the following:
+
+```
+python trainer.py --config config/snips.json
+```
+
 ### Model Performance
 
 We have done extensive testing on our tagger architecture.  Here are the results after runing each model 10 times for each configuration.  All NER models are trained with IOBES tags.  The ELMo configurations are done using our [ELMo Embeddings addon](../python/addons/embed_elmo.py).
 
-| config                                                       | dataset   | model                | metric | mean  |  std  | min   | max   |
-| ------------------------------------------------------------ | --------- | -------------------- |------- | ------| ----- | ----- | ----- |
+| Config                                                       | Dataset   | Model                | Metric | Mean  |  Std  | Min   | Max   |
+|:-------------------------------------------------------------|:----------|:---------------------|-------:|------:|------:|------:|------:|
 | [twpos.json](../python/mead/config/twpos.json)               | twpos-v03 | CNN-BLSTM-CRF        |    acc | 90.75 | 0.140 | 90.53 | 91.02 |
 | [conll.json](../python/mead/config/conll.json)               | CONLL2003 | CNN-BLSTM-CRF        |     f1 | 91.47 | 0.247 | 91.15 | 92.00 |
 | [conll-no-crf.json](../python/mead/config/conll-no-crf.json) | CONLL2003 | CNN-BLSTM-constrain  |     f1 | 91.44 | 0.232 | 91.17 | 91.90 |
@@ -90,6 +98,7 @@ We have done extensive testing on our tagger architecture.  Here are the results
 | [wnut.json](../python/mead/config/wnut.json)                 | WNUT17    | CNN-BLSTM-CRF        |     f1 | 40.33 | 1.13  | 38.38 | 41.90 |
 | [wnut-no-crf.json](../python/mead/config/wnut-no-crf.json)   | WNUT17    | CNN-BLSTM-constrain  |     f1 | 40.59 | 1.06  | 37.96 | 41.71 |
 | [ontonotes.json](../python/mead/config/ontonotes.json)       | ONTONOTES | CNN-BLSTM-CRF        |     f1 | 87.41 | 0.166 | 87.14 | 87.74 |
+| [snips.json](../python/mead/config/snips.json)               | SNIPS     | CNN-BLSTM-CRF        |     f1 | 95.55 | 0.394 | 94.85 | 96.07 |
 
 ### Testing a trained model on your data
 

--- a/python/addons/reader_parallel_classify.py
+++ b/python/addons/reader_parallel_classify.py
@@ -1,0 +1,116 @@
+import re
+import codecs
+from collections import Counter
+import baseline
+from baseline.utils import listify
+from baseline.reader import register_reader, SeqLabelReader, _filter_vocab, _norm_ext
+
+
+@register_reader(task='classify', name='parallel')
+class ParallelSeqLabelReader(SeqLabelReader):
+    REPLACE = { "'s": " 's ",
+                "'ve": " 've ",
+                "n't": " n't ",
+                "'re": " 're ",
+                "'d": " 'd ",
+                "'ll": " 'll ",
+                ",": " , ",
+                "!": " ! ",
+                }
+
+    def __init__(self, vectorizers, trim=False, truncate=False, **kwargs):
+        super(ParallelSeqLabelReader, self).__init__()
+
+        self.label2index = {}
+        self.vectorizers = vectorizers
+        self.clean_fn = kwargs.get('clean_fn')
+        if self.clean_fn is None:
+            self.clean_fn = lambda x: x
+        self.trim = trim
+        self.truncate = truncate
+        self.data = _norm_ext(kwargs.get('data_suffix', 'in'))
+        self.labels = _norm_ext(kwargs.get('label_suffix', 'labels'))
+
+
+    SPLIT_ON = '[\t\s]+'
+
+    @staticmethod
+    def splits(text):
+        return list(filter(lambda s: len(s) != 0, re.split('\s+', text)))
+
+    def get_labels(self):
+        labels = [''] * len(self.label2index)
+        for label, index in self.label2index.items():
+            labels[index] = label
+        return labels
+
+    @staticmethod
+    def do_clean(l):
+        l = l.lower()
+        l = re.sub(r"[^A-Za-z0-9(),!?\'\`]", " ", l)
+        for k, v in ParallelSeqLabelReader.REPLACE.items():
+            l = l.replace(k, v)
+        return l.strip()
+
+    @staticmethod
+    def label_and_sentence(line, clean_fn):
+        label_text = re.split(ParallelSeqLabelReader.SPLIT_ON, line)
+        label = label_text[0]
+        text = label_text[1:]
+        text = ' '.join(list(filter(lambda s: len(s) != 0, [clean_fn(w) for w in text])))
+        text = list(filter(lambda s: len(s) != 0, re.split('\s+', text)))
+        return label, text
+
+    def build_vocab(self, files, **kwargs):
+        label_idx = len(self.label2index)
+        files = listify(files)
+        vocab = {k: Counter() for k in self.vectorizers.keys()}
+        for file_name in files:
+            if file_name is None: continue
+            with codecs.open(file_name + self.data, encoding='utf-8', mode='r') as data_file:
+                with codecs.open(file_name + self.labels, encoding='utf-8', mode='r') as label_file:
+                    for d, l in zip(data_file, label_file):
+                        line = "{}\t{}".format(l, d)
+                        label, text = ParallelSeqLabelReader.label_and_sentence(line, self.clean_fn)
+                        if len(text) == 0: continue
+
+                        for k, vectorizer in self.vectorizers.items():
+                            vocab_file = vectorizer.count(text)
+                            vocab[k].update(vocab_file)
+
+                        if label not in self.label2index:
+                            self.label2index[label] = label_idx
+                            label_idx += 1
+
+        vocab = _filter_vocab(vocab, kwargs.get('min_f', {}))
+
+        return vocab, self.get_labels()
+
+    def load(self, filename, vocabs, batchsz, **kwargs):
+        shuffle = kwargs.get('shuffle', False)
+        sort_key = kwargs.get('sort_key', None)
+        if sort_key is not None and not sort_key.endswith('_lengths'):
+            sort_key += '_lengths'
+
+        examples = []
+
+        with codecs.open(filename + self.data, encoding='utf-8', mode='r') as data_f:
+            with codecs.open(filename + self.labels, encoding='utf-8', mode='r') as label_f:
+                for d, l in zip(data_f, label_f):
+                    line = '{}\t{}'.format(l, d)
+                    label, text = ParallelSeqLabelReader.label_and_sentence(line, self.clean_fn)
+                    if len(text) == 0:
+                        continue
+                    y = self.label2index[label]
+                    example_dict = dict()
+                    for k, vectorizer in self.vectorizers.items():
+                        example_dict[k], lengths = vectorizer.run(text, vocabs[k])
+                        if lengths is not None:
+                            example_dict['{}_lengths'.format(k)] = lengths
+
+                    example_dict['y'] = y
+                    examples.append(example_dict)
+        return baseline.data.ExampleDataFeed(baseline.data.DictExamples(examples,
+                                                                        do_shuffle=shuffle,
+                                                                        sort_key=sort_key),
+                                             batchsz=batchsz, shuffle=shuffle, trim=self.trim, truncate=self.truncate)

--- a/python/mead/config/datasets.json
+++ b/python/mead/config/datasets.json
@@ -127,5 +127,13 @@
     "download": "https://www.dropbox.com/s/ytrp62hoif802nt/seq2seq_reverse.tar.gz?dl=1",
     "sha1": "b6c97f628fd47f2f31b7df5a40a7555a0c7b2585",
     "label": "reverse"
+  },
+  {
+    "train_file": "train",
+    "valid_file": "dev",
+    "test_file": "test",
+    "download": "https://www.dropbox.com/s/lsrdntgu30ftg5l/snips.tar.gz?dl=1",
+    "sha1": "c3dd1bff7ad965303065549a05a7f420fc6f3279",
+    "label": "snips"
   }
 ]

--- a/python/mead/config/snips-intent.json
+++ b/python/mead/config/snips-intent.json
@@ -1,0 +1,51 @@
+{
+  "version": 2,
+  "modules": ["reader_parallel_classify"],
+  "task": "classify",
+  "basedir": "./snips-intent",
+  "batchsz": 50,
+  "features": [
+    {
+      "name": "word",
+      "vectorizer": {
+        "type": "token1d",
+	"transform": "baseline.lowercase"
+      },
+      "embeddings": {
+        "label": "w2v-gn"
+      }
+    }
+  ],
+  "preproc": {
+    "rev": false,
+    "clean": true
+  },
+  "backend": "tensorflow",
+  "dataset": "snips",
+  "loader": {
+    "reader_type": "parallel"
+  },
+  "unif": 0.25,
+  "model": {
+    "model_type": "default",
+    "filtsz": [
+      3,
+      4,
+      5
+    ],
+    "cmotsz": 100,
+    "dropout": 0.5,
+    "finetune": true
+  },
+  "train": {
+    "epochs": 2,
+    "optim": "adadelta",
+    "eta": 1.0,
+    "model_zip": true,
+    "early_stopping_metric": "acc",
+    "verbose": {
+      "console": true,
+      "file": "sst2-cm.csv"
+    }
+  }
+}

--- a/python/mead/config/snips.json
+++ b/python/mead/config/snips.json
@@ -1,0 +1,69 @@
+{
+  "task": "tagger",
+  "batchsz": 10,
+  "conll_output": "snips.conll",
+  "basedir": "./snips-sf",
+  "unif": 0.1,
+  "features": [
+    {
+      "name": "word",
+      "vectorizer": {
+        "type": "token1d",
+        "transform": "baseline.lowercase"
+      },
+      "embeddings": {
+        "label": "glove-6B-100"
+      }
+    },
+    {
+      "name": "senna",
+      "vectorizer": {
+        "type": "token1d",
+        "transform": "baseline.lowercase"
+      },
+      "embeddings": {
+        "label": "senna"
+      }
+    },
+    {
+      "name": "char",
+      "vectorizer": {
+        "type": "char2d"
+      },
+      "embeddings": { "dsz": 30, "wsz": 30, "type": "char-conv" }
+    }
+  ],
+  "preproc": {
+  },
+  "backend": "pytorch",
+  "dataset": "snips",
+  "loader": {
+    "reader_type": "parallel",
+    "data_suffix": "in",
+    "tag_suffix": "out"
+  },
+  "model": {
+    "model_type": "default",
+    "cfiltsz": [
+      3
+    ],
+    "hsz": 400,
+    "dropout": 0.5,
+    "dropin": {"word": 0.1,"senna": 0.1},
+    "rnntype": "blstm",
+    "layers": 1,
+    "constrain_decode": true,
+    "crf": 1
+  },
+  "train": {
+    "epochs": 100,
+    "optim": "sgd",
+    "eta": 0.015,
+    "mom": 0.9,
+    "patience": 40,
+    "early_stopping_metric": "f1",
+    "clip": 5.0,
+    "span_type": "iobes"
+  }
+}
+

--- a/python/mead/tasks.py
+++ b/python/mead/tasks.py
@@ -579,7 +579,7 @@ class EncoderDecoderTask(Task):
     def initialize(self, embeddings):
         embeddings = read_config_file_or_json(embeddings, 'embeddings')
         embeddings_set = index_by_label(embeddings)
-        self.dataset = DataDownloader(self.dataset, self.data_download_cache, True).download()
+        self.dataset = DataDownloader(self.dataset, self.data_download_cache).download()
         print_dataset_info(self.dataset)
         vocab1, vocab2 = self.reader.build_vocabs(
             [self.dataset['train_file'], self.dataset['valid_file'], self.dataset['test_file']],


### PR DESCRIPTION
This PR adds:

 * Parallel data file reader for tagger data (one file is the space separated tokens and the other is space separated labels aligned so each new line is an example).
 * Parallel data file reader for classify task. (This is one is a hack and has a lot of copy paste from the TSV reader so it is put in the addons sectoin)
 * Adds Snips NLU data (intent and slot filling) and performance. This dataset uses the above readers. This dataset is pretty easy (intent classification with sst2 hyperparams give like 98%) so I don't know how useful it will be in practice.
 * Updates the cache checking code so that it can handle the cases here and for seq2seq models where the `dataset.json` has the prefix (`train`) and the actual downloaded data has the full versions (`train.en`).