### PR TITLE
Warning on clean fn

### DIFF
--- a/python/baseline/utils.py
+++ b/python/baseline/utils.py
@@ -146,17 +146,6 @@ def suppress_output():
         yield
 
 
-class JSONFormatter(logging.Formatter):
-    """Format message as JSON if possible, log normally otherwise."""
-    def format(self, record):
-        try:
-            if isinstance(record.msg, (list, dict)):
-                return json.dumps(record.msg)
-        except TypeError:
-            pass
-        return super(JSONFormatter, self).format(record)
-
-
 @exporter
 class Colors(object):
     GREEN = '\033[32;1m'
@@ -172,6 +161,28 @@ def color(msg, color):
     if platform.system() == 'Windows':
         return msg
     return u"{}{}{}".format(color, msg, Colors.RESTORE)
+
+
+class ColoredFormatter(logging.Formatter):
+    COLORS = {
+        'WARNING': Colors.YELLOW,
+    }
+
+    def format(self, record):
+        if record.levelname in self.COLORS:
+            return color(super(ColoredFormatter, self).format(record), self.COLORS[record.levelname])
+        return super(ColoredFormatter, self).format(record)
+
+
+class JSONFormatter(ColoredFormatter):
+    """Format message as JSON if possible, log normally otherwise."""
+    def format(self, record):
+        try:
+            if isinstance(record.msg, (list, dict)):
+                return json.dumps(record.msg)
+        except TypeError:
+            pass
+        return super(JSONFormatter, self).format(record)
 
 
 @exporter

--- a/python/mead/tasks.py
+++ b/python/mead/tasks.py
@@ -167,6 +167,8 @@ class Task(object):
         self._create_vectorizers()
         reader_params = self.config_params['loader']
         reader_params['clean_fn'] = reader_params.get('clean_fn', self.config_params.get('preproc', {}).get('clean_fn'))
+        if reader_params['clean_fn'] is not None and self.config_params['dataset'] != 'SST2':
+            logger.warning('Warning: A reader preprocessing function (%s) is active, it is recommended that all data preprocessing is done outside of baseline to insure data at inference time matches data at training time.', reader_params['clean_fn'])
         reader_params['mxlen'] = self.vectorizers[self.primary_key].mxlen
         if self.config_params['model'].get('gpus', 1) > 1:
             reader_params['truncate'] = True
@@ -676,6 +678,8 @@ class LanguageModelingTask(Task):
         reader_params = self.config_params['loader']
         reader_params['nctx'] = reader_params.get('nctx', self.config_params.get('nctx', self.config_params.get('nbptt', 35)))
         reader_params['clean_fn'] = reader_params.get('clean_fn', self.config_params.get('preproc', {}).get('clean_fn'))
+        if reader_params['clean_fn'] is not None and self.config_params['dataset'] != 'SST2':
+            logger.warning('Warning: A reader preprocessing function (%s) is active, it is recommended that all data preprocessing is done outside of baseline to insure data at inference time matches data at training time.', reader_params['clean_fn'])
         reader_params['mxlen'] = self.vectorizers[self.primary_key].mxlen
         if self.config_params['model'].get('gpus', 1) > 1:
             reader_params['truncate'] = True


### PR DESCRIPTION
This PR logs a big yellow warning when the clean function is active and the dataset isn't SST2.

I also looked to see if warnings were needed for the `web_cleanup` clean function. It seems like it is only used as a vectorizer transform function it shouldn't cause a problem

```bash
(dl) blester@blester:~/dev/work/baseline (feature/clean-warning)$ grep -rn python/ -e 'web_cleanup'
python/mead/config/wnut.json:35:                "transform": "baseline.web_cleanup"
python/mead/config/twpos.json:43:                "transform": "baseline.web_cleanup"
python/mead/config/twpos-dy-autobatch.json:35:		"transform": "baseline.web_cleanup",
python/mead/config/wnut-no-crf.json:35:                "transform": "baseline.web_cleanup"
python/baseline/utils.py:413:def web_cleanup(word):
```