### PR TITLE
Refactor cache checking a bit

### DIFF
--- a/python/mead/config/snips-intent.json
+++ b/python/mead/config/snips-intent.json
@@ -17,8 +17,7 @@
     }
   ],
   "preproc": {
-    "rev": false,
-    "clean": true
+    "rev": false
   },
   "backend": "tensorflow",
   "dataset": "snips",

--- a/python/mead/downloader.py
+++ b/python/mead/downloader.py
@@ -1,3 +1,5 @@
+import os
+import re
 import gzip
 import logging
 import tarfile
@@ -5,9 +7,6 @@ import zipfile
 import hashlib
 import shutil
 import requests
-import os
-import re
-from collections import defaultdict
 from baseline.mime_type import mime_type
 from baseline.utils import export, read_json, write_json
 

--- a/python/mead/downloader.py
+++ b/python/mead/downloader.py
@@ -143,15 +143,11 @@ def is_file_correct(file_loc, data_dcache=None, key=None):
         return True
     # Some files are prefixes (the datasset.json has `train` and the data has `train.fr` and `train.en`)
     dir_name = os.path.dirname(file_loc)
+    # When we are using this for checking embeddings file_loc is a url so we need this check.
     if os.path.exists(dir_name):
-        possible_files = defaultdict(list)
-        # Get all files that have file_loc as a prefix
-        for f in os.listdir(dir_name):
-            possible_files[os.path.join(dir_name, os.path.splitext(f)[0])].append(os.path.join(dir_name, f))
-        # Check all suffixed files are valid
-        if file_loc in possible_files:
-            if all(_verify_file(f) for f in possible_files[file_loc]):
-                return True
+        files = [os.path.join(dir_name, f) for f in os.listdir(dir_name) if os.path.join(dir_name, f).startswith(file_loc)]
+        if files and all(_verify_file(f) for f in files):
+            return True
     delete_old_copy(file_loc)
     if key is not None:  # cache file validation
         update_cache(key, data_dcache)


### PR DESCRIPTION
Something was bugging me about the way I wrote the cache checking code to find files that have the file we care about as a prefix. The way it was makes sense if we were going to reuse that mapping for each file we check but we aren't doing that so it looks weird.

This new way looks better to me.

It also removes the `do_clean` from the snips dataset (the warning works lol)