### PR TITLE
Feature/span tools

### DIFF
--- a/python/baseline/conlleval.py
+++ b/python/baseline/conlleval.py
@@ -1,0 +1,106 @@
+"""An implementation of conlleval.pl https://www.clips.uantwerpen.be/conll2000/chunking/output.html
+
+Input is a conll file with the rightmost columns being gold and predicted tags
+in that order. Sentences are separated by a blank line.
+
+Some parts of the perl script are not replicated (this doesn't generate a latex
+table) but there are other improvements like it supports files in the `IOBES`
+format.
+
+The script produces the same output as conlleval.pl for BIO and IOB tagged file.
+When running on IOBES files it will produce the same F1 scores as if you
+converted the file to BIO and run conlleval.pl however the accuracy will be
+slightly different IOBES accuracy will always equal to or lower than BIO score.
+
+This difference is because if the error is on a B-, I-, or O token then the
+error will be in both IOBES and BIO. In the conversion from IOBES to BIO then
+S- is converted to B- and E- to I- if the IOBES was correct then they will be
+converted and will still be correct. If the token was wrong in that is said
+it was O or something then it will be wrong after the conversion too. If it was
+wrong in that the S- was tagged as B- or the E- was an I- (this is possible and
+a common error) then when the gold is changed these will become correct. So it
+is only possible that the conversion will make some answers correct. It won't
+make anything that was correct wrong.
+"""
+
+import sys
+import argparse
+from itertools import chain
+from baseline.utils import to_chunks, per_entity_f1, conlleval_output, read_conll_sentences
+
+
+def _read_conll_file(f, delim):
+    """Read a golds and predictions out of a conll file.
+
+    :param f: `file` The open file object.
+    :param delim: `str` The symbol that separates columns in the file.
+
+    :returns: `Tuple[List[List[str]], List[List[str]]]` The golds
+        and the predictions. They are aligned lists and each element
+        is a List of strings that are the list of tags.
+
+    Note:
+        the file should contain lines with items separated
+        by $delimiter characters (default space). The final
+        two items should contain the correct tag and the
+        guessed tag in that order. Sentences should be
+        separated from each other by empty lines.
+    """
+    golds = []
+    preds = []
+    for lines in read_conll_sentences(f, delim=delim):
+        golds.append([l[-2] for l in lines])
+        preds.append([l[-1] for l in lines])
+    return golds, preds
+
+
+def _get_accuracy(golds, preds):
+    """Calculate the token level accuracy.
+
+    :param golds: `List[List[str]]` The list of golds of each example.
+    :param preds: `List[List[str]]` The list of predictions of each example.
+
+    :returns: `Tuple[float, int]` The Accuracy and the total number of tokens.
+    """
+    total = 0
+    correct = 0
+    for g, p in zip(chain(*golds), chain(*preds)):
+        if g == p:
+            correct += 1
+        total += 1
+    return correct / float(total) * 100, total
+
+
+def _get_entites(golds, preds, span_type='iobes', verbose=False):
+    """ Convert the tags into sets of entities.
+
+    :param golds: `List[List[str]]` The list of gold tags.
+    :param preds: `List[List[str]]` The list of predicted tags.
+    :param span_type: `str` The span labeling scheme used.
+    :param verbose: `bool` Should warnings be printed when an illegal transistion is found.
+    """
+    golds = [set(to_chunks(g, span_type, verbose)) for g in golds]
+    preds = [set(to_chunks(p, span_type, verbose)) for p in preds]
+    return golds, preds
+
+
+def main():
+    """Use as a cli tool like conlleval.pl"""
+    usage = "usage: %(prog)s [--span_type {bio,iobes,iob}] [-d delimiterTag] [-v] < file"
+    parser = argparse.ArgumentParser(description="Calculate Span level F1 from the CoNLL-2000 shared task.", usage=usage)
+    parser.add_argument("--span_type", default="iobes", choices={"iobes", "iob", "bio"}, help="What tag annotation scheme is this file using.")
+    parser.add_argument("--delimiterTag", "-d", default=" ", help="The separator between items in the file.")
+    parser.add_argument("--verbose", '-v', action="store_true", help="Output warnings when there is an illegal transition.")
+    args = parser.parse_args()
+
+    golds, preds = _read_conll_file(sys.stdin, args.delimiterTag)
+    acc, tokens = _get_accuracy(golds, preds)
+    golds, preds = _get_entites(golds, preds, args.span_type, args.verbose)
+    metrics = per_entity_f1(golds, preds)
+    metrics['acc'] = acc
+    metrics['tokens'] = tokens
+    print(conlleval_output(metrics))
+
+
+if __name__ == "__main__":
+    main()

--- a/python/setup_baseline.py
+++ b/python/setup_baseline.py
@@ -79,7 +79,8 @@ def main():
                 'mead-train = mead.trainer:main',
                 'mead-export = mead.export:main',
                 'mead-clean = mead.clean:main',
-                'bleu = baseline.bleu:main'
+                'bleu = baseline.bleu:main',
+                'conlleval = baseline.conlleval:main',
             ]
         },
         classifiers={

--- a/python/tests/test_iobes.py
+++ b/python/tests/test_iobes.py
@@ -1,0 +1,301 @@
+import random
+from mock import patch
+from baseline.utils import (
+    to_chunks,
+    to_chunks_iobes,
+    convert_iob_to_bio,
+    convert_iobes_to_bio,
+    convert_bio_to_iobes,
+)
+
+# Most of these tests follow this general format. A random sequence of entity spans are generated,
+# These entities are used to generate a tag sequence in some given format. These generated entities
+# are used as gold for the `to_chunks` code. Generating multiple tag sequences from a single
+# random set of spans can be used for gold data for the converting functions.
+
+
+def generate_spans(ents=['X', 'Y'], max_span=5, min_span=0, max_spanl=3, min_spanl=1, min_space=0, max_space=1):
+    """Generate a series of entity spans. They are be touching each other but don't overlap."""
+    i = 0
+    n_spans = random.randint(min_span, max_span)
+    spans = []
+    for _ in range(n_spans):
+        ent = random.choice(ents)
+        span_length = random.randint(min_spanl, max_spanl)
+        span_gap = random.randint(min_space, max_space)
+        span_start = i + span_gap
+        span_end = span_start + span_length
+        i = span_end
+        span = "@".join([ent] + list(map(str, range(span_start, span_end))))
+        spans.append(span)
+    end = random.randint(min_space, max_space)
+    return spans, i + end
+
+
+def parse_span(span):
+    parts = span.split("@")
+    return parts[0], list(map(int, parts[1:]))
+
+
+def generate_iobes(spans):
+    """Convert a set of spans to an IOBES sequence."""
+    spans, length = spans
+    text = ['O'] * length
+    for span in spans:
+        ent, locs = parse_span(span)
+        if len(locs) == 1:
+            text[locs[0]] = 'S-{}'.format(ent)
+            continue
+        for i, loc in enumerate(locs):
+            if i == 0:
+                text[loc] = 'B-{}'.format(ent)
+            elif i == len(locs) - 1:
+                text[loc] = 'E-{}'.format(ent)
+            else:
+                text[loc] = 'I-{}'.format(ent)
+    return text
+
+
+def generate_bio(spans):
+    """Convert a set of spans to a BIO sequence."""
+    spans, length = spans
+    text = ['O'] * length
+    for span in spans:
+        ent, locs = parse_span(span)
+        for i, loc in enumerate(locs):
+            if i == 0:
+                text[loc] = 'B-{}'.format(ent)
+            else:
+                text[loc] = 'I-{}'.format(ent)
+    return text
+
+
+def generate_iob(spans):
+    """Convert a set of spans to an IOB sequence."""
+    spans, length = spans
+    text = ['O'] * length
+    for span in spans:
+        ent, locs = parse_span(span)
+        for i, loc in enumerate(locs):
+            text[loc] = 'I-{}'.format(ent)
+    for span in spans:
+        ent, locs = parse_span(span)
+        if locs[0] != 0 and text[locs[0] - 1][2:] == ent:
+            text[locs[0]] = 'B-{}'.format(ent)
+    return text
+
+
+def test_iob_bio():
+    def test():
+        spans = generate_spans()
+        iob = generate_iob(spans)
+        gold_bio = generate_bio(spans)
+        bio = convert_iob_to_bio(iob)
+        assert bio == gold_bio
+
+    for _ in range(100):
+        test()
+
+
+def test_bio_iobes():
+    def test():
+        spans = generate_spans()
+        bio = generate_bio(spans)
+        gold_iobes = generate_iobes(spans)
+        iobes = convert_bio_to_iobes(bio)
+        assert iobes == gold_iobes
+
+    for _ in range(100):
+        test()
+
+
+def test_iobes_bio():
+    def test():
+        spans = generate_spans()
+        iobes = generate_iobes(spans)
+        gold_bio = generate_bio(spans)
+        bio = convert_iobes_to_bio(iobes)
+        assert bio == gold_bio
+
+    for _ in range(100):
+        test()
+
+
+def test_iobes_bio_cycle():
+    def test():
+        spans = generate_spans()
+        gold_iobes = generate_iobes(spans)
+        res = convert_bio_to_iobes(convert_iobes_to_bio(gold_iobes))
+        assert res == gold_iobes
+
+    for _ in range(100):
+        test()
+
+
+def test_bio_iobes_cycle():
+    def test():
+        spans = generate_spans()
+        gold_bio = generate_bio(spans)
+        res = convert_iobes_to_bio(convert_bio_to_iobes(gold_bio))
+        assert res == gold_bio
+
+    for _ in range(100):
+        test()
+
+
+def test_to_chunks_iobes():
+    def test():
+        spans = generate_spans()
+        gold = spans[0]
+        iobes = generate_iobes(spans)
+        chunks = to_chunks_iobes(iobes)
+        assert chunks == gold
+
+    for _ in range(100):
+        test()
+
+
+def test_to_chunks_iobes_delim():
+    def test():
+        delim = random.choice(["@", "#", "%"])
+        spans = generate_spans()
+        gold = spans[0]
+        gold = [g.replace("@", delim) for g in gold]
+        iobes = generate_iobes(spans)
+        chunks = to_chunks_iobes(iobes, delim=delim)
+        assert chunks == gold
+
+    for _ in range(100):
+        test()
+
+
+def test_to_chunks_calls_iobes():
+    seq = [random.randint(0, 5) for _ in range(random.randint(1, 6))]
+    verbose = random.choice([True, False])
+    delim = random.choice(['@', '#', '%'])
+    with patch('baseline.utils.to_chunks_iobes') as iobes_patch:
+        to_chunks(seq, 'iobes', verbose, delim)
+    iobes_patch.assert_called_once_with(seq, verbose, delim)
+
+
+def test_to_chunks_bio():
+    def test():
+        spans = generate_spans()
+        gold = spans[0]
+        iobes = generate_bio(spans)
+        chunks = to_chunks(iobes, 'bio')
+        assert chunks == gold
+
+    for _ in range(100):
+        test()
+
+
+def test_to_chunks_bio_delim():
+    def test():
+        delim = random.choice(["@", "#", "!"])
+        spans = generate_spans()
+        gold = spans[0]
+        gold = [g.replace("@", delim) for g in gold]
+        iobes = generate_bio(spans)
+        chunks = to_chunks(iobes, 'bio', delim=delim)
+        assert chunks == gold
+
+    for _ in range(100):
+        test()
+
+
+def test_to_chunks_iob():
+    def test():
+        spans = generate_spans()
+        gold = spans[0]
+        iobes = generate_iob(spans)
+        chunks = to_chunks(iobes, 'iob')
+        assert chunks == gold
+
+    for _ in range(100):
+        test()
+
+
+def test_to_chunks_iob_delim():
+    def test():
+        delim = random.choice(["@", "#", "$"])
+        spans = generate_spans()
+        gold = spans[0]
+        gold = [g.replace("@", delim) for g in gold]
+        iobes = generate_iob(spans)
+        chunks = to_chunks(iobes, 'iob', delim=delim)
+        assert chunks == gold
+
+    for _ in range(100):
+        test()
+
+
+# Tests By Hand
+def test_iob_bio_i_after_o():
+    in_ = ['O', 'I-X', 'O']
+    gold = ['O', 'B-X', 'O']
+    res = convert_iob_to_bio(in_)
+    assert res == gold
+
+
+def test_iob_bio_i_after_b_diff():
+    in_ = ['O', 'B-X', 'I-Y', 'O']
+    gold = ['O', 'B-X', 'B-Y', 'O']
+    res = convert_iob_to_bio(in_)
+    assert res == gold
+
+
+def test_iob_bio_i_after_b_same():
+    in_ = ['O', 'B-X', 'I-X', 'O']
+    gold = ['O', 'B-X', 'I-X', 'O']
+    res = convert_iob_to_bio(in_)
+    assert res == gold
+
+
+def test_iob_bio_i_after_i_diff():
+    in_ = ['O', 'I-X', 'I-Y', 'O']
+    gold = ['O', 'B-X', 'B-Y', 'O']
+    res = convert_iob_to_bio(in_)
+    assert res == gold
+
+
+def test_iob_bio_i_after_i_same():
+    in_ = ['O', 'I-X', 'I-X', 'O']
+    gold = ['O', 'B-X', 'I-X', 'O']
+    res = convert_iob_to_bio(in_)
+    assert res == gold
+
+
+def test_iob_bio_i_first():
+    in_ = ['I-X', 'O']
+    gold = ['B-X', 'O']
+    res = convert_iob_to_bio(in_)
+    assert res == gold
+
+
+def test_bio_iobes_single_b():
+    in_ = ['O', 'B-X', 'O']
+    gold = ['O', 'S-X', 'O']
+    res = convert_bio_to_iobes(in_)
+    assert res == gold
+
+
+def test_bio_iobes_i_to_e_at_end():
+    in_ = ['O', 'B-X', 'I-X']
+    gold = ['O', 'B-X', 'E-X']
+    res = convert_bio_to_iobes(in_)
+    assert res == gold
+
+
+def test_bio_iobes_i_to_e_at_o():
+    in_ = ['O', 'B-X', 'I-X', 'O']
+    gold = ['O', 'B-X', 'E-X', 'O']
+    res = convert_bio_to_iobes(in_)
+    assert res == gold
+
+
+def test_bio_iobes_i_to_e_at_b():
+    in_ = ['O', 'B-X', 'I-X', 'B-Y', 'I-Y']
+    gold = ['O', 'B-X', 'E-X', 'B-Y', 'E-Y']
+    res = convert_bio_to_iobes(in_)
+    assert res == gold


### PR DESCRIPTION
This PR updates and expands how we work with sequence tagging evaluation in baseline. The goal is to make it more flexible, allow for more reuse, and output new metrics we couldn't before.

 * In `to_spans` it first converts the sequence from indices to strings with the lut and then it delegates the actual creation of chunks to another function so that we can use and test it easier.
 * The `to_chunks` code returns lists of chunks (in the order they are found) rather than sets and lets users specify what symbol they want to separate the entity type and indices.
 * Adds code to check for and warn about a single `B-` tag in an `IOBES` sequence.
 * Adds tests for these functions. Most of these are randomized tests where a random collection of entities are draw and then tag sequences are created from those. Drawn chunks and generated sequences can be used as gold data to compare to.
 * Adds functions that can calculate the f1 score per entity and format the output the way that `conlleval.pl` does.
 * Changes the train functions. Instead of keeping a running total of gold, pred, and overlap entity counts instead a the actual entities are kept. These are then used to compute the entity level f1 and optional to compute the f1 with entity type breakdowns.
 * It adds a `conlleval.py` script that uses the new functions to produce the same output as `conlleval.pl` (It doesn't do everything like creating latex tables.) This script is also added as an entry point so that we can just run `conlleval conllresults.conll` 
 * I have run about 25 different taggers (a mix of pytorch, tf, and dynet), converted the output from iobes to bio, and ran `conlleval.pl`, `conlleval.py` (on both the bio and iobes files), and compared to the scores output by training and they all matched 