### PR TITLE
remove requests

### DIFF
--- a/python/setup_baseline.py
+++ b/python/setup_baseline.py
@@ -68,7 +68,6 @@ def main():
         install_requires=[
             'numpy',
             'six',
-            'requests',
         ],
         extras_require={
             'test': ['pytest', 'mock', 'contextdecorator', 'pytest-forked'],

--- a/scripts/download_all.py
+++ b/scripts/download_all.py
@@ -1,0 +1,34 @@
+import os
+import argparse
+from baseline.utils import read_json
+from mead.utils import index_by_label, convert_path
+from mead.downloader import EmbeddingDownloader, DataDownloader
+
+
+parser = argparse.ArgumentParser(description="Download all data and embeddings.")
+parser.add_argument("--cache", default="~/.bl-data", type=os.path.expanduser, help="Location of the data cache")
+parser.add_argument('--datasets', help='json library of dataset labels', default='config/datasets.json', type=convert_path)
+parser.add_argument('--embeddings', help='json library of embeddings', default='config/embeddings.json', type=convert_path)
+args = parser.parse_args()
+
+
+datasets = read_json(args.datasets)
+datasets = index_by_label(datasets)
+
+for name, d in datasets.items():
+    print(name)
+    try:
+        DataDownloader(d, args.cache).download()
+    except Exception as e:
+        print(e)
+
+
+emb = read_json(args.embeddings)
+emb = index_by_label(emb)
+
+for name, e in emb.items():
+    print(name)
+    try:
+        EmbeddingDownloader(e['file'], e['dsz'], e.get('sha1'), args.cache).download()
+    except Exception as e:
+        print(e)


### PR DESCRIPTION
The PR removes the dependency on the requests library, It was easier than I expected with the `urlretrieve` function. The code successfully downloads all the data we have in the `datasets.json` and `embeddings.json`.

There is a chance that requests could do something useful under the hood like following redirects (for example if the location of glove vectors get changed) but it seems like we can cross that bridge when we come to it.