### PR TITLE
Feature/mead export path

### DIFF
--- a/docs/export.md
+++ b/docs/export.md
@@ -89,4 +89,18 @@ Once you have an exported model and the docker image pulled, you can load it in 
 ```
 docker run -it --name tf_classify -p 9000:9000 -v ./models:/models/ epigramai/model-server:light --port=9000 --model_name=tf_classify --model_base_path=/models/
 
-```  
+```
+
+
+## Paths
+
+A few commandline arguments to `mead-export` can be used to control what the output paths look like.
+
+The first is `--output_dir` This controls the root of the exported model. The argument `--project` creates a subdirectory for the model and `--name` can be used to create a second one. `--is_remote` is used to split the export into a `client` and `server` trees. Here are a few examples. When neither a `--project` nor as `--name` are given then a directory with the same name is the basename of the `--output_dir` is created. `--model_version` is the last directory.
+
+ * `mead-export ... --output_dir path/to/models --is_remote true --model_version 3` -> `path/to/models/client/models/3` and `path/to/models/server/models/3`
+ * `mead-export ... --output_dir path/to/models --is_remote false --model_version 19` -> `path/to/models/19`
+ * `mead-export ... --output_dir path/to/models --project proj --model_version 2` -> `path/to/models/client/proj/2` and `path/to/models/server/proj/2`
+ * `mead-export ... --output_dir path/to/models --project example --name bob --model_version 1 --is_remote false` -> `path/to/models/example/bob/1`
+
+`--model_version` can be set to `None` and it will search in the export dir and use a model number one larger than the largest one currently in there.

--- a/python/mead/export.py
+++ b/python/mead/export.py
@@ -29,8 +29,10 @@ def main():
     parser.add_argument('--return_labels', help='if true, the exported model returns actual labels else '
                                                 'the indices for labels vocab', default=False, type=str2bool)
     parser.add_argument('--model', help='model name', required=True, type=unzip_model)
-    parser.add_argument('--model_version', help='model_version', default=1)
+    parser.add_argument('--model_version', help='model_version', default=None)
     parser.add_argument('--output_dir', help='output dir', default='./models')
+    parser.add_argument('--project', help='Name of project, used in path first', default=None)
+    parser.add_argument('--name', help='Name of the model, used second in the path', default=None)
     parser.add_argument('--beam', help='beam_width', default=30, type=int)
     parser.add_argument('--is_remote', help='if True, separate items for remote server and client. If False bundle everything together', default=True, type=str2bool)
 
@@ -51,7 +53,7 @@ def main():
     feature_exporter_field_map = create_feature_exporter_field_map(config_params['features'])
     exporter = create_exporter(task, args.exporter_type, return_labels=args.return_labels,
                                feature_exporter_field_map=feature_exporter_field_map)
-    exporter.run(args.model, args.output_dir, args.model_version, remote=args.is_remote)
+    exporter.run(args.model, args.output_dir, args.project, args.name, args.model_version, remote=args.is_remote)
 
 
 if __name__ == "__main__":

--- a/python/mead/exporters.py
+++ b/python/mead/exporters.py
@@ -11,7 +11,7 @@ class Exporter(object):
         super(Exporter, self).__init__()
         self.task = task
 
-    def run(self, model_file, output_dir, model_version, **kwargs):
+    def run(self, model_file, output_dir, project=None, name=None, model_version=None, **kwargs):
         pass
 
 

--- a/python/tests/test_mead_utils.py
+++ b/python/tests/test_mead_utils.py
@@ -1,6 +1,15 @@
 import os
+import string
+import random
+from itertools import chain
+from collections import namedtuple
+from mock import patch, call
 import pytest
-from mead.utils import convert_path
+from mead.utils import convert_path, find_model_version, get_output_paths
+
+
+CHARS = list(chain(string.ascii_letters, string.digits))
+
 
 @pytest.fixture
 def file_name():
@@ -9,11 +18,13 @@ def file_name():
     yield file_
     os.remove(file_)
 
+
 def test_no_loc():
     file_name = "test"
     gold = os.path.realpath(os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "mead", file_name))
     path = convert_path(file_name)
     assert path == gold
+
 
 def test_loc():
     file_name = "test"
@@ -22,6 +33,7 @@ def test_loc():
     path = convert_path(file_name, start)
     assert path == gold
 
+
 def test_file_exists(file_name):
     start = "/dev"
     gold = file_name
@@ -29,3 +41,185 @@ def test_file_exists(file_name):
     path = convert_path(file_name, start)
     assert path == gold
     assert path != wrong
+
+
+def rand_str(length=None, min_=3, max_=10):
+    if length is None:
+        length = random.randint(min_, max_)
+    return ''.join([random.choice(CHARS) for _ in range(length)])
+
+
+def test_find_version():
+    gold = random.randint(5, 15)
+    items = list(map(str, range(gold)))
+    gold = str(gold)
+    with patch('mead.utils._listdir') as list_patch:
+        list_patch.return_value = items
+        res = find_model_version(None)
+    assert res == gold
+
+
+def test_find_version_gappy():
+    gold = random.randint(5, 15)
+    items = list(map(str, random.sample(range(gold), gold // 2)))
+    items.append(str(gold - 1))
+    gold = str(gold)
+    with patch('mead.utils._listdir') as list_patch:
+        list_patch.return_value = items
+        res = find_model_version(None)
+    assert res == gold
+
+
+def test_find_version_non_int():
+    gold = random.randint(5, 15)
+    items = list(map(str, random.sample(range(gold), gold // 2)))
+    items.append(str(gold - 1))
+    gold = str(gold)
+    items.insert(random.randint(0, len(items)), rand_str())
+    with patch('mead.utils._listdir') as list_patch:
+        list_patch.return_value = items
+        res = find_model_version(None)
+    assert res == gold
+
+
+def test_find_version_none():
+    gold = "1"
+    items = []
+    with patch('mead.utils._listdir') as list_patch:
+        list_patch.return_value = items
+        res = find_model_version(None)
+    assert res == gold
+
+
+def test_find_version_non_int_only():
+    gold = "1"
+    items = [rand_str for _ in range(random.randint(1, 3))]
+    with patch('mead.utils._listdir') as list_patch:
+        list_patch = items
+        res = find_model_version(None)
+    assert res == gold
+
+
+names = namedtuple("d", "dir base proj name version")
+
+
+@pytest.fixture
+def d():
+    data = []
+    data.append(os.path.join(*[rand_str() for _ in range(random.randint(1, 4))]))
+    data.append(os.path.basename(data[-1]))
+    data.append(rand_str())
+    data.append(rand_str())
+    data.append(str(random.randint(1, 4)))
+    return names(*data)
+
+
+@pytest.fixture
+def m_patch():
+    with patch('mead.utils.os.makedirs') as m_patch:
+        yield m_patch
+
+
+def test_get_output_paths_old_remote(d, m_patch):
+    gc = os.path.join(d.dir, 'client', d.base, d.version)
+    gs = os.path.join(d.dir, 'server', d.base, d.version)
+    c, s = get_output_paths(d.dir, None, None, d.version, True)
+    assert c == gc
+    assert s == gs
+
+
+def test_get_output_paths_old(d, m_patch):
+    gc = os.path.join(d.dir, d.version)
+    gs = os.path.join(d.dir, d.version)
+    c, s = get_output_paths(d.dir, None, None, d.version, False)
+    assert c == gc
+    assert s == gs
+    assert c == s
+
+
+def test_get_output_paths_project_name(d, m_patch):
+    g = os.path.join(d.dir, d.proj, d.name, d.version)
+    c, s = get_output_paths(d.dir, d.proj, d.name, d.version, False)
+    assert c == g
+    assert c == s
+
+
+def test_get_output_paths_project_name_remote(d, m_patch):
+    gc = os.path.join(d.dir, 'client', d.proj, d.name, d.version)
+    gs = os.path.join(d.dir, 'server', d.proj, d.name, d.version)
+    c, s = get_output_paths(d.dir, d.proj, d.name, d.version, True)
+    assert c == gc
+    assert s == gs
+
+
+def test_get_output_paths_project(d, m_patch):
+    g = os.path.join(d.dir, d.proj, d.version)
+    c, s = get_output_paths(d.dir, d.proj, None, d.version, False)
+    assert c == g
+    assert c == s
+
+
+def test_get_output_paths_project_remote(d, m_patch):
+    gc = os.path.join(d.dir, "client", d.proj, d.version)
+    gs = os.path.join(d.dir, "server", d.proj, d.version)
+    c, s = get_output_paths(d.dir, d.proj, None, d.version, True)
+    assert c == gc
+    assert s == gs
+
+
+def test_get_output_paths_name(d, m_patch):
+    g = os.path.join(d.dir, d.name, d.version)
+    c, s = get_output_paths(d.dir, None, d.name, d.version, False)
+    assert c == g
+    assert c == s
+
+
+def test_get_output_paths_name_remote(d, m_patch):
+    gc = os.path.join(d.dir, "client", d.name, d.version)
+    gs = os.path.join(d.dir, "server", d.name, d.version)
+    c, s = get_output_paths(d.dir, None, d.name, d.version, True)
+    assert c == gc
+    assert s == gs
+
+
+def test_get_output_paths_no_version(d, m_patch):
+    g = os.path.join(d.dir, d.proj, d.name, d.version)
+    with patch('mead.utils.find_model_version') as v_patch:
+        v_patch.return_value = d.version
+        c, s = get_output_paths(d.dir, d.proj, d.name, None, False)
+    assert c == g
+    assert c == s
+
+
+def test_get_output_paths_no_version_remote(d, m_patch):
+    gc = os.path.join(d.dir, "client", d.proj, d.name, d.version)
+    gs = os.path.join(d.dir, "server", d.proj, d.name, d.version)
+    with patch('mead.utils.find_model_version') as v_patch:
+        v_patch.return_value = d.version
+        c, s = get_output_paths(d.dir, d.proj, d.name, None, True)
+    assert c == gc
+    assert s == gs
+
+
+def test_get_output_paths_make_server(d, m_patch):
+    g = os.path.join(d.dir, d.proj, d.name, d.version)
+    _, _ = get_output_paths(d.dir, d.proj, d.name, d.version, False, True)
+    m_patch.assert_called_once_with(g)
+
+
+def test_get_output_paths_no_make_server(d, m_patch):
+    _, _ = get_output_paths(d.dir, d.proj, d.name, d.version, False, False)
+    m_patch.assert_not_called()
+
+
+def test_get_output_paths_make_server_remote(d, m_patch):
+    gs = os.path.join(d.dir, "server", d.proj, d.name, d.version)
+    gc = os.path.join(d.dir, "client", d.proj, d.name, d.version)
+    _, _ = get_output_paths(d.dir, d.proj, d.name, d.version, True, True)
+    assert m_patch.call_args_list == [call(gc), call(gs)]
+
+
+def test_get_output_paths_no_make_server_remote(d, m_patch):
+    gc = os.path.join(d.dir, "client", d.proj, d.name, d.version)
+    _, _ = get_output_paths(d.dir, d.proj, d.name, d.version, True, False)
+    m_patch.assert_called_once_with(gc)


### PR DESCRIPTION
This PR updates the paths that `mead-export` creates when it exports a model.

 * This adds two parameters `--project` and `--name` that are used to name sub-directories. If these are both set to `None` then the old behavior happens.
 * When `--model_verson` is set to None then it looks in the dir you will export to and will figure out what version it should be.
 * Adds tests for these new features.