### PR TITLE
Feature/export in config

### DIFF
--- a/python/baseline/utils.py
+++ b/python/baseline/utils.py
@@ -385,6 +385,7 @@ def revlut(lut):
 
 @exporter
 def str2bool(v):
+    if isinstance(v, bool): return v
     if v.lower() in ('yes', 'true', 't', 'y', '1'):
         return True
     elif v.lower() in ('no', 'false', 'f', 'n', '0'):

--- a/python/mead/export.py
+++ b/python/mead/export.py
@@ -1,8 +1,6 @@
 import argparse
+from baseline.utils import read_config_file, unzip_model
 import mead
-from baseline.utils import unzip_model
-from baseline.utils import read_config_file
-from baseline.utils import str2bool
 from mead.exporters import create_exporter
 from mead.utils import convert_path, configure_logger, get_export_params
 
@@ -25,16 +23,16 @@ def main():
     parser.add_argument('--datasets', help='json library of dataset labels', default='config/datasets.json', type=convert_path)
     parser.add_argument('--logging', help='json file for logging', default='config/logging.json', type=convert_path)
     parser.add_argument('--task', help='task to run', choices=['classify', 'tagger', 'seq2seq', 'lm'])
-    parser.add_argument('--exporter_type', help='exporter type', default=None)
+    parser.add_argument('--exporter_type', help="exporter type (default 'default')", default=None)
     parser.add_argument('--return_labels', help='if true, the exported model returns actual labels else '
-                                                'the indices for labels vocab', default=None)
+                                                'the indices for labels vocab (default False)', default=None)
     parser.add_argument('--model', help='model name', required=True, type=unzip_model)
     parser.add_argument('--model_version', help='model_version', default=None)
-    parser.add_argument('--output_dir', help='output dir', default=None)
+    parser.add_argument('--output_dir', help="output dir (default './models')", default=None)
     parser.add_argument('--project', help='Name of project, used in path first', default=None)
     parser.add_argument('--name', help='Name of the model, used second in the path', default=None)
     parser.add_argument('--beam', help='beam_width', default=30, type=int)
-    parser.add_argument('--is_remote', help='if True, separate items for remote server and client. If False bundle everything together', default=True, type=str2bool)
+    parser.add_argument('--is_remote', help='if True, separate items for remote server and client. If False bundle everything together (default True)', default=None)
 
     args = parser.parse_args()
     configure_logger(args.logging)
@@ -50,19 +48,20 @@ def main():
 
     task = mead.Task.get_task_specific(task_name, args.settings)
 
-    output_dir, project, name, model_version, exporter_type, return_labels = get_export_params(
+    output_dir, project, name, model_version, exporter_type, return_labels, is_remote = get_export_params(
         config_params.get('export', {}),
         args.output_dir,
         args.project, args.name,
         args.model_version,
         args.exporter_type,
         args.return_labels,
+        args.is_remote,
     )
     task.read_config(config_params, args.datasets, exporter_type=exporter_type)
     feature_exporter_field_map = create_feature_exporter_field_map(config_params['features'])
     exporter = create_exporter(task, exporter_type, return_labels=return_labels,
                                feature_exporter_field_map=feature_exporter_field_map)
-    exporter.run(args.model, output_dir, project, name, model_version, remote=args.is_remote)
+    exporter.run(args.model, output_dir, project, name, model_version, remote=is_remote)
 
 
 if __name__ == "__main__":

--- a/python/mead/export.py
+++ b/python/mead/export.py
@@ -25,9 +25,9 @@ def main():
     parser.add_argument('--datasets', help='json library of dataset labels', default='config/datasets.json', type=convert_path)
     parser.add_argument('--logging', help='json file for logging', default='config/logging.json', type=convert_path)
     parser.add_argument('--task', help='task to run', choices=['classify', 'tagger', 'seq2seq', 'lm'])
-    parser.add_argument('--exporter_type', help='exporter type', default='default')
+    parser.add_argument('--exporter_type', help='exporter type', default=None)
     parser.add_argument('--return_labels', help='if true, the exported model returns actual labels else '
-                                                'the indices for labels vocab', default=False, type=str2bool)
+                                                'the indices for labels vocab', default=None)
     parser.add_argument('--model', help='model name', required=True, type=unzip_model)
     parser.add_argument('--model_version', help='model_version', default=None)
     parser.add_argument('--output_dir', help='output dir', default=None)
@@ -49,13 +49,19 @@ def main():
     config_params['modules'] = config_params.get('modules', []) + args.modules
 
     task = mead.Task.get_task_specific(task_name, args.settings)
-    task.read_config(config_params, args.datasets, exporter_type=args.exporter_type)
-    feature_exporter_field_map = create_feature_exporter_field_map(config_params['features'])
-    exporter = create_exporter(task, args.exporter_type, return_labels=args.return_labels,
-                               feature_exporter_field_map=feature_exporter_field_map)
-    output_dir, project, name, model_version = get_export_params(
-        config_params.get('export', {}), args.output_dir, args.project, args.name, args.model_version
+
+    output_dir, project, name, model_version, exporter_type, return_labels = get_export_params(
+        config_params.get('export', {}),
+        args.output_dir,
+        args.project, args.name,
+        args.model_version,
+        args.exporter_type,
+        args.return_labels,
     )
+    task.read_config(config_params, args.datasets, exporter_type=exporter_type)
+    feature_exporter_field_map = create_feature_exporter_field_map(config_params['features'])
+    exporter = create_exporter(task, exporter_type, return_labels=return_labels,
+                               feature_exporter_field_map=feature_exporter_field_map)
     exporter.run(args.model, output_dir, project, name, model_version, remote=args.is_remote)
 
 

--- a/python/mead/export.py
+++ b/python/mead/export.py
@@ -1,10 +1,10 @@
 import argparse
 import mead
-from mead.utils import convert_path, configure_logger
 from baseline.utils import unzip_model
 from baseline.utils import read_config_file
-from mead.exporters import create_exporter
 from baseline.utils import str2bool
+from mead.exporters import create_exporter
+from mead.utils import convert_path, configure_logger, get_export_params
 
 
 def create_feature_exporter_field_map(feature_section, default_exporter_field='tokens'):
@@ -30,7 +30,7 @@ def main():
                                                 'the indices for labels vocab', default=False, type=str2bool)
     parser.add_argument('--model', help='model name', required=True, type=unzip_model)
     parser.add_argument('--model_version', help='model_version', default=None)
-    parser.add_argument('--output_dir', help='output dir', default='./models')
+    parser.add_argument('--output_dir', help='output dir', default=None)
     parser.add_argument('--project', help='Name of project, used in path first', default=None)
     parser.add_argument('--name', help='Name of the model, used second in the path', default=None)
     parser.add_argument('--beam', help='beam_width', default=30, type=int)
@@ -53,7 +53,10 @@ def main():
     feature_exporter_field_map = create_feature_exporter_field_map(config_params['features'])
     exporter = create_exporter(task, args.exporter_type, return_labels=args.return_labels,
                                feature_exporter_field_map=feature_exporter_field_map)
-    exporter.run(args.model, args.output_dir, args.project, args.name, args.model_version, remote=args.is_remote)
+    output_dir, project, name, model_version = get_export_params(
+        config_params.get('export', {}), args.output_dir, args.project, args.name, args.model_version
+    )
+    exporter.run(args.model, output_dir, project, name, model_version, remote=args.is_remote)
 
 
 if __name__ == "__main__":

--- a/python/mead/export.py
+++ b/python/mead/export.py
@@ -1,9 +1,11 @@
+import logging
 import argparse
 from baseline.utils import read_config_file, unzip_model
 import mead
 from mead.exporters import create_exporter
 from mead.utils import convert_path, configure_logger, get_export_params
 
+logger = logging.getLogger('mead')
 
 def create_feature_exporter_field_map(feature_section, default_exporter_field='tokens'):
     feature_exporter_field_map = {}

--- a/python/mead/export.py
+++ b/python/mead/export.py
@@ -39,6 +39,12 @@ def main():
 
     config_params = read_config_file(args.config)
 
+    try:
+        args.settings = read_config_stream(args.settings)
+    except:
+        logger.warning('Warning: no mead-settings file was found at [{}]'.format(args.settings))
+        args.settings = {}
+
     task_name = config_params.get('task', 'classify') if args.task is None else args.task
 
     if task_name == 'seq2seq' and 'beam' not in config_params:

--- a/python/mead/tf/exporters.py
+++ b/python/mead/tf/exporters.py
@@ -66,6 +66,7 @@ class TensorFlowExporter(mead.exporters.Exporter):
                     # export process broke.
                     # TODO(MB): we should remove the directory, if one has been saved already.
                     raise e
+        return client_output, server_output
 
     def _create_saved_model_builder(self, sess, output_path, sig_input, sig_output, sig_name):
         """

--- a/python/mead/utils.py
+++ b/python/mead/utils.py
@@ -296,6 +296,7 @@ def get_export_params(
         model_version=None,
         exporter_type=None,
         return_labels=None,
+        is_remote=None,
 ):
     """Combine export parameters from the config file and cli arguments.
 
@@ -306,9 +307,10 @@ def get_export_params(
     :param model_version: `str` The version of this model.
     :param exporter_type: `str` The name of the exporter to use (defaults to 'default')
     :param return_labels: `str` Should labels be returned? (defaults to False)
+    :param is_remote: `str` Should the bundle be split into client and server dirs.
 
-    :returns: `Tuple[str, str, str, str, str, bool]`
-        The output_dir, project, name, model_version, exporter_type, and return_labels
+    :returns: `Tuple[str, str, str, str, str, bool, bool]`
+        The output_dir, project, name, model_version, exporter_type, return_labels, and remote
     """
     project = project if project is not None else config.get('project')
     name = name if name is not None else config.get('name')
@@ -316,6 +318,8 @@ def get_export_params(
     output_dir = os.path.expanduser(output_dir)
     model_version = model_version if model_version is not None else config.get('model_version')
     exporter_type = exporter_type if exporter_type is not None else config.get('exporter_type', 'default')
-    return_labels = return_labels if return_labels is not None else config.get('return_labels', 'false')
+    return_labels = return_labels if return_labels is not None else config.get('return_labels', False)
     return_labels = str2bool(return_labels)
-    return output_dir, project, name, model_version, exporter_type, return_labels
+    is_remote = is_remote if is_remote is not None else config.get('is_remote', True)
+    is_remote = str2bool(is_remote)
+    return output_dir, project, name, model_version, exporter_type, return_labels, is_remote

--- a/python/mead/utils.py
+++ b/python/mead/utils.py
@@ -317,7 +317,7 @@ def get_export_params(
     output_dir = output_dir if output_dir is not None else config.get('output_dir', './models')
     output_dir = os.path.expanduser(output_dir)
     model_version = model_version if model_version is not None else config.get('model_version')
-    exporter_type = exporter_type if exporter_type is not None else config.get('exporter_type', 'default')
+    exporter_type = exporter_type if exporter_type is not None else config.get('type', config.get('exporter_type', 'default'))
     return_labels = return_labels if return_labels is not None else config.get('return_labels', False)
     return_labels = str2bool(return_labels)
     is_remote = is_remote if is_remote is not None else config.get('is_remote', True)

--- a/python/mead/utils.py
+++ b/python/mead/utils.py
@@ -286,3 +286,28 @@ def get_output_paths(
     if make_server:
         os.makedirs(server_path)
     return client_path, server_path
+
+
+@exporter
+def get_export_params(
+        config,
+        output_dir=None,
+        project=None, name=None,
+        model_version=None
+):
+    """Combine export parameters from the config file and cli arguments.
+
+    :param config: `dict` The export block of the config.
+    :param output_dir: `str` The base of export paths.
+    :param project: `str` The name of the project this model is for.
+    :param name: `str` The name of this model (often the use case for it, `ner`, `intent` etc).
+    :param model_version: `str` The version of this model.
+
+    :returns: `Tuple[str, str, str, str]` The output_dir, project, name, and model_version
+    """
+    project = project if project is not None else config.get('project')
+    name = name if name is not None else config.get('name')
+    output_dir = output_dir if output_dir is not None else config.get('output_dir', './models')
+    output_dir = os.path.expanduser(output_dir)
+    model_version = model_version if model_version is not None else config.get('model_version')
+    return output_dir, project, name, model_version

--- a/python/mead/utils.py
+++ b/python/mead/utils.py
@@ -293,21 +293,29 @@ def get_export_params(
         config,
         output_dir=None,
         project=None, name=None,
-        model_version=None
+        model_version=None,
+        exporter_type=None,
+        return_labels=None,
 ):
     """Combine export parameters from the config file and cli arguments.
 
     :param config: `dict` The export block of the config.
-    :param output_dir: `str` The base of export paths.
+    :param output_dir: `str` The base of export paths. (defaults to './models')
     :param project: `str` The name of the project this model is for.
     :param name: `str` The name of this model (often the use case for it, `ner`, `intent` etc).
     :param model_version: `str` The version of this model.
+    :param exporter_type: `str` The name of the exporter to use (defaults to 'default')
+    :param return_labels: `str` Should labels be returned? (defaults to False)
 
-    :returns: `Tuple[str, str, str, str]` The output_dir, project, name, and model_version
+    :returns: `Tuple[str, str, str, str, str, bool]`
+        The output_dir, project, name, model_version, exporter_type, and return_labels
     """
     project = project if project is not None else config.get('project')
     name = name if name is not None else config.get('name')
     output_dir = output_dir if output_dir is not None else config.get('output_dir', './models')
     output_dir = os.path.expanduser(output_dir)
     model_version = model_version if model_version is not None else config.get('model_version')
-    return output_dir, project, name, model_version
+    exporter_type = exporter_type if exporter_type is not None else config.get('exporter_type', 'default')
+    return_labels = return_labels if return_labels is not None else config.get('return_labels', 'false')
+    return_labels = str2bool(return_labels)
+    return output_dir, project, name, model_version, exporter_type, return_labels

--- a/python/tests/test_mead_utils.py
+++ b/python/tests/test_mead_utils.py
@@ -111,6 +111,10 @@ names = namedtuple("d", "dir base proj name version")
 
 @pytest.fixture
 def d():
+    return make_data()
+
+
+def make_data():
     data = []
     data.append(os.path.join(*[rand_str() for _ in range(random.randint(1, 4))]))
     data.append(os.path.basename(data[-1]))
@@ -316,8 +320,8 @@ def choice(in_, config, key):
 
 def test_get_export_params():
     def test():
-        in_ = d()
-        c = d()
+        in_ = make_data()
+        c = make_data()
         config = {
             'output_dir': c.dir,
             'project': c.proj,

--- a/python/tests/test_mead_utils.py
+++ b/python/tests/test_mead_utils.py
@@ -238,6 +238,7 @@ def test_get_export_input_override():
     model_version = str(random.randint(1, 5))
     exporter_type = rand_str()
     return_labels = random.choice([True, False])
+    is_remote = random.choice([True, False])
     config = {
         'project': rand_str(),
         'name': rand_str(),
@@ -245,24 +246,27 @@ def test_get_export_input_override():
         'model_version': str(random.randint(1, 5)),
         'exporter_type': rand_str(),
         'return_labels': not return_labels,
+        'is_remote': not is_remote,
     }
-    o, p, n, v, e, l = get_export_params(config, output_dir, project, name, model_version, exporter_type, return_labels)
+    o, p, n, v, e, l, r = get_export_params(config, output_dir, project, name, model_version, exporter_type, return_labels, is_remote)
     assert o == output_dir
     assert p == project
     assert n == name
     assert v == model_version
     assert e == exporter_type
     assert l == return_labels
+    assert r == is_remote
 
 
 def test_get_export_defaults():
-    o, p, n, v, e, l = get_export_params({})
+    o, p, n, v, e, l, r = get_export_params({})
     assert o == './models'
     assert p is None
     assert n is None
     assert v is None
     assert e == 'default'
     assert l is False
+    assert r is True
 
 
 def test_get_export_config():
@@ -272,28 +276,31 @@ def test_get_export_config():
         'output_dir': os.path.join(rand_str(), rand_str()),
         'model_version': str(random.randint(1, 5)),
         'exporter_type': rand_str(),
-        'return_labels': random.choice(['true', 'false'])
+        'return_labels': random.choice(['true', 'false']),
+        'is_remote': random.choice(['true', 'false']),
     }
-    o, p, n, v, e, l = get_export_params(config)
+    o, p, n, v, e, l, r = get_export_params(config)
     assert o == config['output_dir']
     assert p == config['project']
     assert n == config['name']
     assert v == config['model_version']
     assert e == config['exporter_type']
     assert l == str2bool(config['return_labels'])
+    assert r == str2bool(config['is_remote'])
 
 
 def test_get_export_output_expanded():
     output_dir = "~/example"
     gold_output_dir = os.path.expanduser(output_dir)
-    o, _, _, _, _, _ = get_export_params({}, output_dir)
+    o, _, _, _, _, _, _ = get_export_params({}, output_dir)
 
 
 def test_get_export_str2bool_called():
     return_labels = random.choice(['true', 'false'])
+    is_remote = random.choice(['true', 'false'])
     with patch('mead.utils.str2bool') as b_patch:
-        _ = get_export_params({}, return_labels=return_labels)
-        b_patch.assert_called_once_with(return_labels)
+        _ = get_export_params({}, return_labels=return_labels, is_remote=is_remote)
+        assert b_patch.call_args_list == [call(return_labels), call(is_remote)]
 
 
 def choice(in_, config, key):
@@ -317,7 +324,8 @@ def test_get_export_params():
             'name': c.name,
             'model_version': c.version,
             'exporter_type': rand_str(),
-            'return_labels': random.choice(['true', 'false'])
+            'return_labels': random.choice(['true', 'false']),
+            'is_remote': random.choice(['true', 'false']),
         }
         in_output, gold_output = choice(in_.dir, config, 'output_dir')
         gold_output = './models' if gold_output is None else gold_output
@@ -328,13 +336,16 @@ def test_get_export_params():
         gold_export = gold_export if gold_export is not None else 'default'
         in_labels, gold_labels = choice(random.choice(['true', 'false']), config, 'return_labels')
         gold_labels = str2bool(gold_labels) if gold_labels is not None else False
-        o, p, n, v, e, l = get_export_params(
+        in_remote, gold_remote = choice(random.choice(['true', 'false']), config, 'is_remote')
+        gold_remote = str2bool(gold_remote) if gold_remote is not None else True
+        o, p, n, v, e, l, r = get_export_params(
             config,
             in_output,
             in_project, in_name,
             in_version,
             in_export,
-            in_labels
+            in_labels,
+            in_remote,
         )
         assert o == gold_output
         assert p == gold_project
@@ -342,6 +353,7 @@ def test_get_export_params():
         assert v == gold_version
         assert e == gold_export
         assert l == gold_labels
+        assert r == gold_remote
 
     for _ in range(100):
         test()

--- a/python/tests/test_mead_utils.py
+++ b/python/tests/test_mead_utils.py
@@ -303,6 +303,7 @@ def test_get_export_output_expanded():
     output_dir = "~/example"
     gold_output_dir = os.path.expanduser(output_dir)
     o, _, _, _, _, _, _ = get_export_params({}, output_dir)
+    assert o == gold_output_dir
 
 
 def test_get_export_str2bool_called():

--- a/python/tests/test_mead_utils.py
+++ b/python/tests/test_mead_utils.py
@@ -293,6 +293,12 @@ def test_get_export_config():
     assert r == str2bool(config['is_remote'])
 
 
+def test_get_export_type_in_config():
+    config = {'type': rand_str()}
+    _, _, _, _, e, _, _ = get_export_params(config)
+    assert e == config['type']
+
+
 def test_get_export_output_expanded():
     output_dir = "~/example"
     gold_output_dir = os.path.expanduser(output_dir)


### PR DESCRIPTION
This PR adds the ability to have an `export` block in mead that lets you set parameters used in the model export process.

The order that things are taken. cli -> config -> default.

These are the arguments that are handled and their defaults:

 * `output_dir` -> `'./models'`
 * `project` -> `None`
 * `name` -> `None`
 * `model_version` -> `None`
 * `exporter_type` -> `'default'`
 * `return_labels` -> `False`
 * `is_remote` -> `True`

This pr also had to shuffle the order things are called inside `mead.export` to make sure that the property registries are loaded but once the pytorch pr is merged this order won't matter as much.:wq