### PR TITLE
Feature/easier names

### DIFF
--- a/python/baseline/model.py
+++ b/python/baseline/model.py
@@ -47,7 +47,7 @@ def register_model(cls, task, name=None):
 
 @exporter
 def create_model_for(activity, input_, output_, **kwargs):
-    model_type = kwargs.get('model_type', 'default')
+    model_type = kwargs.get('type', kwargs.get('model_type', 'default'))
     creator_fn = BASELINE_MODELS[activity][model_type]
     logger.info('Calling model %s', creator_fn)
     if output_ is not None:
@@ -136,7 +136,7 @@ def load_model_for(activity, filename, **kwargs):
     # TODO: Currently in pytorch all models are always reloaded with the load
     # classmethod with a default model class. This is fine given how simple pyt
     # loading is but it could cause problems if a model has a custom load
-    model_type = kwargs.get('model_type', state.get('model_type', 'default'))
+    model_type = kwargs.get('type', kwargs.get('model_type', state.get('type', state.get('model_type', 'default'))))
     creator_fn = BASELINE_LOADERS[activity][model_type]
     logger.info('Calling model %s', creator_fn)
     return creator_fn(filename, **kwargs)

--- a/python/baseline/reader.py
+++ b/python/baseline/reader.py
@@ -41,7 +41,7 @@ def register_reader(cls, task, name=None):
 
 @exporter
 def create_reader(task, vectorizers, trim, **kwargs):
-    name = kwargs.get('reader_type', 'default')
+    name = kwargs.get('type', kwargs.get('reader_type', 'default'))
     Constructor = BASELINE_READERS[task][name]
     return Constructor(vectorizers, trim, **kwargs)
 

--- a/python/mead/config/conll.json
+++ b/python/mead/config/conll.json
@@ -1,6 +1,5 @@
 {
   "task": "tagger",
-  "batchsz": 10,
   "conll_output": "conllresults.conll",
   "unif": 0.1,
   "features": [
@@ -57,7 +56,8 @@
     "crf": 1
   },
   "train": {
-    "epochs": 1,
+    "batchsz": 10,
+    "epochs": 100,
     "optim": "sgd",
     "eta": 0.015,
     "mom": 0.9,

--- a/python/mead/config/conll.json
+++ b/python/mead/config/conll.json
@@ -34,19 +34,17 @@
       "embeddings": { "dsz": 30, "wsz": 30, "type": "char-conv" }
     }
   ],
-  "preproc": {
-  },
   "backend": "pytorch",
   "dataset": "conll-iobes",
-  "loader": {
-    "reader_type": "default",
+  "reader": {
+    "type": "default",
     "named_fields": {
       "0": "text",
       "-1": "y"
     }
   },
   "model": {
-    "model_type": "default",
+    "type": "default",
     "cfiltsz": [
       3
     ],
@@ -59,7 +57,7 @@
     "crf": 1
   },
   "train": {
-    "epochs": 100,
+    "epochs": 1,
     "optim": "sgd",
     "eta": 0.015,
     "mom": 0.9,

--- a/python/mead/config/iwslt15-en-vi.json
+++ b/python/mead/config/iwslt15-en-vi.json
@@ -5,7 +5,7 @@
     "basedir": "iwslt15-en-vi-s2s",
     "unif": 0.25,
     "features": [
-	{ 
+	{
 	    "name": "src",
 	    "vectorizer": { "type": "token1d"},
 	    "embeddings": { "dsz": 512 }
@@ -21,13 +21,13 @@
     },
     "backend": "tensorflow",
     "dataset": "iwslt15-en-vi",
-    "loader": {
-        "reader_type": "default",
-	"pair_suffix": ["en", "vi"]
+    "reader": {
+        "type": "default",
+        "pair_suffix": ["en", "vi"]
     },
 
     "model": {
-        "model_type": "attn",
+        "type": "attn",
         "rnntype": "blstm",
         "hsz": 512,
         "dropout": 0.5,
@@ -37,7 +37,7 @@
         "epochs": 32,
         "optim": "adam",
         "eta": 0.001,
-	"do_early_stopping": true,
+        "do_early_stopping": true,
         "clip": 1.0
     }
 }

--- a/python/mead/config/iwslt15-en-vi.json
+++ b/python/mead/config/iwslt15-en-vi.json
@@ -1,7 +1,6 @@
 {
     "task": "seq2seq",
     "num_valid_to_show": 0,
-    "batchsz": 100,
     "basedir": "iwslt15-en-vi-s2s",
     "unif": 0.25,
     "features": [
@@ -34,6 +33,7 @@
         "layers": 2
     },
     "train": {
+        "batchsz": 100,
         "epochs": 32,
         "optim": "adam",
         "eta": 0.001,

--- a/python/mead/config/sst2.json
+++ b/python/mead/config/sst2.json
@@ -21,12 +21,12 @@
   },
   "backend": "tensorflow",
   "dataset": "SST2",
-  "loader": {
-    "reader_type": "default"
+  "reader": {
+    "type": "default"
   },
   "unif": 0.25,
   "model": {
-    "model_type": "default",
+    "type": "default",
     "filtsz": [
       3,
       4,

--- a/python/mead/tasks.py
+++ b/python/mead/tasks.py
@@ -165,7 +165,7 @@ class Task(object):
 
     def _create_task_specific_reader(self):
         self._create_vectorizers()
-        reader_params = self.config_params.get('reader', self.config_params.get('loader', {}))
+        reader_params = self.config_params['reader'] if 'reader' in self.config_params else self.config_params['loader']
         reader_params['clean_fn'] = reader_params.get('clean_fn', self.config_params.get('preproc', {}).get('clean_fn'))
         if reader_params['clean_fn'] is not None and self.config_params['dataset'] != 'SST2':
             logger.warning('Warning: A reader preprocessing function (%s) is active, it is recommended that all data preprocessing is done outside of baseline to insure data at inference time matches data at training time.', reader_params['clean_fn'])
@@ -176,7 +176,8 @@ class Task(object):
 
     @staticmethod
     def _get_min_f(config):
-        backoff = config.get('reader', config.get('loader', {})).get('min_f', config.get('preproc', {}).get('min_f', -1))
+        read = config['reader'] if 'reader' in config else config['loader']
+        backoff = read.get('min_f', config.get('preproc', {}).get('min_f', -1))
         return {f['name']: f.get('min_f', backoff) for f in config['features']}
 
     def _setup_task(self, **kwargs):
@@ -405,13 +406,15 @@ class ClassifierTask(Task):
         return baseline.model.create_model(self.embeddings, self.labels, **model)
 
     def _load_dataset(self):
+        read = self.config_params['reader'] if 'reader' in self.config_params else self.config_params['loader']
+        sort_key = read.get('sort_key')
         bsz, vbsz, tbsz = Task._get_batchsz(self.config_params)
         self.train_data = self.reader.load(
             self.dataset['train_file'],
             self.feat2index,
             bsz,
             shuffle=True,
-            sort_key=self.config_params.get('reader', self.config_params.get('loader', {})).get('sort_key')
+            sort_key=sort_key,
         )
         self.valid_data = self.reader.load(
             self.dataset['valid_file'],
@@ -687,7 +690,7 @@ class LanguageModelingTask(Task):
     def _create_task_specific_reader(self):
         self._create_vectorizers()
 
-        reader_params = self.config_params.get('reader', self.config_params.get('loader', {}))
+        reader_params = self.config_params['reader'] if reader in self.config_params else self.config_params['loader']
         reader_params['nctx'] = reader_params.get('nctx', self.config_params.get('nctx', self.config_params.get('nbptt', 35)))
         reader_params['clean_fn'] = reader_params.get('clean_fn', self.config_params.get('preproc', {}).get('clean_fn'))
         if reader_params['clean_fn'] is not None and self.config_params['dataset'] != 'SST2':
@@ -734,7 +737,8 @@ class LanguageModelingTask(Task):
         baseline.save_vocabs(self.get_basedir(), self.feat2index)
 
     def _load_dataset(self):
-        tgt_key = self.config_params.get('reader', self.config_params.get('loader', {})).get('tgt_key', self.primary_key)
+        read = self.config_params['reader'] if 'reader' in self.config_params else self.config_params['loader']
+        tgt_key = read.get('tgt_key', self.primary_key)
         bsz, vbsz, tbsz = Task._get_batchsz(self.config_params)
         self.train_data = self.reader.load(
             self.dataset['train_file'],

--- a/python/mead/tasks.py
+++ b/python/mead/tasks.py
@@ -165,7 +165,7 @@ class Task(object):
 
     def _create_task_specific_reader(self):
         self._create_vectorizers()
-        reader_params = self.config_params['loader']
+        reader_params = self.config_params.get('reader', self.config_params.get('loader', {}))
         reader_params['clean_fn'] = reader_params.get('clean_fn', self.config_params.get('preproc', {}).get('clean_fn'))
         if reader_params['clean_fn'] is not None and self.config_params['dataset'] != 'SST2':
             logger.warning('Warning: A reader preprocessing function (%s) is active, it is recommended that all data preprocessing is done outside of baseline to insure data at inference time matches data at training time.', reader_params['clean_fn'])
@@ -176,7 +176,7 @@ class Task(object):
 
     @staticmethod
     def _get_min_f(config):
-        backoff = config['loader'].get('min_f', config.get('preproc', {}).get('min_f', -1))
+        backoff = config.get('reader', config.get('loader', {})).get('min_f', config.get('preproc', {}).get('min_f', -1))
         return {f['name']: f.get('min_f', backoff) for f in config['features']}
 
     def _setup_task(self, **kwargs):
@@ -401,7 +401,7 @@ class ClassifierTask(Task):
             self.feat2index,
             self.config_params['batchsz'],
             shuffle=True,
-            sort_key=self.config_params['loader'].get('sort_key')
+            sort_key=self.config_params.get('reader', self.config_params.get('loader', {})).get('sort_key')
         )
         self.valid_data = self.reader.load(
             self.dataset['valid_file'],
@@ -675,7 +675,7 @@ class LanguageModelingTask(Task):
     def _create_task_specific_reader(self):
         self._create_vectorizers()
 
-        reader_params = self.config_params['loader']
+        reader_params = self.config_params.get('reader', self.config_params.get('loader', {}))
         reader_params['nctx'] = reader_params.get('nctx', self.config_params.get('nctx', self.config_params.get('nbptt', 35)))
         reader_params['clean_fn'] = reader_params.get('clean_fn', self.config_params.get('preproc', {}).get('clean_fn'))
         if reader_params['clean_fn'] is not None and self.config_params['dataset'] != 'SST2':
@@ -722,7 +722,7 @@ class LanguageModelingTask(Task):
         baseline.save_vocabs(self.get_basedir(), self.feat2index)
 
     def _load_dataset(self):
-        tgt_key = self.config_params['loader'].get('tgt_key', self.primary_key)
+        tgt_key = self.config_params.get('reader', self.config_params.get('loader', {})).get('tgt_key', self.primary_key)
         self.train_data = self.reader.load(
             self.dataset['train_file'],
             self.feat2index,
@@ -748,7 +748,7 @@ class LanguageModelingTask(Task):
         unif = self.config_params.get('unif', 0.1)
         model['unif'] = model.get('unif', unif)
         model['batchsz'] = self.config_params['batchsz']
-        model['tgt_key'] = self.config_params['loader'].get('tgt_key', self.primary_key)
+        model['tgt_key'] = self.config_params.get('reader', self.config_params.get('loader', {})).get('tgt_key', self.primary_key)
         if self.backend.params is not None:
             for k, v in self.backend.params.items():
                 model[k] = v


### PR DESCRIPTION
This PR uses some backoff to create easier names for some parts of the mead config.

 * the loader section can be `loader` or `reader`
 * things like `model_type`, `reader_type` can just be type because they are inside of a block
 * `batchsz`, `valid_batchsz`, and `test_batchsz` can be used inside of the `train` block