### PR TITLE
better error message on unsupported backend

### DIFF
--- a/python/baseline/utils.py
+++ b/python/baseline/utils.py
@@ -55,6 +55,7 @@ exporter = export(__all__)
 
 @exporter
 def normalize_backend(name):
+    allowed_backends = {'tf', 'pytorch', 'dy', 'keras'}
     name = name.lower()
     if name == 'tensorflow':
         name = 'tf'
@@ -62,6 +63,8 @@ def normalize_backend(name):
         name = 'pytorch'
     elif name == 'dynet':
         name = 'dy'
+    if name not in allowed_backends:
+        raise ValueError("Supported backends are %s, got %s" % (allowed_backends, name))
     return name
 
 


### PR DESCRIPTION
If you make a mistake in a config and specify a wrong backend or make a typo you get a slightly esoteric error like `ModuleNotFoundError: No module named 'baseline.pytrch'`.

This PR throws an exception when this happens that explicitly tells you the backend was bad.