### PR TITLE
make sure beam is passed to the model

### DIFF
--- a/api-examples/ed-text.py
+++ b/api-examples/ed-text.py
@@ -35,7 +35,7 @@ else:
     batch = [args.text.split()]
     batches.append(batch)
 
-m = bl.EncoderDecoderService.load(args.model, backend=args.backend,
+m = bl.EncoderDecoderService.load(args.model, backend=args.backend, beam=args.beam,
                                   remote=args.remote, name=args.name, device=args.device)
 
 f = open(args.target, 'w') if args.target is not None else None

--- a/python/baseline/remote.py
+++ b/python/baseline/remote.py
@@ -42,7 +42,7 @@ class RemoteModelTensorFlowREST(object):
         """
         return self.labels
 
-    def predict(self, examples):
+    def predict(self, examples, **kwargs):
         """Run prediction over HTTP/REST.
 
         :param examples: The input examples
@@ -173,7 +173,7 @@ class RemoteModelTensorFlowGRPC(object):
         """
         return self.labels
 
-    def predict(self, examples):
+    def predict(self, examples, **kwargs):
         """Run prediction over gRPC
 
         :param examples: The input examples


### PR DESCRIPTION
The beam size wasn't being passed to the seq2seq service so when the GRPC client was used the default beam size was being used to reshape the results which caused them to be wrong while the http response is already the correct shape so the result was correct.

There are a few problems with the seq2seq services that probably should be reexamined. For example the GRPC de-serialization code can only handle a batch size of 1 it looks like. There is also a divergence between `tf` and `pytorch` models where things like `beam` need to be given to `tf` when the model is loaded where as `pytorch` can have different beam sizes on each `.predict` 