### PR TITLE
easier unzipping

### DIFF
--- a/python/baseline/utils.py
+++ b/python/baseline/utils.py
@@ -966,13 +966,13 @@ def find_files_with_prefix(directory, prefix):
 def zip_files(basedir):
     pid = str(os.getpid())
     tgt_zip_base = os.path.abspath(basedir)
+    zip_name = os.path.basename(tgt_zip_base)
     model_files = [x for x in os.listdir(basedir) if x.find(pid) >= 0 and os.path.isfile(os.path.join(basedir, x))]
-    z = zipfile.ZipFile("{}-{}.zip".format(tgt_zip_base, pid), "w")
-    for f in model_files:
-        f = os.path.join(basedir, f)
-        z.write(f)
-        os.remove(f)
-    z.close()
+    with zipfile.ZipFile("{}-{}.zip".format(tgt_zip_base, pid), "w") as z:
+        for f in model_files:
+            abs_f = os.path.join(basedir, f)
+            z.write(abs_f, os.path.join(zip_name, f))
+            os.remove(abs_f)
 
 
 @exporter

--- a/python/mead/tasks.py
+++ b/python/mead/tasks.py
@@ -137,7 +137,7 @@ class Task(object):
         basedir = self.get_basedir()
         if basedir is not None and not os.path.exists(basedir):
             logger.info('Creating: {}'.format(basedir))
-            os.mkdir(basedir)
+            os.makedirs(basedir)
         self.config_params['train']['basedir'] = basedir
         # Read GPUS from env variables now so that the reader has access
         if self.config_params['model'].get('gpus', 1) == -1:


### PR DESCRIPTION
This PR does 2 things

 * When the `basedir` in the mead file is multiple subdirs it makes them all instead of failing when one of them doesn't exist
 * When it zips a multidir path it only zips the files and the basename into the `.zip` So when you have `"./tests/sst2"` you get a file `./tests/sst2-{pid}.zip` and when you zip it you get `./tests/sst2/files...` instead of `./tests/tests/sst2/files...`