### PR TITLE
added support for dated keys of form x:y:datestamp

### DIFF
--- a/python/mead/tasks.py
+++ b/python/mead/tasks.py
@@ -17,6 +17,7 @@ from mead.utils import (
     get_mead_settings,
     print_dataset_info,
     read_config_file_or_json,
+    get_dataset_from_key
 )
 
 
@@ -146,7 +147,7 @@ class Task(object):
         self._setup_task(**kwargs)
         self._load_user_modules()
         self._configure_reporting(config_params.get('reporting', {}), **kwargs)
-        self.dataset = datasets_set[self.config_params['dataset']]
+        self.dataset = get_dataset_from_key(self.config_params['dataset'], datasets_set)
         self.reader = self._create_task_specific_reader()
 
     def _load_user_modules(self):

--- a/python/mead/utils.py
+++ b/python/mead/utils.py
@@ -8,6 +8,7 @@ from copy import deepcopy
 from itertools import chain
 from collections import OrderedDict
 from baseline.utils import export, str2bool, read_config_file, get_logging_level
+from dateutil.parser import parse as parse_date
 
 __all__ = []
 exporter = export(__all__)
@@ -55,6 +56,29 @@ def read_config_file_or_json(config, name=''):
     if os.path.exists(config):
         return read_config_file(config)
     raise Exception('Expected {} config file or a JSON object.'.format(name))
+
+
+@exporter
+def get_dataset_from_key(dataset_key, datasets_set):
+
+    # This is the previous behavior
+    if dataset_key in datasets_set:
+        return datasets_set[dataset_key]
+
+    last_date = parse_date('1900')
+    last_k = None
+    for k, v in datasets_set.items():
+
+        if dataset_key in k:
+            dt = parse_date(k.split(':')[-1])
+            if dt > last_date:
+                last_date = dt
+                last_k = k
+
+    if last_k is None:
+        raise Exception("No dataset could be found with key {}".format(dataset_key))
+
+    return datasets_set[last_k]
 
 
 @exporter

--- a/python/mead/utils.py
+++ b/python/mead/utils.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 from itertools import chain
 from collections import OrderedDict
 from baseline.utils import export, str2bool, read_config_file, get_logging_level
-from dateutil.parser import parse as parse_date
+from datetime import datetime
 
 __all__ = []
 exporter = export(__all__)
@@ -57,6 +57,16 @@ def read_config_file_or_json(config, name=''):
         return read_config_file(config)
     raise Exception('Expected {} config file or a JSON object.'.format(name))
 
+
+def parse_date(s):
+    KNOWN_FMTS = ['%Y%m%d', '%Y-%m-%d', '%Y/%m/%d', '%Y', '%Y%m', '%Y-%m', '%Y/%m']
+    for fmt in KNOWN_FMTS:
+        try:
+            dt = datetime.strptime(s, fmt)
+            return dt
+        except:
+            continue
+    raise Exception("Couldn't parse datestamp {}".format(s))
 
 @exporter
 def get_dataset_from_key(dataset_key, datasets_set):

--- a/python/tests/test_mead_utils.py
+++ b/python/tests/test_mead_utils.py
@@ -11,6 +11,7 @@ from mead.utils import (
     get_output_paths,
     get_export_params,
     find_model_version,
+    get_dataset_from_key
 )
 
 
@@ -20,7 +21,8 @@ CHARS = list(chain(string.ascii_letters, string.digits))
 @pytest.fixture
 def file_name():
     file_ = "test_file"
-    with open(file_, "w"): pass
+    with open(file_, "w"):
+        pass
     yield file_
     os.remove(file_)
 
@@ -368,3 +370,23 @@ def test_get_export_params():
 
     for _ in range(100):
         test()
+
+
+def test_dataset_formats():
+    keys = {'1': 1,
+            '1:1978': 7,
+            '2:1996': 2,
+            '2:20190327': 3,
+            '2:2019-03-28': 42
+    }
+
+    # Test exact match first
+    assert get_dataset_from_key('1', keys) == 1
+    # Test where not exact that we get last date
+    assert get_dataset_from_key('2', keys) == 42
+    # Test where we do not get last date that we get an exception
+    try:
+        j = get_dataset_from_key('3', keys)
+        assert j is None
+    except:
+        pass


### PR DESCRIPTION
A user should be able to specify a generic key inside the mead config that applies to the latest version of a dataset.

Assume that dates are used to specify the latest version of a dataset, and that keys are of the form:
```
<x>
<y>:<datestamp1>
<y>:<datestamp2>
```
where `<datestamp*>` is a parseable date expression and `2` is assumed to be more recent than `1` in this case.

- If a user requests `<x>` they should get back `<x>`, the exact match
- If a user requests `<y>:<datestamp1>` they should also get back the exact match
- If a user requests `<y>` they should get back `<y>:<datestamp2>``
