### PR TITLE
use included tensor dim to decode suggest text

### DIFF
--- a/python/baseline/remote.py
+++ b/python/baseline/remote.py
@@ -238,10 +238,11 @@ class RemoteModelTensorFlowGRPC(object):
 
         if self.signature == 'suggest_text':
             # s2s returns int values.
-            classes = predict_response.outputs.get('classes').int_val
-            results = [classes[x:x+self.beam] for x in range(0, len(classes), self.beam)]
-            results = list(zip(*results)) #transpose
-            return [results]
+            classes = predict_response.outputs.get('classes')
+            shape = [dim.size for dim in classes.tensor_shape.dim]
+            results = np.reshape(np.array(classes.int_val), shape)
+            results = results.transpose(1, 2, 0)
+            return results
 
         if self.signature == 'tag_text':
             if self.return_labels:


### PR DESCRIPTION
The current way that the gRPC response from suggest text models relies on the beam size passed in and can only handle a batch size of one. This PR updates the remote models to use the included tensor shape to format the response allowing us to handle batched requests.