### PR TITLE
change call that required pd>=0.21.0

### DIFF
--- a/python/baseline/utils.py
+++ b/python/baseline/utils.py
@@ -504,11 +504,14 @@ def read_config_stream(config_stream):
     if isinstance(config_stream, (dict, list)) or config_stream is None:
         return config_stream
     if os.path.exists(config_stream) and os.path.isfile(config_stream):
+        logger.info("Reading config file '{}'".format(config_stream))
         return read_config_file(config_stream)
     config = config_stream
     if config_stream.startswith("$"):
-        logger.info('Reading config from {}'.format(config_stream))
+        logger.info("Reading config from '{}'".format(config_stream))
         config = os.getenv(config_stream[1:])
+    else:
+        logger.info("No file found '{}...', loading as string".format(config_stream[:12]))
     return json.loads(config)
 
 

--- a/python/xpctl/helpers.py
+++ b/python/xpctl/helpers.py
@@ -40,7 +40,8 @@ def df_get_results(result_frame, dataset, num_exps, num_exps_per_config, metric,
             rframe = rframe.sort_values(by='date', ascending=False).head(int(num_exps_per_config))
             df = df.append(rframe)
         result_frame = df
-    result_frame = result_frame.drop(columns=["id"])
+
+    result_frame = result_frame.drop(["id"], axis=1)
     result_frame = result_frame.groupby("sha1").agg([len, np.mean, np.std, np.min, np.max])\
         .rename(columns={'len': 'num_exps', 'amean': 'mean', 'amin': 'min', 'amax': 'max'})
     metrics = listify(metric)


### PR DESCRIPTION
Previously, `xpctl` called the `drop(columns=X`)
method.  This required the pandas version to be
0.21 or greater.  Since this is a one-liner and
can be fixed easily, lets be lenient on the pd
requirement and just change that line.

Also make the config logging more explicit.
if someone fat-fingers the CL, they may currently
not realize that the file they requested wasnt on
the FS.  The logging here identifies the path that
is taken in an attempt to help the user realize
that they probably didnt intent to provie a config
string.