### PR TITLE
xpctl get by id or label

### DIFF
--- a/python/xpctl/cli.py
+++ b/python/xpctl/cli.py
@@ -146,10 +146,11 @@ def getmodelloc(task, id):
 @click.option('--sort', help="specify one metric to sort the results")
 @click.option('--output', help='output file')
 @click.option('--nconfig', help='number of experiments to aggregate', type=int)
+@click.option('--id', help='filter by specific experiment')
 @click.option('--n', help='number of rows to show', type=int)
 @click.argument('task')
 @click.argument('dataset')
-def results(metric, event_type, sort, output, nconfig, n, task, dataset):
+def results(metric, event_type, sort, output, nconfig, n, task, dataset, id):
     """
     Provides a statistical summary of the results for a problem . A problem is defined by a (task, dataset) tuple. For each config used in the task, shows the average, min, max and std dev and number of experiments done using config. Optionally: a. --metrics: choose metric(s) to show. results ll be sorted on the first metric. b. --sort output all metrics but sort on one. c. --n: limit number of experiments. d. event_type: show results for train/dev/valid datasets. e. output: put the results in an output file.
     """
@@ -159,7 +160,7 @@ def results(metric, event_type, sort, output, nconfig, n, task, dataset):
     event_type = EVENT_TYPES[event_type]
     num_exps = n
     num_exps_per_config = nconfig
-    results = RepoManager.get().get_results(task, dataset, event_type, num_exps, num_exps_per_config, metric, sort)
+    results = RepoManager.get().get_results(task, dataset, event_type, num_exps, num_exps_per_config, metric, sort, id)
     if results is None:
         click.echo("can't produce summary for the requested task {}".format(task))
         return

--- a/python/xpctl/cli.py
+++ b/python/xpctl/cli.py
@@ -147,10 +147,11 @@ def getmodelloc(task, id):
 @click.option('--output', help='output file')
 @click.option('--nconfig', help='number of experiments to aggregate', type=int)
 @click.option('--id', help='filter by specific experiment')
+@click.option('--label', help='filter by label')
 @click.option('--n', help='number of rows to show', type=int)
 @click.argument('task')
 @click.argument('dataset')
-def results(metric, event_type, sort, output, nconfig, n, task, dataset, id):
+def results(metric, event_type, sort, output, nconfig, n, task, dataset, id, label):
     """
     Provides a statistical summary of the results for a problem . A problem is defined by a (task, dataset) tuple. For each config used in the task, shows the average, min, max and std dev and number of experiments done using config. Optionally: a. --metrics: choose metric(s) to show. results ll be sorted on the first metric. b. --sort output all metrics but sort on one. c. --n: limit number of experiments. d. event_type: show results for train/dev/valid datasets. e. output: put the results in an output file.
     """
@@ -160,7 +161,9 @@ def results(metric, event_type, sort, output, nconfig, n, task, dataset, id):
     event_type = EVENT_TYPES[event_type]
     num_exps = n
     num_exps_per_config = nconfig
-    results = RepoManager.get().get_results(task, dataset, event_type, num_exps, num_exps_per_config, metric, sort, id)
+    results = RepoManager.get().get_results(task, dataset, event_type,
+                                            num_exps, num_exps_per_config,
+                                            metric, sort, id, label)
     if results is None:
         click.echo("can't produce summary for the requested task {}".format(task))
         return

--- a/python/xpctl/core.py
+++ b/python/xpctl/core.py
@@ -99,7 +99,7 @@ class ExperimentRepo(object):
         """
         pass
 
-    def get_results(self, task, dataset, event_type, num_exps, num_exps_per_config, metric, sort):
+    def get_results(self, task, dataset, event_type, num_exps, num_exps_per_config, metric, sort, id):
         """Get results from the database
 
         :param task: (``str``) The taskname

--- a/python/xpctl/mongo/backend.py
+++ b/python/xpctl/mongo/backend.py
@@ -173,6 +173,8 @@ class MongoRepo(ExperimentRepo):
             if "id" in kwargs and kwargs["id"]:
                 query.update({"_id": ObjectId(kwargs["id"])})
                 return query
+            if "label" in kwargs:
+                query.update({"label": kwargs["label"]})
             if "username" in kwargs and kwargs["username"]:
                 query.update({"username": {"$in": list(kwargs["username"])}})
             if "dataset" in kwargs:
@@ -195,10 +197,11 @@ class MongoRepo(ExperimentRepo):
         result_frame = self._generate_data_frame(coll, metrics=metrics, query=query, projection=projection, event_type=event_type)
         return df_experimental_details(result_frame, sha1, users, sort, metric, n)
 
-    def get_results(self, task, dataset, event_type,  num_exps=None, num_exps_per_config=None, metric=None, sort=None, id=None):
+    def get_results(self, task, dataset, event_type,  num_exps=None,
+                    num_exps_per_config=None, metric=None, sort=None, id=None, label=None):
         metrics = listify(metric)
         coll = self.db[task]
-        query = self._update_query({}, dataset=dataset, id=id)
+        query = self._update_query({}, dataset=dataset, id=id, label=label)
         projection = self._update_projection(event_type=event_type)
         result_frame = self._generate_data_frame(coll, metrics=metrics, query=query, projection=projection, event_type=event_type)
         if not result_frame.empty:

--- a/python/xpctl/mongo/backend.py
+++ b/python/xpctl/mongo/backend.py
@@ -173,7 +173,7 @@ class MongoRepo(ExperimentRepo):
             if "id" in kwargs and kwargs["id"]:
                 query.update({"_id": ObjectId(kwargs["id"])})
                 return query
-            if "label" in kwargs:
+            if "label" in kwargs and kwargs["label"]:
                 query.update({"label": kwargs["label"]})
             if "username" in kwargs and kwargs["username"]:
                 query.update({"username": {"$in": list(kwargs["username"])}})

--- a/python/xpctl/mongo/backend.py
+++ b/python/xpctl/mongo/backend.py
@@ -170,6 +170,9 @@ class MongoRepo(ExperimentRepo):
         if not kwargs:
             return query
         else:
+            if "id" in kwargs and kwargs["id"]:
+                query.update({"_id": ObjectId(kwargs["id"])})
+                return query
             if "username" in kwargs and kwargs["username"]:
                 query.update({"username": {"$in": list(kwargs["username"])}})
             if "dataset" in kwargs:
@@ -192,10 +195,10 @@ class MongoRepo(ExperimentRepo):
         result_frame = self._generate_data_frame(coll, metrics=metrics, query=query, projection=projection, event_type=event_type)
         return df_experimental_details(result_frame, sha1, users, sort, metric, n)
 
-    def get_results(self, task, dataset, event_type,  num_exps=None, num_exps_per_config=None, metric=None, sort=None):
+    def get_results(self, task, dataset, event_type,  num_exps=None, num_exps_per_config=None, metric=None, sort=None, id=None):
         metrics = listify(metric)
         coll = self.db[task]
-        query = self._update_query({}, dataset=dataset)
+        query = self._update_query({}, dataset=dataset, id=id)
         projection = self._update_projection(event_type=event_type)
         result_frame = self._generate_data_frame(coll, metrics=metrics, query=query, projection=projection, event_type=event_type)
         if not result_frame.empty:

--- a/python/xpctl/sql/backend.py
+++ b/python/xpctl/sql/backend.py
@@ -215,14 +215,21 @@ class SQLRepo(ExperimentRepo):
         else:
             return [x for x in allmetrics if x.label in metrics]
 
-    def get_results(self, task, dataset, event_type, num_exps=None, num_exps_per_config=None, metric=None, sort=None, id=None):
+    def get_results(self, task, dataset, event_type, num_exps=None, num_exps_per_config=None, metric=None, sort=None, id=None, label=None):
         session = self.Session()
         results = []
         metrics = listify(metric)
         metrics_to_add = [metrics[0]] if len(metrics) == 1 else []
         phase = self.event2phase(event_type)
         if id is not None:
-            hits = session.query(Experiment).get(id)
+            hit = session.query(Experiment).get(id)
+            if hit is None:
+                return None
+            hits = [hit]
+        elif label is not None:
+            hits = session.query(Experiment).filter(Experiment.label == label). \
+                filter(Experiment.dataset == dataset). \
+                filter(Experiment.task == task)
         else:
             hits = session.query(Experiment).filter(Experiment.dataset == dataset). \
                 filter(Experiment.task == task)

--- a/python/xpctl/sql/backend.py
+++ b/python/xpctl/sql/backend.py
@@ -215,14 +215,17 @@ class SQLRepo(ExperimentRepo):
         else:
             return [x for x in allmetrics if x.label in metrics]
 
-    def get_results(self, task, dataset, event_type, num_exps=None, num_exps_per_config=None, metric=None, sort=None):
+    def get_results(self, task, dataset, event_type, num_exps=None, num_exps_per_config=None, metric=None, sort=None, id=None):
         session = self.Session()
         results = []
         metrics = listify(metric)
         metrics_to_add = [metrics[0]] if len(metrics) == 1 else []
         phase = self.event2phase(event_type)
-        hits = session.query(Experiment).filter(Experiment.dataset == dataset). \
-            filter(Experiment.task == task)
+        if id is not None:
+            hits = session.query(Experiment).get(id)
+        else:
+            hits = session.query(Experiment).filter(Experiment.dataset == dataset). \
+                filter(Experiment.task == task)
         for exp in hits:
             for event in exp.events:
                 if event.phase == phase:

--- a/python/xpctl/version.py
+++ b/python/xpctl/version.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.1dev"
+__version__ = "0.5.2"


### PR DESCRIPTION
Add support for getting results from `xpctl` by `id` or `label`.  This adds CLI options for `--id` which has a backend-specific database key, and `--label` which is a string

*By ID*
```
(tf) dpressel@dpressel-CORSAIR-ONE:~/dev/work/baseline$ xpctl --config ~/local-cred.json results classify SST2 --id 2
db postgres connection successful with [host]: 127.0.0.1, [port]: 5432
db postgres connection successful with [host]: 127.0.0.1, [port]: 5432
                                              acc                                   precision                                     recall                                         f1                                   avg_loss                                  
                                         num_exps      mean std       min       max  num_exps      mean std       min       max num_exps      mean std       min       max num_exps      mean std       min       max num_exps      mean std       min       max
sha1                                                                                                                                                                                                                                                            
2efc2fda646ec15003cbe39395e0ae1ea1634c36      1.0  0.872048 NaN  0.872048  0.872048       1.0  0.871429 NaN  0.871429  0.871429      1.0  0.872387 NaN  0.872387  0.872387      1.0  0.871908 NaN  0.871908  0.871908      1.0  0.317796 NaN  0.317796  0.317796
```
*By Label*

```
xpctl > results classify SST2 --metric=acc --label=get-by-id-test
db postgres connection successful with [host]: 127.0.0.1, [port]: 5432
db postgres connection successful with [host]: 127.0.0.1, [port]: 5432
                                              acc                                  
                                         num_exps      mean std       min       max
sha1                                                                               
2efc2fda646ec15003cbe39395e0ae1ea1634c36      1.0  0.872048 NaN  0.872048  0.872048
xpctl > quit

```
*Inside of XPCTL Shell*

```
(tf) dpressel@dpressel-CORSAIR-ONE:~/dev/work/baseline/python$ xpctl --config ~/local-cred.json results classify SST2 --label get-by-id-test
db postgres connection successful with [host]: 127.0.0.1, [port]: 5432
db postgres connection successful with [host]: 127.0.0.1, [port]: 5432
                                              acc                                   precision                                     recall                                         f1                                   avg_loss                                  
                                         num_exps      mean std       min       max  num_exps      mean std       min       max num_exps      mean std       min       max num_exps      mean std       min       max num_exps      mean std       min       max
sha1                                                                                                                                                                                                                                                            
2efc2fda646ec15003cbe39395e0ae1ea1634c36      1.0  0.872048 NaN  0.872048  0.872048       1.0  0.871429 NaN  0.871429  0.871429      1.0  0.872387 NaN  0.872387  0.872387      1.0  0.871908 NaN  0.871908  0.871908      1.0  0.317796 NaN  0.317796  0.317796

```