### PR TITLE
Fix bugs that stopped us from exporting a model in a directory.

### DIFF
--- a/python/baseline/utils.py
+++ b/python/baseline/utils.py
@@ -875,6 +875,8 @@ def unzip_model(path):
     # Import inside function to avoid circular dep :(
     # TODO: future solution move the export code a different file so mime_type can import from it
     # rather then from here, this allows here to import mime_type
+    if os.path.isdir(path):
+        return path
     from baseline.mime_type import mime_type
     if mime_type(path) == 'application/zip':
         with open(path, 'rb') as f:
@@ -944,6 +946,8 @@ def load_vectorizers(directory):
 
 @exporter
 def unzip_files(zip_path):
+    if os.path.isdir(zip_path):
+        return zip_path
     from baseline.mime_type import mime_type
     if mime_type(zip_path) == 'application/zip':
         with open(zip_path, 'rb') as f:

--- a/python/mead/tf/exporters.py
+++ b/python/mead/tf/exporters.py
@@ -265,8 +265,8 @@ def create_bundle(builder, output_path, basename, assets=None):
     """
     builder.save()
 
-    model_name = basename.split("/")[-1]
-    directory = os.path.join('/', *basename.split("/")[:-1])
+    model_name = os.path.basename(basename)
+    directory = os.path.realpath(os.path.dirname(basename))
     save_to_bundle(output_path, directory, assets)
 
 


### PR DESCRIPTION
There were a few assumptions that were baked into some code that stopped mead-export from working with directories.

 * Checking for the zip magic number rather than just checking the filename caused failures for a dir, this is fixed by checking for it ahead of time.
 * The conversion from (for example) `sst2/classify-model-tf-1435` to the directory and model name was by hand when when the dir was relative it turned it into an absolute by prepending `/` (`sst2` became `/sst2`) instead of using os.path. This means the dir probably didn't exist and caused errors. This is fixed.