### PR TITLE
Bugfix/handle conll runoff

### DIFF
--- a/api-examples/tag-text.py
+++ b/api-examples/tag-text.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import baseline as bl
 import argparse
 import os
@@ -71,4 +73,4 @@ m = bl.TaggerService.load(args.model, backend=args.backend, remote=args.remote,
 for sen in m.predict(texts, export_mapping=create_export_mapping(args.export_mapping)):
     for word_tag in sen:
         print("{} {}".format(word_tag['text'], word_tag['label']))
-    print("\n")
+    print()

--- a/api-examples/tag-text.py
+++ b/api-examples/tag-text.py
@@ -56,12 +56,13 @@ if os.path.exists(args.text) and os.path.isfile(args.text):
                 else:
                     texts.append(sentence)
                     sentence = []
+            if sentence:
+                texts.append(sentence)
     else:
         with open(args.text, 'r') as f:
             for line in f:
                 text = line.strip().split()
                 texts += [text]
-
 else:
     texts = [args.text.split()]
 


### PR DESCRIPTION
Currently if the last sentence in a conll file doesn't have a blank line after it the `tag-text.py` program will not include it in the batch. While this means the file isn't technically valid it is an easy fix. This PR makes it so this sentence will be included.

Also the program was creating 2 blank lines between sentences which didn't break any of our conll reading code but the PR changes it to output the correct 1 blank line.