### PR TITLE
Updated Conll Tools

### DIFF
--- a/api-examples/bio_to_iobes.py
+++ b/api-examples/bio_to_iobes.py
@@ -1,19 +1,18 @@
-from baseline.utils import convert_bio_to_iobes
 import os
 import argparse
+from baseline.utils import convert_bio_conll_to_iobes
 
 
-parser = argparse.ArgumentParser(description='Translate input sequence to output sequence')
+parser = argparse.ArgumentParser(description='Convert a CONLL file with BIO tagging to IOBES.')
 parser.add_argument('--io_dir', help='Input/Output dir', default='../data')
-parser.add_argument('--train_file', help='Training file relative name', default='eng.train')
-parser.add_argument('--valid_file', help='Validation file relative name', default='eng.testa')
-parser.add_argument('--test_file', help='Test file relative name', default='eng.testb')
+parser.add_argument('--train_file', help='Training file relative name', default='eng.train.bio')
+parser.add_argument('--valid_file', help='Validation file relative name', default='eng.testa.bio')
+parser.add_argument('--test_file', help='Test file relative name', default='eng.testb.bio')
 parser.add_argument('--suffix', help='Suffix to append', default='.iobes')
-
+parser.add_argument("--fields", help="The fields to convert", default=[-1], type=int, nargs="+")
 args = parser.parse_args()
 
 
-convert_bio_to_iobes(os.path.join(args.io_dir, args.train_file), os.path.join(args.io_dir, args.train_file + args.suffix))
-convert_bio_to_iobes(os.path.join(args.io_dir, args.valid_file), os.path.join(args.io_dir, args.valid_file + args.suffix))
-convert_bio_to_iobes(os.path.join(args.io_dir, args.test_file), os.path.join(args.io_dir, args.test_file + args.suffix))
-
+convert_bio_conll_to_iobes(os.path.join(args.io_dir, args.train_file), os.path.join(args.io_dir, args.train_file + args.suffix), fields=args.fields)
+convert_bio_conll_to_iobes(os.path.join(args.io_dir, args.valid_file), os.path.join(args.io_dir, args.valid_file + args.suffix), fields=args.fields)
+convert_bio_conll_to_iobes(os.path.join(args.io_dir, args.test_file), os.path.join(args.io_dir, args.test_file + args.suffix), fields=args.fields)

--- a/api-examples/iob_to_bio.py
+++ b/api-examples/iob_to_bio.py
@@ -1,19 +1,18 @@
-from baseline.utils import convert_iob_to_bio
 import os
 import argparse
+from baseline.utils import convert_iob_conll_to_bio
 
 
-parser = argparse.ArgumentParser(description='Translate input sequence to output sequence')
+parser = argparse.ArgumentParser(description='Convert a CONLL file tagged with IOB to BIO.')
 parser.add_argument('--io_dir', help='Input/Output dir', default='../data')
 parser.add_argument('--train_file', help='Training file relative name', default='eng.train')
 parser.add_argument('--valid_file', help='Validation file relative name', default='eng.testa')
 parser.add_argument('--test_file', help='Test file relative name', default='eng.testb')
+parser.add_argument('--fields', help="The fields to convert.", default=[-1], type=int, nargs="+")
 parser.add_argument('--suffix', help='Suffix to append', default='.bio')
-
 args = parser.parse_args()
 
 
-convert_iob_to_bio(os.path.join(args.io_dir, args.train_file), os.path.join(args.io_dir, args.train_file + args.suffix))
-convert_iob_to_bio(os.path.join(args.io_dir, args.valid_file), os.path.join(args.io_dir, args.valid_file + args.suffix))
-convert_iob_to_bio(os.path.join(args.io_dir, args.test_file), os.path.join(args.io_dir, args.test_file + args.suffix))
-
+convert_iob_conll_to_bio(os.path.join(args.io_dir, args.train_file), os.path.join(args.io_dir, args.train_file + args.suffix), fields=args.fields)
+convert_iob_conll_to_bio(os.path.join(args.io_dir, args.valid_file), os.path.join(args.io_dir, args.valid_file + args.suffix), fields=args.fields)
+convert_iob_conll_to_bio(os.path.join(args.io_dir, args.test_file), os.path.join(args.io_dir, args.test_file + args.suffix), fields=args.fields)

--- a/api-examples/iob_to_iobes.py
+++ b/api-examples/iob_to_iobes.py
@@ -1,0 +1,18 @@
+import os
+import argparse
+from baseline.utils import convert_iob_conll_to_iobes
+
+
+parser = argparse.ArgumentParser(description='Convert a CONLL file tagged with IOB to IOBES.')
+parser.add_argument('--io_dir', help='Input/Output dir', default='../data')
+parser.add_argument('--train_file', help='Training file relative name', default='eng.train')
+parser.add_argument('--valid_file', help='Validation file relative name', default='eng.testa')
+parser.add_argument('--test_file', help='Test file relative name', default='eng.testb')
+parser.add_argument('--suffix', help='Suffix to append', default='.iobes')
+parser.add_argument("--fields", help="The fields to convert", default=[-1], type=int, nargs="+")
+args = parser.parse_args()
+
+
+convert_iob_conll_to_iobes(os.path.join(args.io_dir, args.train_file), os.path.join(args.io_dir, args.train_file + args.suffix), fields=args.fields)
+convert_iob_conll_to_iobes(os.path.join(args.io_dir, args.valid_file), os.path.join(args.io_dir, args.valid_file + args.suffix), fields=args.fields)
+convert_iob_conll_to_iobes(os.path.join(args.io_dir, args.test_file), os.path.join(args.io_dir, args.test_file + args.suffix), fields=args.fields)

--- a/api-examples/iobes_result_to_bio.py
+++ b/api-examples/iobes_result_to_bio.py
@@ -1,0 +1,12 @@
+import argparse
+from baseline.reader import _norm_ext
+from baseline.utils import convert_iobes_conll_to_bio
+
+parser = argparse.ArgumentParser(description="Convert a CONLL file from IOBES to BIO. This defaults to changing the right two most columns and is used to convert the output of IOBES taggers so that conlleval.pl will work on them.")
+parser.add_argument("--file", help="The file to convert", default="conllresults.conll")
+parser.add_argument("--fields", help="The fields to convert", default=[-2, -1], type=int, nargs="+")
+parser.add_argument("--delim", "-d", help="The delimiter between items", default=" ")
+parser.add_argument("--suffix", help="Suffix to append", default=".bio", type=_norm_ext)
+args = parser.parse_args()
+
+convert_iobes_conll_to_bio(args.file, args.file + args.suffix, args.fields, args.delim)

--- a/api-examples/tag-text.py
+++ b/api-examples/tag-text.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 import baseline as bl
 import argparse
 import os
-from baseline.utils import str2bool
+from baseline.utils import str2bool, read_conll
 
 
 parser = argparse.ArgumentParser(description='Tag text with a model')
@@ -45,21 +45,11 @@ if os.path.exists(args.text) and os.path.isfile(args.text):
     texts = []
     if args.conll:
         feature_indices = feature_index_mapping(args.features)
-        sentence = []
-        with open(args.text, 'r') as f:
-            for line in f:
-                if line.strip():
-                    text = line.strip().split()
-                    if feature_indices:
-                        text = {feature: text[feature_indices[feature]] for feature in feature_indices}
-                    else:
-                        text = text[0]
-                    sentence.append(text)
-                else:
-                    texts.append(sentence)
-                    sentence = []
-            if sentence:
-                texts.append(sentence)
+        for sentence in read_conll(args.text):
+            if feature_indices:
+                texts.append([{k: line[v] for k, v in feature_indices.items()} for line in sentence])
+            else:
+                texts.append([line[0] for line in sentence])
     else:
         with open(args.text, 'r') as f:
             for line in f:

--- a/python/tests/test_conll.py
+++ b/python/tests/test_conll.py
@@ -1,0 +1,139 @@
+import os
+import random
+from io import StringIO
+from baseline.utils import (
+    _sniff_conll_file,
+    read_conll_docs,
+    read_conll_docs_md,
+    read_conll_sentences,
+    read_conll_sentences_md,
+)
+
+
+file_loc = os.path.realpath(os.path.dirname(__file__))
+TEST_FILE = os.path.join(file_loc, 'test_data', 'test.conll')
+
+gold_sentences = [
+    [
+        ['a', '1', '2'],
+        ['b', '3', '4'],
+        ['c', '5', '6'],
+    ],
+    [
+        ['d', '7', '8'],
+        ['e', '9', '10'],
+    ],
+    [
+        ['g', '11', '12'],
+        ['h', '13', '14'],
+        ['i', '15', '16'],
+        ['j', '17', '18'],
+    ],
+    [
+        ['k', '19', '20'],
+    ],
+    [
+        ['l', '21', '22'],
+        ['m', '23', '24'],
+        ['n', '25', '26'],
+    ],
+    [
+        ['o', '27', '28'],
+        ['p', '29', '30']
+    ]
+]
+
+gold_documents = [
+    [gold_sentences[0], gold_sentences[1]],
+    [gold_sentences[2], gold_sentences[3]],
+    [gold_sentences[4], gold_sentences[5]]
+]
+
+comments = [
+    '# begin doc',
+    '# This is a comment',
+    '# This is the second sentence',
+    '# This is an extra comment',
+    '# end doc',
+    '# begin doc',
+    '# 2 2',
+    '# begin doc',
+]
+
+sentence_comments = [
+    [comments[0], comments[1]],
+    [comments[2], comments[3]],
+    [comments[4], comments[5]],
+    [comments[6]],
+    [comments[7]],
+    []
+]
+
+doc_comments = [
+    [comments[0]],
+    [comments[4], comments[5]],
+    [comments[7]],
+]
+
+doc_sent_comments = [
+    [
+        [comments[1]],
+        [comments[2], comments[3]],
+    ],
+    [
+        [],
+        [comments[6]],
+    ],
+    [
+        [],
+        [],
+    ]
+]
+
+def test_read_conll_sentences():
+    for p, g in zip(read_conll_sentences(TEST_FILE), gold_sentences):
+        assert p == g
+
+
+def test_read_conll_sentences_md():
+    for (p, pm), g, m in zip(read_conll_sentences_md(TEST_FILE), gold_sentences, sentence_comments):
+        assert p == g
+        assert pm == m
+
+
+def test_read_conll_docs():
+    for d, g in zip(read_conll_docs(TEST_FILE), gold_documents):
+        assert d == g
+
+
+def test_sniff_conll():
+    files = StringIO()
+    for _ in range(random.randint(0, 4)):
+        files.write("#{}\n".format(random.random()))
+    gold = random.randint(2, 12)
+    files.write(" ".join(["a"] * gold) + "\n")
+    files.seek(0)
+    res = _sniff_conll_file(files)
+    assert res == gold
+
+
+def test_sniff_reset():
+    files = StringIO()
+    files.write("We shouldn't see this\n")
+    start = files.tell()
+    gold = "#This is the gold!"
+    files.write(gold + "\n")
+    for _ in range(random.randint(0, 3)):
+        files.write('#\n')
+    files.write("a a\n")
+    files.seek(start)
+    _ = _sniff_conll_file(files)
+    res = files.readline().rstrip()
+    assert res == gold
+
+
+def test_read_conll_docs_md():
+    for (d, dm, dsm), g, gd, gsm in zip(read_conll_docs_md(TEST_FILE), gold_documents, doc_comments, doc_sent_comments):
+        assert d == g
+        assert dm == gd
+        assert dsm == gsm

--- a/python/tests/test_data/test.conll
+++ b/python/tests/test_data/test.conll
@@ -1,0 +1,28 @@
+# begin doc
+# This is a comment
+a 1 2
+b 3 4
+c 5 6
+
+# This is the second sentence
+# This is an extra comment
+d 7 8
+e 9 10
+
+# end doc
+# begin doc
+g 11 12
+h 13 14
+i 15 16
+j 17 18
+
+# 2 2
+k 19 20
+
+# begin doc
+l 21 22
+m 23 24
+n 25 26
+
+o 27 28
+p 29 30


### PR DESCRIPTION
This PR pulls the new conll reading stuff out of the span-tools pr so that the merges will be easier (this PR doesn't touch any model evaluation code). Now the conll reading functions are generators that yield a sentence at a time. This makes it easier to use elsewhere and to create data processing tools.

It also adds the ability to convert arbitrary columns instead of just the right most one, the ability to process more complex conll files (document level and handling comments), and some tests

It also adds a new decorator that allows a function to take either a string or an open file like object without a bunch of messy code in each function.