### PR TITLE
Unify Seq2Seq Output Shapes

### DIFF
--- a/python/baseline/tf/seq2seq/decoders.py
+++ b/python/baseline/tf/seq2seq/decoders.py
@@ -56,6 +56,7 @@ class TransformerDecoder(DecoderBase):
                 activation_type='relu',
                 d_ff=None,
                 **kwargs):
+        """self.best is [T, B]"""
         mxlen = kwargs.get('mxlen', 100)
         src_enc = encoder_outputs.output
         B = get_shape_as_list(src_enc)[0]
@@ -111,7 +112,7 @@ class TransformerDecoder(DecoderBase):
 
         ])
         self.preds = tf.no_op()
-        best = decoded_ids
+        best = tf.transpose(decoded_ids)
         self.output(best, do_probs=False)
 
     def decode(self, encoder_outputs,
@@ -124,6 +125,7 @@ class TransformerDecoder(DecoderBase):
                scale=True,
                activation_type='relu',
                d_ff=None, **kwargs):
+        """self.best is [T, B]"""
         src_enc = encoder_outputs.output
         if hasattr(encoder_outputs, 'src_mask'):
             src_mask = encoder_outputs.src_mask
@@ -234,6 +236,7 @@ got {} hsz and {} dsz".format(self.hsz, self.tgt_embedding.get_dsz()))
         return Wo
 
     def predict(self, encoder_outputs, src_len, pdrop, **kwargs):
+        """self.best is [T, B, K]"""
 
         beam_width = kwargs.get('beam', 1)
         mxlen = kwargs.get('mxlen', 100)
@@ -270,6 +273,7 @@ got {} hsz and {} dsz".format(self.hsz, self.tgt_embedding.get_dsz()))
             self.output(best)
 
     def decode(self, encoder_outputs, src_len, tgt_len, pdrop, **kwargs):
+        """self.best is [T, B]"""
         self.tgt_embedding.x = kwargs.get('tgt', self.tgt_embedding.create_placeholder('tgt'))
         mxlen = kwargs.get('mxlen', 100)
 

--- a/python/baseline/tf/seq2seq/model.py
+++ b/python/baseline/tf/seq2seq/model.py
@@ -346,10 +346,12 @@ class EncoderDecoderModelBase(EncoderDecoderModel):
     def predict(self, batch_dict, **kwargs):
         feed_dict = self.make_input(batch_dict)
         vec = self.sess.run(self.decoder.best, feed_dict=feed_dict)
-        # (B x K x T)
-        if len(vec.shape) == 3:
-            return vec.transpose(1, 2, 0)
-        return np.expand_dims(vec, axis=1)
+        # Vec is either [T, B] or [T, B, K]
+        if len(vec.shape) == 2:
+            # Add a fake K
+            vec = np.expand_dims(vec, axis=2)
+        # convert to (B x K x T)
+        return vec.transpose(1, 2, 0)
 
     def step(self, batch_dict):
         """

--- a/python/baseline/utils.py
+++ b/python/baseline/utils.py
@@ -1386,6 +1386,7 @@ def _try_user_cmp(user_cmp):
 
 @exporter
 def show_examples(model, es, rlut1, rlut2, vocab, mxlen, sample, prob_clip, max_examples, reverse):
+    """Expects model.predict to return [B, K, T]."""
     si = np.random.randint(0, len(es))
 
     batch_dict = es[si]

--- a/python/mead/config/reverse-transformer.json
+++ b/python/mead/config/reverse-transformer.json
@@ -1,0 +1,45 @@
+{
+    "task": "seq2seq",
+    "num_valid_to_show": 1,
+    "batchsz": 128,
+    "basedir": "s2s_reverse",
+    "test_batchsz": 16,
+    "unif": 0.25,
+    "features": [
+	{
+	    "name": "src",
+	    "vectorizer": { "type": "token1d"},
+	    "embeddings": { "dsz": 128, "type": "positional" }
+	},
+	{
+	    "name": "tgt",
+	    "vectorizer": { "type": "token1d"},
+	    "embeddings": { "dsz": 128, "type": "positional" }
+	}
+    ],
+    "preproc": {
+        "mxlen": 10
+    },
+    "backend": "tensorflow",
+    "dataset": "reverse",
+    "loader": {
+        "reader_type": "default",
+    	"pair_suffix": ["fwd", "bwd"]
+    },
+    "model": {
+        "encoder_type": "transformer",
+        "decoder_type": "transformer",
+        "hsz": 256,
+        "dropout": 0.1,
+        "layers": 4
+    },
+    "train": {
+        "epochs": 64,
+        "optim": "adam",
+        "eta": 0.001,
+        "patience": 40,
+        "nsteps": 200,
+    	"do_early_stopping": true,
+        "clip": 1.0
+    }
+}

--- a/python/mead/tasks.py
+++ b/python/mead/tasks.py
@@ -3,7 +3,6 @@ import json
 import logging
 import numpy as np
 import baseline
-from baseline.tf.tfy import show_examples_tf
 from baseline.utils import (
     export,
     revlut,
@@ -557,8 +556,6 @@ class EncoderDecoderTask(Task):
         self.config_params['preproc']['show_ex'] = show_examples
         if backend.name == 'pytorch':
             self.config_params['preproc']['trim'] = True
-        elif backend.name == 'tf':
-            self.config_params['preproc']['show_ex'] = show_examples_tf
         elif backend.name == 'dy':
             import _dynet
             dy_params = _dynet.DynetParams()


### PR DESCRIPTION
The shapes of the various outputs of the tensorflow seq2seq models were not all matching which was causing problems in the `show_examples` function.

The way the `model.predict` was working was that a tensor that has 3 dims (from beam search) was transposed to `[B, K, T]` which is what we expect elsewhere in the code. Other tensors (from greedy search) had a fake K inserted at `axis=1`. This is fine for the transformer predict function which returned `[B, T]` but for things like the rnn greedy decode it yielded tensors of shape `[T, K, B]`. This caused the `show_examples` to only output a single token.

The table below shows the old shapes for self.best that each decoder type created and the shape that was output from `model.predict`

| Model               | `self.best` | `model.predict` |
|---------------------|----------:|--------------:|
| RNN predict         | [T, B, K] |     [B, K, T] |
| RNN decode          |    [T, B] |     [T, K, B] |
| Transformer predict |    [B, T] |     [B, K, T] |
| Transformer decode  |    [T, B] |     [T, K, B] |

This PR standardized all outputs to be either `[T, B]` or `[T, B, K]` and updates the `model.predict` to add a fake `K` to greedy outputs at `axis=2` so the transpose to `[B, K, T]` works for all input.

The table below has the new shapes for `self.best` and outputs from `model.predict`

| Model               | `self.best` | `model.predict` |
|---------------------|----------:|--------------:|
| RNN predict         | [T, B, K] |     [B, K, T] |
| RNN decode          |    [T, B] |     [B, K, T] |
| Transformer predict |    [T, B] |     [B, K, T] |
| Transformer decode  |    [T, B] |     [B, K, T] |

There is also a config for a transformer model that gets ~98-100 bleu on the reverse dataset which helped test these output changes.