### PR TITLE
use do_probs to allow a beam of size 1

### DIFF
--- a/python/baseline/tf/seq2seq/decoders.py
+++ b/python/baseline/tf/seq2seq/decoders.py
@@ -270,7 +270,7 @@ got {} hsz and {} dsz".format(self.hsz, self.tgt_embedding.get_dsz()))
             self.final_decoder_state = final_decoder_state
             self.preds = tf.no_op()
             best = final_outputs.predicted_ids
-            self.output(best)
+            self.output(best, do_probs=False)
 
     def decode(self, encoder_outputs, src_len, tgt_len, pdrop, **kwargs):
         """self.best is [T, B]"""


### PR DESCRIPTION
This allows an RNN to be loaded with a beam of size 1 and have it not fail.