### PR TITLE
small fixes: exporter test script + bert loading + classify-text batching

### DIFF
--- a/api-examples/classify-text.py
+++ b/api-examples/classify-text.py
@@ -11,7 +11,7 @@ parser.add_argument('--remote', help='(optional) remote endpoint', type=str) # l
 parser.add_argument('--name', help='(optional) service name', type=str)
 parser.add_argument('--device', help='device')
 parser.add_argument('--preproc', help='(optional) where to perform preprocessing', choices={'client', 'server'}, default='client')
-parser.add_argument('--batch_sz', help='batch data', default=100, type=int)
+parser.add_argument('--batchsz', help='batch data', default=100, type=int)
 args = parser.parse_args()
 
 if os.path.exists(args.text) and os.path.isfile(args.text):
@@ -23,7 +23,7 @@ if os.path.exists(args.text) and os.path.isfile(args.text):
 
 else:
     texts = [args.text.split()]
-batched = [texts[i:i + args.batch_sz] for i in range(0, len(texts), args.batch_sz)]
+batched = [texts[i:i + args.batchsz] for i in range(0, len(texts), args.batchsz)]
 
 m = bl.ClassifierService.load(args.model, backend=args.backend, remote=args.remote,
                               name=args.name, preproc=args.preproc,

--- a/api-examples/classify-text.py
+++ b/api-examples/classify-text.py
@@ -2,7 +2,6 @@ import baseline as bl
 import argparse
 import os
 
-
 parser = argparse.ArgumentParser(description='Classify text with a model')
 parser.add_argument('--model', help='A classifier model', required=True, type=str)
 parser.add_argument('--text', help='raw value', type=str)

--- a/api-examples/classify-text.py
+++ b/api-examples/classify-text.py
@@ -2,6 +2,7 @@ import baseline as bl
 import argparse
 import os
 
+
 parser = argparse.ArgumentParser(description='Classify text with a model')
 parser.add_argument('--model', help='A classifier model', required=True, type=str)
 parser.add_argument('--text', help='raw value', type=str)
@@ -10,6 +11,7 @@ parser.add_argument('--remote', help='(optional) remote endpoint', type=str) # l
 parser.add_argument('--name', help='(optional) service name', type=str)
 parser.add_argument('--device', help='device')
 parser.add_argument('--preproc', help='(optional) where to perform preprocessing', choices={'client', 'server'}, default='client')
+parser.add_argument('--batch_sz', help='batch data', default=100, type=int)
 args = parser.parse_args()
 
 if os.path.exists(args.text) and os.path.isfile(args.text):
@@ -21,9 +23,11 @@ if os.path.exists(args.text) and os.path.isfile(args.text):
 
 else:
     texts = [args.text.split()]
+batched = [texts[i:i + args.batch_sz] for i in range(0, len(texts), args.batch_sz)]
 
 m = bl.ClassifierService.load(args.model, backend=args.backend, remote=args.remote,
                               name=args.name, preproc=args.preproc,
                               device=args.device)
-for text, output in zip(texts, m.predict(texts)):
-    print("{}, {}".format(" ".join(text), output[0][0]))
+for texts in batched:
+    for text, output in zip(texts, m.predict(texts)):
+        print("{}, {}".format(" ".join(text), output[0][0]))

--- a/docker/Dockerfile.tf
+++ b/docker/Dockerfile.tf
@@ -1,4 +1,4 @@
-ARG TF_VERSION=1.7.0
+ARG TF_VERSION=1.12.0
 
 FROM python:3.6
 FROM tensorflow/tensorflow:${TF_VERSION}-gpu-py3

--- a/python/addons/embed_bert.py
+++ b/python/addons/embed_bert.py
@@ -1443,8 +1443,10 @@ class BERTHubModel(TensorFlowEmbeddings):
     def __init__(self, name, **kwargs):
         super(BERTHubModel, self).__init__(name=name)
         self.handle = kwargs.get('embed_file')
-        self.vocab_file = kwargs.get('vocab_file')
-        self.vocab = load_vocab(self.vocab_file)
+        if 'vocab' in kwargs:
+            self.vocab = kwargs['vocab']
+        else:
+            self.vocab = load_vocab(kwargs.get('vocab_file'))
         self.vsz = len(self.vocab)
         self.dsz = kwargs.get('dsz')
         self.trainable = kwargs.get('trainable', False)
@@ -1482,7 +1484,7 @@ class BERTHubModel(TensorFlowEmbeddings):
             'dsz': self.dsz,
             'module': self.__class__.__module__,
             'embed_file': self.handle,
-            'vocab_file': self.vocab_file
+            'vocab': self.vocab
             },
             target)
 

--- a/python/addons/embed_bert.py
+++ b/python/addons/embed_bert.py
@@ -1443,7 +1443,8 @@ class BERTHubModel(TensorFlowEmbeddings):
     def __init__(self, name, **kwargs):
         super(BERTHubModel, self).__init__(name=name)
         self.handle = kwargs.get('embed_file')
-        self.vocab = load_vocab(kwargs.get('vocab_file'))
+        self.vocab_file = kwargs.get('vocab_file')
+        self.vocab = load_vocab(self.vocab_file)
         self.vsz = len(self.vocab)
         self.dsz = kwargs.get('dsz')
         self.trainable = kwargs.get('trainable', False)
@@ -1476,7 +1477,14 @@ class BERTHubModel(TensorFlowEmbeddings):
 
 
     def save_md(self, target):
-        write_json({'vsz': self.vsz, 'dsz': self.dsz}, target)
+        write_json({
+            'vsz': self.vsz,
+            'dsz': self.dsz,
+            'module': self.__class__.__module__,
+            'embed_file': self.handle,
+            'vocab_file': self.vocab_file
+            },
+            target)
 
     def get_dsz(self):
         return self.dsz


### PR DESCRIPTION
-  add a function to check if a file is empty. was missing before.
-  make exporter tests optional when preproc=serve
-  use `[[` instead of `[` : intellij warnings. 
-  fix bert model loading problem. we save out the vocab itself in the embedder json file along with some other info needed to rehydrate the embedding model.
-  batching in `classify-text`