### PR TITLE
fixed bug that cause basedir to not be removed from config hash

### DIFF
--- a/python/mead/utils.py
+++ b/python/mead/utils.py
@@ -200,8 +200,8 @@ KEYS = {
     ('train', 'model_base'),
     ('train', 'model_zip'),
     ('train', 'nsteps'),
-    ('test_batchsz'),
-    ('basedir'),
+    ('test_batchsz',),
+    ('basedir',),
 }
 
 

--- a/python/tests/test_mead_utils.py
+++ b/python/tests/test_mead_utils.py
@@ -7,6 +7,7 @@ from mock import patch, call
 import pytest
 from baseline.utils import str2bool
 from mead.utils import (
+    KEYS,
     convert_path,
     get_output_paths,
     get_export_params,
@@ -371,6 +372,12 @@ def test_get_export_params():
     for _ in range(100):
         test()
 
+
+def test_ensure_keys_are_tuples():
+    for key in KEYS:
+        assert isinstance(key, tuple)
+        for k in key:
+            assert isinstance(k, str)
 
 def test_dataset_formats():
     keys = {'1': 1,


### PR DESCRIPTION
The keys to remove a supposed to be tuples but two of them `basedir` especially is not. This means it wasn't being removed from the config. This meant that two otherwise the same configs could have different hashs.

This updated the keys and adds a test so that in the future updates won't make this mistake