### PR TITLE
feat: modules can be added at the mead-train cli and can be file paths

### DIFF
--- a/python/baseline/utils.py
+++ b/python/baseline/utils.py
@@ -549,6 +549,32 @@ def ls_props(thing):
     return [x for x in dir(thing) if isinstance(getattr(type(thing), x, None), property)]
 
 
+def _idempotent_append(element, data):
+    """Append to a list if that element is not already in the list.
+
+    :param element: The element to add to the list.
+    :param data: `List` the list to add to.
+    :returns: `List` the list with the element in it.
+    """
+    if element not in data:
+        data.append(element)
+    return data
+
+
+def _parse_module_as_path(module_name):
+    """Convert a path to a file to a format that it can be imported.
+
+    :param module_name: The module as a path.
+    :returns: `Tuple[str, str]` the module name (without a file ext) and the
+        absolute path of the dir the file lives in (or '' if the module_name
+        is just a filename).
+    """
+    module_dir, module_name = os.path.split(module_name)
+    module_dir = os.path.realpath(os.path.expanduser(module_dir)) if module_dir else module_dir
+    module_name, _ = os.path.splitext(module_name)
+    return module_name, module_dir
+
+
 @exporter
 def import_user_module(module_name):
     """Load a module that is in the python path
@@ -557,8 +583,10 @@ def import_user_module(module_name):
     :return:
     """
     addon_path = os.path.dirname(os.path.realpath(addons.__file__))
-    if addon_path not in sys.path:
-        sys.path.append(addon_path)
+    _idempotent_append(addon_path, sys.path)
+    if module_name.endswith(".py"):
+        module_name, module_dir = _parse_module_as_path(module_name)
+        _idempotent_append(module_dir, sys.path)
     mod = importlib.import_module(module_name)
     return mod
 

--- a/python/mead/trainer.py
+++ b/python/mead/trainer.py
@@ -72,6 +72,7 @@ def main():
     parser.add_argument('--config', help='JSON Configuration for an experiment', type=convert_path, default="$MEAD_CONFIG")
     parser.add_argument('--settings', help='JSON Configuration for mead', default='config/mead-settings.json', type=convert_path)
     parser.add_argument('--datasets', help='json library of dataset labels', default='config/datasets.json', type=convert_path)
+    parser.add_argument('--modules', help='modules to load', default=[], nargs='+', required=False)
     parser.add_argument('--mod_train_file', help='override the training set')
     parser.add_argument('--mod_valid_file', help='override the validation set')
     parser.add_argument('--mod_test_file', help='override the test set')
@@ -111,6 +112,8 @@ def main():
 
     if args.backend is not None:
         config_params['backend'] = normalize_backend(args.backend)
+
+    config_params['modules'] = list(set(chain(config_params.get('modules', []), args.modules)))
 
     cmd_hooks = args.reporting if args.reporting is not None else []
     config_hooks = config_params.get('reporting') if config_params.get('reporting') is not None else []

--- a/python/tests/test_utils.py
+++ b/python/tests/test_utils.py
@@ -1,7 +1,10 @@
 import os
-from functools import partial
+import string
+import random
+from itertools import chain
 import pytest
-from baseline.utils import get_env_gpus
+from mock import patch
+from baseline.utils import get_env_gpus, _idempotent_append, _parse_module_as_path
 
 
 @pytest.fixture
@@ -46,3 +49,103 @@ def test_none(remove_envs):
     gold = ['0']
     gpus = get_env_gpus()
     assert gpus == gold
+
+
+def test_idempotent_add_missing():
+    element = random.randint(0, 5)
+    data = set(random.randint(0, 10) for _ in range(random.randint(5, 10)))
+    data.discard(element)
+    data = list(data)
+    assert element not in data
+    _idempotent_append(element, data)
+    assert element in data
+    assert data[-1] == element
+
+
+def test_idempotent_add_there():
+    element = random.randint(0, 5)
+    data = set(random.randint(0, 10) for _ in range(random.randint(5, 10)))
+    data.add(element)
+    data = list(data)
+    random.shuffle(data)
+    # Make sure element isn't at the end in this example
+    data.append(None)
+    assert element in data
+    element_idx = data.index(element)
+    data_len = len(data)
+    _idempotent_append(element, data)
+    assert element in data
+    assert data.index(element) == element_idx
+    assert data[-1] != element
+    assert len(data) == data_len
+
+
+def test_idempotent_add_last():
+    # Because the last tests forces not to be last this tests always forces last
+    element = random.randint(0, 5)
+    data = set(random.randint(0, 10) for _ in range(random.randint(5, 10)))
+    data.discard(element)
+    data = list(data)
+    data.append(element)
+    assert element in data
+    element_idx = data.index(element)
+    data_len = len(data)
+    _idempotent_append(element, data)
+    assert element in data
+    assert data.index(element) == element_idx
+    assert data[-1] == element
+    assert len(data) == data_len
+
+
+CHARS = list(chain(string.ascii_letters, string.digits))
+
+
+def rand_str(length=None, min_=3, max_=10):
+    if length is None:
+        length = random.randint(min_, max_)
+    return ''.join([random.choice(CHARS) for _ in range(length)])
+
+
+def test_parse_module_as_path_file():
+    file_base = rand_str()
+    file_ext = rand_str()
+    file_name = "{}.{}".format(file_base, file_ext)
+    n, d = _parse_module_as_path(file_name)
+    assert n == file_base
+    assert d == ''
+
+
+def test_parse_module_as_path_relative():
+    file_base = rand_str()
+    file_ext = rand_str()
+    file_name = "{}.{}".format(file_base, file_ext)
+    path = os.path.join(*[rand_str() for _ in range(random.randint(1, 5))])
+    gold_path = rand_str()
+    assert not os.path.isabs(path)
+    module_name = os.path.join(path, file_name)
+    with patch('baseline.utils.os.path.realpath') as real_patch:
+        with patch('baseline.utils.os.path.expanduser') as user_patch:
+            real_patch.return_value = gold_path
+            user_patch.return_value = path
+            n, d = _parse_module_as_path(module_name)
+            real_patch.assert_called_once_with(path)
+    assert n == file_base
+    assert d == gold_path
+
+
+def test_parse_module_as_path_absolute():
+    file_base = rand_str()
+    file_ext = rand_str()
+    file_name = "{}.{}".format(file_base, file_ext)
+    path = os.path.join(*[rand_str() for _ in range(random.randint(1, 5))])
+    path = '/' + path
+    assert os.path.isabs(path)
+    module_name = os.path.join(path, file_name)
+    with patch('baseline.utils.os.path.realpath') as real_patch:
+        with patch('baseline.utils.os.path.expanduser') as user_patch:
+            real_patch.return_value = path
+            user_patch.return_value = path
+            n, d = _parse_module_as_path(module_name)
+            real_patch.assert_called_once_with(path)
+    assert n == file_base
+    assert d == path


### PR DESCRIPTION
This PR does two things.

 * It lets us import modules via path. If you give it a path to a file it will chop off the `.py` extension, add the directory to `sys.path` and then import the module.
 * It lets us specify modules needed from the  command line for `mead-train`

Tested by removing the modules field from `sst2-elmo-hub.yml` and specifying them from cli both as names (because they are in addons) and as paths after moving them from the addons dir.

There are also unit tests for some of the helper functions.