### PR TITLE
fix: able to handle the dsz != d_model for pyt transformers

### DIFF
--- a/python/baseline/pytorch/seq2seq/decoders.py
+++ b/python/baseline/pytorch/seq2seq/decoders.py
@@ -255,8 +255,6 @@ class TransformerDecoderWrapper(torch.nn.Module):
         self.preds = pytorch_linear(dsz, self.tgt_embeddings.get_vsz())
 
         do_weight_tying = bool(kwargs.get('tie_weights', False))
-
-        self.preds = pytorch_linear(hsz, self.tgt_embeddings.get_vsz())
         if do_weight_tying:
             self.preds.weight = self.tgt_embeddings.weight.transpose(0, 1)
 


### PR DESCRIPTION
There was a second definition of `self.preds` in the pytorch transformer decoder that used `hsz` rather than `dsz` as the input size. This caused errors when the transformer had different embeddings sizes (dsz) and d_model size (hsz)