### PR TITLE
don't make go vectorizer shrink input

### DIFF
--- a/python/baseline/vectorizers.py
+++ b/python/baseline/vectorizers.py
@@ -108,8 +108,6 @@ class GOVectorizer(Vectorizer):
 
     def __init__(self, vectorizer):
         self.vectorizer = vectorizer
-        if self.vectorizer.mxlen != -1:
-            self.vectorizer.mxlen -= 2
 
     def iterable(self, tokens):
         raise Exception("Not implemented")

--- a/python/mead/config/reverse.json
+++ b/python/mead/config/reverse.json
@@ -35,13 +35,14 @@
         "layers": 2
     },
     "train": {
-        "epochs": 16,
+        "epochs": 30,
         "optim": "adam",
         "eta": 0.001,
         "mom": 0.9,
-        "patience": 20,
+        "patience": 10,
         "nsteps": 200,
     	"do_early_stopping": true,
+        "early_stopping_metric": "bleu",
         "clip": 1.0
     }
 }


### PR DESCRIPTION
Currently the GOVectorizer uses the same mxlen as the src vectorizers. This means that when a src input is the max length two tokens in the output will be cut off to make room for `<GO>` and `<EOS>`.

On my seq2seq testing dataset (the output is the input sequence reversed) this can cause large bleu drops when evaluated on the real data. For example the bleu reported during training (where the targets are the truncated translations can be almost 100

```json
{"tick_type": "EPOCH", "tick": 0, "phase": "Test", "bleu": 99.9245402509523}
```

but when you use `ed-text.py` and the bleu evaluation script you see a large drop in score.

```
BLEU = 93.08, 100.0/100.0/100.0/100.0 (BP=0.931, ratio=0.933, hyp_len=7029, ref_len=7533)
```

Also in this example you can see that the model has perfect 1-4 gram precision and all the missed bleu points are from inputs being too short, this suggests the model learned to ignore parts of longer utterances. (the magnitude of the effect here may be an artifact of the dataset given that 34% of examples are of length 9 or 10 and therefore get cut off)

When the vectorizer produces examples that are mxlen + 2 rather than mxlen we don't see this drop off

```
{"tick_type": "EPOCH", "tick": 0, "phase": "Test", "bleu": 100.0}
BLEU = 100.00, 100.0/100.0/100.0/100.0 (BP=1.000, ratio=1.000, hyp_len=7533, ref_len=7533)
```

This change causes a bit more variance in trained models so I had to tweak some hps to get back to the behavior before (models have bleu scores between 98 and 100). I haven't investigated how this effects other seq2seq datasets and plan to do that soon.