### PR TITLE
fix: fixed regression where the large lut code clashes with multigpu

### DIFF
--- a/python/baseline/tf/classify/train.py
+++ b/python/baseline/tf/classify/train.py
@@ -150,7 +150,8 @@ def fit(model, ts, vs, es=None, **kwargs):
     trainer = create_trainer(model, **kwargs)
     tables = tf.tables_initializer()
     model.sess.run(tables)
-    feed_dict = {k: v for e in model.embeddings.values() for k, v in e.get_feed_dict().items()}
+    m = model.replicas[0] if hasattr(model, 'replicas') else model
+    feed_dict = {k: v for e in m.embeddings.values() for k, v in e.get_feed_dict().items()}
     model.sess.run(tf.global_variables_initializer(), feed_dict)
     model.set_saver(tf.train.Saver())
     checkpoint = kwargs.get('checkpoint')

--- a/python/baseline/tf/lm/train.py
+++ b/python/baseline/tf/lm/train.py
@@ -148,7 +148,8 @@ def fit(model, ts, vs, es=None, **kwargs):
     after_train_fn = kwargs['after_train_fn'] if 'after_train_fn' in kwargs else None
     trainer = create_trainer(model, **kwargs)
     init = tf.global_variables_initializer()
-    feed_dict = {k: v for e in model.embeddings.values() for k, v in e.get_feed_dict().items()}
+    m = model.replicas[0] if hasattr(model, 'replicas') else model
+    feed_dict = {k: v for e in m.embeddings.values() for k, v in e.get_feed_dict().items()}
     model.sess.run(init, feed_dict)
     saver = tf.train.Saver()
     model.set_saver(saver)

--- a/python/baseline/tf/seq2seq/train.py
+++ b/python/baseline/tf/seq2seq/train.py
@@ -151,8 +151,9 @@ def fit(model, ts, vs, es=None, **kwargs):
     model_file = get_model_file('seq2seq', 'tf', kwargs.get('basedir'))
     after_train_fn = kwargs['after_train_fn'] if 'after_train_fn' in kwargs else None
     trainer = create_trainer(model, **kwargs)
-    feed_dict = {k: v for e in model.src_embeddings.values() for k, v in e.get_feed_dict().items()}
-    feed_dict.update(model.tgt_embedding.get_feed_dict())
+    m = model.replicas[0] if hasattr(model, 'replicas') else model
+    feed_dict = {k: v for e in m.src_embeddings.values() for k, v in e.get_feed_dict().items()}
+    feed_dict.update(m.tgt_embedding.get_feed_dict())
     init = tf.global_variables_initializer()
     model.sess.run(init, feed_dict)
     saver = tf.train.Saver()


### PR DESCRIPTION
This PR fixes a clash where the large lut code assumed the model was always the model but the multigpu code you basically had a model that holds a list of models.

This is tested and work for a multigpu job and a single gpu job. It was not tested on a multigpu job that uses a large lut because we don't have any of those at the moment