### PR TITLE
chore: timing logs to console and to files in basedir

### DIFF
--- a/python/baseline/utils.py
+++ b/python/baseline/utils.py
@@ -173,6 +173,7 @@ def color(msg, color):
 class ColoredFormatter(logging.Formatter):
     COLORS = {
         'WARNING': Colors.YELLOW,
+        'ERROR': Colors.RED
     }
 
     def format(self, record):
@@ -190,6 +191,15 @@ class JSONFormatter(ColoredFormatter):
         except TypeError:
             pass
         return super(JSONFormatter, self).format(record)
+
+
+class MakeFileHandler(logging.FileHandler):
+    """A File logger that will create intermediate dirs if need be."""
+    def __init__(self, filename, mode='a', encoding=None, delay=0):
+        log_dir = os.path.dirname(filename)
+        if not os.path.exists(log_dir):
+            os.makedirs(log_dir)
+        super(MakeFileHandler, self).__init__(filename, mode, encoding, delay)
 
 
 @exporter

--- a/python/mead/config/logging.json
+++ b/python/mead/config/logging.json
@@ -46,6 +46,12 @@
             "filename": "timing.log",
             "formatter": "json",
             "encoding": "utf-8"
+        },
+        "timing_console_handler": {
+            "class": "logging.StreamHandler",
+            "level": "INFO",
+            "stream": "ext://sys.stdout",
+            "formatter": "json"
         }
     },
     "loggers": {
@@ -66,7 +72,7 @@
         },
         "baseline.timing": {
             "level": "DEBUG",
-            "handlers": ["timing_file_handler"],
+            "handlers": ["timing_file_handler", "timing_console_handler"],
             "propagate": false
         }
     }


### PR DESCRIPTION
This PR updates the logging in baseline.

It adds a console logging handler to the timing log that defaults to a level higher than what the timing logger logs at (INFO vs DEBUG). This means that logs don't appear on screen unless you set `TIMING_LOG_LEVEL=DEBUG`

It also creates two extra logging file handlers that create reporting and timing logs in the basedir. This involved shuffling when some arguments are used and a bit of logic duplication from `mead.Task.get_basedir` but it now creates two copies of the logs. One in the basedir (which gets included in the zip) and one in the cwd for back compat