### PR TITLE
fix: lengths are sent for classifiers now

### DIFF
--- a/python/mead/tf/exporters.py
+++ b/python/mead/tf/exporters.py
@@ -137,6 +137,7 @@ class ClassifyTensorFlowExporter(TensorFlowExporter):
         model, classes, values = self._create_model(sess, basename)
 
         predict_tensors = {}
+        predict_tensors[model.lengths_key] = tf.saved_model.utils.build_tensor_info(model.lengths)
 
         for k, v in model.embeddings.items():
             try:


### PR DESCRIPTION
This PR fixes a bug in baseline. Before [this change](https://github.com/dpressel/baseline/pull/325) the model lengths were never needed for most of the classifier models. As a result the lengths were never in the required inputs. This was fine because even though the model was trained with an placeholder for lengths the tf was smart enough to know during serving that because we didn't use the length we didn't need to provide them.

Now that we use the lengths for NBowModels we got errors when trying to use an exported model `"grpc_message":"You must feed a value for placeholder tensor 'lengths' with dtype int32 and shape [?]\n\t [[{{node lengths}}]]` I also went back and found that one master we couldn't actually use exported lstms either.

This update adds the lengths to the required inputs for classifier models.

Tested by training and export a conv net that doesn't use lengths, a composite that does and an lstm that uses lengths. All worked. The lengths were sent to the conv nest even though it doesn't use them.