### PR TITLE
replaces ignite w train loop in pretrain-lm sample

### DIFF
--- a/api-examples/pretrain-transformer-lm.py
+++ b/api-examples/pretrain-transformer-lm.py
@@ -521,7 +521,7 @@ def train():
         metrics['train_ppl'] = train_token_ppl
         model_base = os.path.join(args.basedir, 'checkpoint')
         avg_valid_loss = Average('average_valid_loss')
-        start = 0
+        start = time.time()
         model.eval()
         for batch in valid_loader:
             with torch.no_grad():

--- a/api-examples/pretrain-transformer-lm.py
+++ b/api-examples/pretrain-transformer-lm.py
@@ -439,8 +439,8 @@ def train():
                                             layers=args.num_layers,
                                             src_keys=['x'], tgt_key=tgt_key)
     model.to(args.device)
-    train_loss = model.create_loss()
-    train_loss.to(args.device)
+    loss_function = model.create_loss()
+    loss_function.to(args.device)
 
     logger.info("Loaded model and loss")
 
@@ -485,7 +485,7 @@ def train():
             logits = model(inputs, None)[0].transpose(0, 1).contiguous()
             shift_logits = logits[:-1]
             shift_labels = labels[1:]
-            loss = train_loss(shift_logits, shift_labels)
+            loss = loss_function(shift_logits, shift_labels)
             loss.backward()
             agg_loss += loss.item()
 
@@ -506,8 +506,6 @@ def train():
         metrics['train_ppl'] = train_token_ppl
         model_base = os.path.join(args.basedir, 'checkpoint')
         if args.local_rank < 1:
-            valid_loss = model.create_loss()
-            valid_loss.to(args.device)
             agg_valid_loss = 0.0
             model.eval()
             for batch in valid_loader:
@@ -518,7 +516,7 @@ def train():
                     logits = model(inputs, None)[0].transpose(0, 1).contiguous()
                     shift_logits = logits[:-1]
                     shift_labels = labels[1:]
-                    loss = valid_loss(shift_logits, shift_labels)
+                    loss = loss_function(shift_logits, shift_labels)
                     agg_valid_loss += loss.item()
 
             # Should probably do this more often

--- a/api-examples/pretrain-transformer-lm.py
+++ b/api-examples/pretrain-transformer-lm.py
@@ -462,6 +462,7 @@ def train():
     logger.info("Loaded model and loss")
 
     steps_per_epoch = len(train_loader)
+    update_on = steps_per_epoch // 10
     cosine_decay = CosineDecaySchedulerPyTorch(len(train_loader) * args.epochs, lr=args.lr)
     linear_warmup = WarmupLinearSchedulerPyTorch(args.warmup_steps, lr=args.lr)
     lr_sched = CompositeLRScheduler(linear_warmup, cosine_decay, lr=args.lr)
@@ -507,7 +508,7 @@ def train():
             torch.nn.utils.clip_grad_norm_(model.parameters(), args.clip)
             optimizer.step()
             optimizer.zero_grad()
-            if (i + 1) % 100 == 0:
+            if (i + 1) % update_on == 0:
                 logging.info(avg_loss)
 
         # How much time elapsed in minutes

--- a/python/baseline/pytorch/optz.py
+++ b/python/baseline/pytorch/optz.py
@@ -73,8 +73,10 @@ class ExponentialDecaySchedulerPyTorch(ExponentialDecayScheduler):
     def __init__(self, *args, **kwargs):
         super(ExponentialDecaySchedulerPyTorch, self).__init__(*args, **kwargs)
 
+
 @register_lr_scheduler(name='composite')
-class CompositeLRSchedulerPyTorch(CompositeLRScheduler): pass
+class CompositeLRSchedulerPyTorch(CompositeLRScheduler):
+    pass
 
 
 class AdamW(torch.optim.Optimizer):
@@ -150,9 +152,12 @@ class OptimizerManager(object):
 
     def __init__(self, model, global_step=0, **kwargs):
         self.global_step = global_step
-        if 'lr_scheduler_type' not in kwargs:
-            kwargs['lr_scheduler_type'] = 'default'
-        self.lr_function = create_lr_scheduler(**kwargs)
+        if 'lr_function' in kwargs:
+            self.lr_function = kwargs['lr_function']
+        else:
+            if 'lr_scheduler_type' not in kwargs:
+                kwargs['lr_scheduler_type'] = 'default'
+            self.lr_function = create_lr_scheduler(**kwargs)
         self._init_optimizer(model, **kwargs)
 
     @property

--- a/python/baseline/train.py
+++ b/python/baseline/train.py
@@ -55,8 +55,8 @@ class WarmupLinearScheduler(WarmupLearningRateScheduler):
 
     def __call__(self, global_step):
         lr_factor = min(1.0, global_step / float(self.warmup_steps))
-        return self.lr * lr_factor
-
+        new_lr = self.lr * lr_factor
+        return new_lr
 
 @exporter
 class CyclicLRScheduler(LearningRateScheduler):


### PR DESCRIPTION
This change replaces the ignite code with a simpler, streamlined training loop.  This allows the example to be fully contained and remove a previous requirement