### PR TITLE
fix: don't double the scope in the variable name

### DIFF
--- a/python/baseline/tf/embeddings.py
+++ b/python/baseline/tf/embeddings.py
@@ -303,7 +303,7 @@ class CharConvEmbeddings(TensorFlowEmbeddings):
 
         with tf.device("/cpu:0"):
             with tf.variable_scope(self.scope, reuse=tf.AUTO_REUSE):
-                self.Wch = tf.get_variable('{}/Wch'.format(self.scope),
+                self.Wch = tf.get_variable('Wch',
                                            initializer=tf.constant_initializer(self.weights, dtype=tf.float32,
                                                                                verify_shape=True),
                                            shape=[self.vsz, self.dsz], trainable=True)
@@ -312,8 +312,9 @@ class CharConvEmbeddings(TensorFlowEmbeddings):
         self.outsz = np.sum(self.nfeats)
 
         if self.projsz:
-            self.Wp = tf.get_variable('{}/Wp'.format(self.scope), shape=[self.outsz, self.projsz], trainable=True)
-            self.bp = tf.get_variable('{}/bp'.format(self.scope), shape=[self.projsz], trainable=True, initializer=tf.constant_initializer(0.0))
+            with tf.variable_scope(self.scope, reuse=tf.AUTO_REUSE):
+                self.Wp = tf.get_variable('Wp', shape=[self.outsz, self.projsz], trainable=True)
+                self.bp = tf.get_variable('bp', shape=[self.projsz], trainable=True, initializer=tf.constant_initializer(0.0))
             self.outsz = self.projsz
 
     def detached_ref(self):


### PR DESCRIPTION
Tensorflow automatically prepends the scope on variable names. This means what this code is run the scope is manually added to the `self.Wch` variables (`char/CharLUT/Wch`) and then tensorflow automatically add the scope again (`char/CharLUT/char/CharLUT/Wch`).

This caused errors when models trained before this change (git blame says it was make on the 18th) are exported by code from after this change.

The double scope seem undesirable so this change removes it.