### PR TITLE
chore: step reporting is turned on when nsteps in config

### DIFF
--- a/python/baseline/reporting.py
+++ b/python/baseline/reporting.py
@@ -197,8 +197,6 @@ class VisdomReporting(ReportingHook):
 @exporter
 def create_reporting(reporting_hooks, hook_settings, proc_info):
     reporting = [LoggingReporting()]
-    if proc_info['task'] in {'seq2seq', 'lm'}:
-        reporting.append(StepLoggingReporting())
 
     for name in reporting_hooks:
         ReportingClass = BASELINE_REPORTING[name]

--- a/python/mead/tasks.py
+++ b/python/mead/tasks.py
@@ -255,17 +255,11 @@ class Task(object):
         :param kwargs:
         :return:
         """
-        default_reporting = self.mead_settings_config.get('reporting_hooks', {})
-        # Add default reporting information to the reporting settings.
-        for report_type in default_reporting:
-            if report_type in reporting:
-                for report_arg, report_val in default_reporting[report_type].items():
-                    if report_arg not in reporting[report_type]:
-                        reporting[report_type][report_arg] = report_val
-        reporting_hooks = list(reporting.keys())
-        for settings in reporting.values():
-            for module in listify(settings.get('module', settings.get('modules', []))):
-                import_user_module(module)
+        # If there is an nstep request in config or we are doing seq2seq/lm log steps to console
+        if 'nsteps' in self.config_params['train'] or self.__class__.task_name() in {'seq2seq', 'lm'}:
+            reporting['step_logging'] = reporting.get('step_logging', {})
+
+        reporting_hooks, reporting = merge_reporting_with_settings(reporting, self.mead_settings_config)
 
         self.reporting = baseline.create_reporting(reporting_hooks,
                                                    reporting,


### PR DESCRIPTION
This PR updates mead so that is `nsteps` is found in the `train` section of a config then step reporting (which logs to the console and is used by the nsteps logging) is automatically turned on.

step logging used to automatically be turned on when using seq2seq and lms. This used to happen inside the create function. This was moved outside of the create into the mead configure_reporting method. This makes it eaiser to insure there are not 2 step loggers (for example if nsteps is in the config and it is a seq2seq task)