### PR TITLE
Adds optional transformer pretrain support for BPE

### DIFF
--- a/python/addons/embed_tlm_pytorch.py
+++ b/python/addons/embed_tlm_pytorch.py
@@ -90,7 +90,7 @@ class TransformerLMEmbeddings(PyTorchEmbeddings):
         self.vocab = read_json(kwargs.get('vocab_file'))
         self.cls_index = self.vocab['[CLS]']
         self.vsz = len(self.vocab)
-        layers = int(kwargs.get('layers', 18))
+        layers = int(kwargs.get('layers', 16))
         num_heads = int(kwargs.get('num_heads', 10))
         pdrop = kwargs.get('dropout', 0.1)
         self.d_model = int(kwargs.get('dsz', kwargs.get('d_model', 410)))


### PR DESCRIPTION
- Refactors subword into `['bpe', 'wordpiece', None]`
- For WP for now, still using HF library, defaults
  - Pass in the subword model argument though
- For BPE, uses fastBPE
  - Pass in subword model (codes)
  - Pass in subword vocab (vocab)
- Future versions will default to fastBPE