### PR TITLE
fix: don't overwrite preproc if clean is false

### DIFF
--- a/python/mead/tasks.py
+++ b/python/mead/tasks.py
@@ -380,7 +380,7 @@ class ClassifierTask(Task):
             self.config_params.get('preproc', {})['clean_fn'] = baseline.TSVSeqLabelReader.do_clean
             logger.info('Clean')
         else:
-            self.config_params['preproc'] = {}
+            self.config_params.setdefault('preproc', {})
             self.config_params['preproc']['clean_fn'] = None
 
     def initialize(self, embeddings):


### PR DESCRIPTION
What happens here is that if `'clean'` is not set in the preproc section then the whole preproc section is overwritten, which means that often the mxlen can get ignored.

```python
def _setup_task(self, **kwargs):
    super(ClassifierTask, self)._setup_task(**kwargs)
    if self.config_params.get('preproc', {}).get('clean', False) is True:
        self.config_params.get('preproc', {})['clean_fn'] = baseline.TSVSeqLabelReader.do_clean
        logger.info('Clean')
    else:
        self.config_params['preproc'] = {}
        self.config_params['preproc']['clean_fn'] = None
```

Here we can see some values before and after that snippet:

```
Before: {'mxlen': 10}
After: {'clean_fn': None}
```
```
Before: {'clean': True, 'mxlen': 10}
Clean
After: {'clean': True, 'mxlen': 10, 'clean_fn': <function TSVSeqLabelReader.do_clean at 0x7f25348cad08>}
```

In the first one we can see that the mxlen is removed, while in the second one it is preserved

These are outputs from before and after the same snippet after my fix

```
Before: {'mxlen': 10}
After: {'mxlen': 10, 'clean_fn': None}
```
```
Before: {'clean': True, 'mxlen': 10}
Clean
After: {'clean': True, 'mxlen': 10, 'clean_fn': <function TSVSeqLabelReader.do_clean at 0x7fb78fe62c80>}
```

Here we can see that `mxlen` isn't removed.