### PR TITLE
fix: stack bert layers and reduce mean

### DIFF
--- a/python/addons/embed_bert.py
+++ b/python/addons/embed_bert.py
@@ -1432,7 +1432,7 @@ class BERTEmbeddings(TensorFlowEmbeddings):
         if self.operator == 'concat':
             z = tf.concat(layers, axis=-1)
         else:
-            z = tf.reduce_mean(tf.add_n(layers), axis=-1, keepdims=True)
+            z = tf.reduce_mean(tf.stack(layers, axis=-1), axis=-1)
         z = tf.stop_gradient(z)
         return z
 


### PR DESCRIPTION
Use `tf.stack` to yield a tensor of shape `[B, T, D, len(layers)]` and then `tf.reduce_mean` with `axis = -1` to do an element wise mean over the layers resulting in a tensor of shape `[B, T, D]` to use bert as embeddings