### PR TITLE
fix: set the drop mask to match the mask_pad b/c new pyt 1.2 type

### DIFF
--- a/python/baseline/pytorch/tagger/model.py
+++ b/python/baseline/pytorch/tagger/model.py
@@ -117,7 +117,7 @@ class TaggerModelBase(nn.Module, TaggerModel):
             return x
 
         mask_pad = x != Offsets.PAD
-        mask_drop = x.new(x.size(0), x.size(1)).bernoulli_(v).byte()
+        mask_drop = x.new(x.size(0), x.size(1)).bernoulli_(v).to(mask_pad.dtype)
         x.masked_fill_(mask_pad & mask_drop, Offsets.UNK)
         return x
 


### PR DESCRIPTION
Pytorch 1.2 introduced a `torch.bool` type that things like `x != Offsets.PAD` create. This caused a problem because `mask_drop` was a `torch.uint8` so they couldn't be `&`ed together.

This fixes that by setting the type of the dropout mask to the same type as the pad mask. So in < 1.2 it will still be a byte tensor and on 1.2 it will be a bool

Tested by running the conll config with both pytorch 1.2 and pytorch 1.0 