### PR TITLE
Fix collection class references

### DIFF
--- a/layers/eight_mile/utils.py
+++ b/layers/eight_mile/utils.py
@@ -396,7 +396,7 @@ def str2bool(v):
 def is_sequence(x) -> bool:
     if isinstance(x, str):
         return False
-    return isinstance(x, (collections.Sequence, collections.MappingView))
+    return isinstance(x, (collections.abc.Sequence, collections.abc.MappingView))
 
 
 @export


### PR DESCRIPTION
They are prefixed with `abc`:
- https://docs.python.org/3/library/collections.abc.html#collections.abc.Sequence
- https://docs.python.org/3/library/collections.abc.html#collections.abc.MappingView